### PR TITLE
Fix release workflow to handle immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,62 +44,77 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate release notes (changes + GitHub @usernames)
-        id: release_notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
+       - name: Check if release exists
+         id: check_release
+         run: |
+           if gh release view ${{ steps.get_tag.outputs.tag }} >/dev/null 2>&1; then
+             echo "Release exists, skipping creation"
+             echo "exists=true" >> $GITHUB_OUTPUT
+           else
+             echo "Release does not exist, will create"
+             echo "exists=false" >> $GITHUB_OUTPUT
+           fi
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          CURR_TAG=${{ steps.get_tag.outputs.tag }}
-          PREV_TAG=$(git describe --tags --abbrev=0 "${CURR_TAG}^" 2>/dev/null || echo "")
-          ROOT_SHA=$(git rev-list --max-parents=0 HEAD | tail -n1)
+       - name: Generate release notes (changes + GitHub @usernames)
+         id: release_notes
+         if: steps.check_release.outputs.exists == 'false'
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         run: |
+           set -euo pipefail
 
-          if [ -n "$PREV_TAG" ]; then
-            BASE_REF="$PREV_TAG"
-            RANGE="$PREV_TAG..$CURR_TAG"
-          else
-            BASE_REF="$ROOT_SHA"
-            RANGE="$ROOT_SHA..$CURR_TAG"
-          fi
+           CURR_TAG=${{ steps.get_tag.outputs.tag }}
+           PREV_TAG=$(git describe --tags --abbrev=0 "${CURR_TAG}^" 2>/dev/null || echo "")
+           ROOT_SHA=$(git rev-list --max-parents=0 HEAD | tail -n1)
 
-          {
-            echo "## Release $CURR_TAG"
-            echo
-            echo "### Changes"
-          } > RELEASE_NOTES.md
+           if [ -n "$PREV_TAG" ]; then
+             BASE_REF="$PREV_TAG"
+             RANGE="$PREV_TAG..$CURR_TAG"
+           else
+             BASE_REF="$ROOT_SHA"
+             RANGE="$ROOT_SHA..$CURR_TAG"
+           fi
 
-          git log "$RANGE" --pretty=format:"- %s" >> RELEASE_NOTES.md || true
-          if ! grep -q "^- " RELEASE_NOTES.md; then
-            echo "- None" >> RELEASE_NOTES.md
-          fi
+           {
+             echo "## Release $CURR_TAG"
+             echo
+             echo "### Changes"
+           } > RELEASE_NOTES.md
 
-          {
-            echo
-            echo "### Contributors"
-          } >> RELEASE_NOTES.md
+           git log "$RANGE" --pretty=format:"- %s" >> RELEASE_NOTES.md || true
+           if ! grep -q "^- " RELEASE_NOTES.md; then
+             echo "- None" >> RELEASE_NOTES.md
+           fi
 
-          gh api "repos/${{ github.repository }}/compare/${BASE_REF}...${CURR_TAG}" \
-            -q '.commits[].author.login' 2>/dev/null | \
-            grep -v '^$' | sort -u | sed 's/^/- @/' >> RELEASE_NOTES.md || true
+           {
+             echo
+             echo "### Contributors"
+           } >> RELEASE_NOTES.md
 
-          if ! tail -n +1 RELEASE_NOTES.md | awk '/^### Contributors/{p=1;next} /^### /{p=0} p' | grep -q "^- @"; then
-            echo "- None" >> RELEASE_NOTES.md
-          fi
+           gh api "repos/${{ github.repository }}/compare/${BASE_REF}...${CURR_TAG}" \
+             -q '.commits[].author.login' 2>/dev/null | \
+             grep -v '^$' | sort -u | sed 's/^/- @/' >> RELEASE_NOTES.md || true
 
-          echo "----- RELEASE_NOTES.md -----"
-          cat RELEASE_NOTES.md
+           if ! tail -n +1 RELEASE_NOTES.md | awk '/^### Contributors/{p=1;next} /^### /{p=0} p' | grep -q "^- @"; then
+             echo "- None" >> RELEASE_NOTES.md
+           fi
 
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.get_tag.outputs.tag }}
-          name: "Harper ${{ steps.get_tag.outputs.tag }}"
-          body_path: RELEASE_NOTES.md
-          prerelease: ${{ contains(steps.get_tag.outputs.tag, '-') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           echo "----- RELEASE_NOTES.md -----"
+           cat RELEASE_NOTES.md
+
+       - name: Create Release
+         id: create_release
+         if: steps.check_release.outputs.exists == 'false'
+         uses: softprops/action-gh-release@v2
+         with:
+           tag_name: ${{ steps.get_tag.outputs.tag }}
+           name: "Harper ${{ steps.get_tag.outputs.tag }}"
+           body_path: RELEASE_NOTES.md
+           prerelease: ${{ contains(steps.get_tag.outputs.tag, '-') }}
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-release:
     name: Build Release


### PR DESCRIPTION
## Problem
The release workflow fails when attempting to update an existing immutable release, with error: 'target_commitish cannot be changed when release is immutable'. This issue was encountered during the v0.1.5 release process.

## Solution
Modified the workflow to check if the release already exists before trying to create or update it. If the release exists, skip the creation steps and proceed to build and upload assets to the existing release.

## Changes Made
- Added a new step 'Check if release exists' that uses `gh release view` to determine if the release for the tag already exists.
- Made the 'Generate release notes' and 'Create Release' steps conditional on the release not existing.
- This prevents the workflow from attempting to modify immutable releases while still allowing asset uploads.

## Testing
The workflow will now handle re-runs on existing tags gracefully without errors.

Closes #26

## Resolution
This fix resolves the issue faced in v0.1.5 and ensures smooth release processes for v0.1.6 and future versions.