### PR TITLE
Fix YAML indentation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-       - name: Get tag name
+      - name: Get tag name
          id: get_tag
          env:
            EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
Corrects inconsistent indentation causing YAML syntax error on line 32.