### PR TITLE
feat: improve error handling in test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,16 +370,19 @@ mod tests {
         assert!(file_path.to_string_lossy().contains("harper_images"));
         assert!(file_path.to_string_lossy().ends_with(".png"));
 
-        // Verify it's a valid PNG
-        let loaded_img = image_open(&file_path)?;
-        assert_eq!(loaded_img.width(), 2);
-        assert_eq!(loaded_img.height(), 2);
+        let result = (|| {
+            let loaded_img = image_open(&file_path)?;
+            assert_eq!(loaded_img.width(), 2);
+            assert_eq!(loaded_img.height(), 2);
+            Ok(())
+        })();
 
-        // Clean up
-        fs::remove_file(&file_path)?;
+        // Clean up is now guaranteed to run.
+        // We ignore the result of remove_file, as the test result is more important.
+        let _ = fs::remove_file(&file_path);
+
+        result
         // Optional: clean up directory if empty, but be careful in tests
         // fs::remove_dir(file_path.parent().unwrap()).ok();
-
-        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod tests {
     use ::image::open as image_open;
     use arboard::ImageData;
     use std::borrow::Cow;
+    use std::error::Error;
     use std::fs;
 
     #[test]
@@ -347,7 +348,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clipboard_image_processing() {
+    fn test_clipboard_image_processing() -> Result<(), Box<dyn Error>> {
         // Test the core image processing logic used in clipboard functionality
         // Create mock RGBA image data (2x2 red square)
         let mock_bytes = vec![
@@ -370,13 +371,15 @@ mod tests {
         assert!(file_path.to_string_lossy().ends_with(".png"));
 
         // Verify it's a valid PNG
-        let loaded_img = image_open(&file_path).expect("Failed to load saved image");
+        let loaded_img = image_open(&file_path)?;
         assert_eq!(loaded_img.width(), 2);
         assert_eq!(loaded_img.height(), 2);
 
         // Clean up
-        fs::remove_file(&file_path).expect("Failed to clean up test file");
+        fs::remove_file(&file_path)?;
         // Optional: clean up directory if empty, but be careful in tests
         // fs::remove_dir(file_path.parent().unwrap()).ok();
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Replace expect() with proper Result propagation in test_clipboard_image_processing to avoid panics and improve robustness.