### PR TITLE
feat: add block cipher constructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,11 @@
 ## Why
-What problem does this solve?
+<1–2 factual sentences>
 
 ## What changed
-High-level summary only.
+- bullet points tied to files or logic
+
+## Behavior change
+- what happens now vs before
 
 ## Risk
-- [ ] Low (refactor, docs)
-- [ ] Medium (behavior change)
-- [ ] High (public API, semantics)
-
-## Validation
-How was this tested?
+- low / medium / high + why

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +294,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +351,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -389,6 +418,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -644,6 +683,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1114,14 +1162,18 @@ dependencies = [
 name = "harper"
 version = "0.3.4"
 dependencies = [
+ "aes",
  "arboard",
  "base64 0.22.1",
  "bitflags",
+ "block-padding",
+ "cbc",
  "chrono",
  "colored",
  "config",
  "criterion",
  "crossterm",
+ "ctr",
  "dirs",
  "dotenvy",
  "getrandom 0.2.16",
@@ -1537,6 +1589,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }
 tower = "0.5"
 uuid = { version = "1.17.0", features = ["v4"] }
 ring = "0.17.14"
+aes = "0.8"
+cbc = "0.1"
+ctr = "0.9"
+block-padding = "0.3"
 hex-literal = "0.4.1"
 once_cell = "1.19"
 

--- a/src/runtime/utils/crypto.rs
+++ b/src/runtime/utils/crypto.rs
@@ -16,6 +16,13 @@
 
 use crate::core::constants::crypto;
 use crate::core::error::{HarperError, HarperResult};
+use aes::{
+    cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit},
+    Aes256,
+};
+use block_padding::Pkcs7;
+use cbc::{Decryptor, Encryptor};
+use ctr::{cipher::StreamCipher, Ctr64BE};
 use ring::{
     aead, digest,
     rand::{SecureRandom, SystemRandom},
@@ -79,6 +86,111 @@ impl CryptoUtils {
             .map_err(|_| HarperError::Crypto("Nonce generation failed".to_string()))?;
         Ok(aead::Nonce::assume_unique_for_key(nonce_bytes))
     }
+
+    /// Encrypt data using AES-CBC block cipher
+    pub fn encrypt_block_cipher(data: &[u8]) -> HarperResult<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+        if data.is_empty() {
+            return Err(HarperError::Crypto("empty data".to_string()));
+        }
+
+        let rng = SystemRandom::new();
+
+        let mut key = vec![0u8; 32];
+        rng.fill(&mut key)
+            .map_err(|e| HarperError::Crypto(format!("Key generation failed: {}", e)))?;
+
+        let mut iv = vec![0u8; 16];
+        rng.fill(&mut iv)
+            .map_err(|e| HarperError::Crypto(format!("IV generation failed: {}", e)))?;
+
+        let cipher = Encryptor::<Aes256>::new_from_slices(&key, &iv)
+            .map_err(|_| HarperError::Crypto("Invalid key or IV".to_string()))?;
+
+        let block_size = 16;
+        let padded_len = data.len().div_ceil(block_size) * block_size;
+        let mut buf = vec![0u8; padded_len];
+        buf[..data.len()].copy_from_slice(data);
+        let encrypted = cipher
+            .encrypt_padded_mut::<Pkcs7>(&mut buf, data.len())
+            .map_err(|_| HarperError::Crypto("Encryption failed".to_string()))?;
+
+        Ok((encrypted.to_vec(), key, iv))
+    }
+
+    /// Decrypt data using AES-CBC block cipher
+    pub fn decrypt_block_cipher(encrypted: &[u8], key: &[u8], iv: &[u8]) -> HarperResult<Vec<u8>> {
+        if encrypted.is_empty() {
+            return Err(HarperError::Crypto("empty data".to_string()));
+        }
+
+        if key.len() != 32 {
+            return Err(HarperError::Crypto("invalid key length".to_string()));
+        }
+
+        if iv.len() != 16 {
+            return Err(HarperError::Crypto("invalid IV length".to_string()));
+        }
+
+        let cipher = Decryptor::<Aes256>::new_from_slices(key, iv)
+            .map_err(|_| HarperError::Crypto("Invalid key or IV".to_string()))?;
+
+        let mut buf = encrypted.to_vec();
+        let decrypted = cipher
+            .decrypt_padded_mut::<Pkcs7>(&mut buf)
+            .map_err(|_| HarperError::Crypto("decryption failed".to_string()))?;
+
+        Ok(decrypted.to_vec())
+    }
+
+    /// Encrypt data using AES-CTR block cipher mode
+    pub fn encrypt_block_cipher_ctr(data: &[u8]) -> HarperResult<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+        if data.is_empty() {
+            return Err(HarperError::Crypto("empty data".to_string()));
+        }
+
+        let rng = SystemRandom::new();
+
+        let mut key = vec![0u8; 32];
+        rng.fill(&mut key)
+            .map_err(|e| HarperError::Crypto(format!("Key generation failed: {}", e)))?;
+
+        let mut nonce = vec![0u8; 16];
+        rng.fill(&mut nonce)
+            .map_err(|e| HarperError::Crypto(format!("Nonce generation failed: {}", e)))?;
+
+        let mut cipher = Ctr64BE::<Aes256>::new(key[..].into(), nonce[..].into());
+
+        let mut result = data.to_vec();
+        cipher.apply_keystream(&mut result);
+
+        Ok((result, key, nonce))
+    }
+
+    /// Decrypt data using AES-CTR (same as encrypt)
+    pub fn decrypt_block_cipher_ctr(
+        encrypted: &[u8],
+        key: &[u8],
+        nonce: &[u8],
+    ) -> HarperResult<Vec<u8>> {
+        if encrypted.is_empty() {
+            return Err(HarperError::Crypto("empty data".to_string()));
+        }
+
+        if key.len() != 32 {
+            return Err(HarperError::Crypto("invalid key length".to_string()));
+        }
+
+        if nonce.len() != 16 {
+            return Err(HarperError::Crypto("invalid nonce length".to_string()));
+        }
+
+        let mut cipher = Ctr64BE::<Aes256>::new(key[..].into(), nonce[..].into());
+
+        let mut result = encrypted.to_vec();
+        cipher.apply_keystream(&mut result);
+
+        Ok(result)
+    }
 }
 
 #[cfg(test)]
@@ -103,6 +215,39 @@ mod tests {
         let (challenge, response) = CryptoUtils::generate_zk_proof(secret_data, public_data)?;
         let is_valid = CryptoUtils::verify_zk_proof(public_data, &challenge, &response)?;
         assert!(is_valid);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_cipher_encrypt_decrypt() -> HarperResult<()> {
+        let message = b"Hello, block cipher world!";
+        let (encrypted, key, iv) = CryptoUtils::encrypt_block_cipher(message)?;
+
+        assert!(!encrypted.is_empty());
+        assert_eq!(key.len(), 32);
+        assert_eq!(iv.len(), 16);
+
+        let decrypted = CryptoUtils::decrypt_block_cipher(&encrypted, &key, &iv)?;
+
+        assert_eq!(decrypted, message);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_cipher_ctr_encrypt_decrypt() -> HarperResult<()> {
+        let message = b"Hello, CTR block cipher world!";
+        let (encrypted, key, nonce) = CryptoUtils::encrypt_block_cipher_ctr(message)?;
+
+        assert!(!encrypted.is_empty());
+        assert_eq!(encrypted.len(), message.len()); // No padding
+        assert_eq!(key.len(), 32);
+        assert_eq!(nonce.len(), 16);
+
+        let decrypted = CryptoUtils::decrypt_block_cipher_ctr(&encrypted, &key, &nonce)?;
+
+        assert_eq!(decrypted, message);
 
         Ok(())
     }


### PR DESCRIPTION
## Why
We needed block-cipher helpers for cases where AEAD is not used. The codebase did not have CBC or CTR utilities, and buffer sizing was over-allocating.

## What changed
* Added AES-CBC encrypt/decrypt with PKCS7 padding
* Added AES-CTR mode (no padding)
* Fixed buffer sizing to allocate exact lengths using \`div_ceil\`
* Added roundtrip tests for both modes
* Updated crypto dependencies
* Updated the PR template format
* Fixed Clippy lint and ran pre-commit checks

## Behavior change
* Before: only AEAD helpers were available and block-cipher modes were missing
* Now: CBC and CTR helpers are available, with tests
* AEAD behavior is unchanged

## Risk
**Low** — changes are additive, scoped to crypto utilities, and existing defaults remain unchanged.