### PR TITLE
chore: minimal changelog workflow name

### DIFF
--- a/.github/workflows/fix-changelog.yml
+++ b/.github/workflows/fix-changelog.yml
@@ -1,4 +1,4 @@
-name: Fix Changelog Formatting
+name: Fix Changelog
 
 on:
   pull_request:


### PR DESCRIPTION
Updates the fix-changelog workflow name to be more minimal.

## Why
The workflow name was verbose.

## What changed
- Changed workflow name from 'Fix Changelog Formatting' to 'Fix Changelog'

## Behavior change
- Workflow name is shorter in CI

## Risk
Low — name-only change.