### PR TITLE
chore: update release-please config for harper-core and harper-ui packages

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,4 @@
 {
-  ".": "0.3.4"
+  "lib/harper-core": "0.3.4",
+  "lib/harper-ui": "0.3.4"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,4 @@
 {
-  ".": "0.3.4",
   "lib/harper-core": "0.3.4",
   "lib/harper-ui": "0.3.4"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  ".": "0.3.4",
   "lib/harper-core": "0.3.4",
   "lib/harper-ui": "0.3.4"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,11 @@
 {
   "packages": {
+    ".": {
+      "release-type": "cargo-workspace",
+      "package-name": "harper",
+      "changelog-path": "CHANGELOG.md",
+      "prerelease": false
+    },
     "lib/harper-core": {
       "release-type": "rust",
       "package-name": "harper-core",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,23 +1,12 @@
 {
   "packages": {
     ".": {
-      "release-type": "cargo-workspace",
-      "package-name": "harper",
+      "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
       "prerelease": false
     },
-    "lib/harper-core": {
-      "release-type": "rust",
-      "package-name": "harper-core",
-      "changelog-path": "CHANGELOG.md",
-      "prerelease": false
-    },
-    "lib/harper-ui": {
-      "release-type": "rust",
-      "package-name": "harper-ui",
-      "changelog-path": "CHANGELOG.md",
-      "prerelease": false
-    }
+    "lib/harper-core": {},
+    "lib/harper-ui": {}
   },
   "changelog-sections": [
     { "type": "feat", "section": "Features" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,14 @@
 {
   "packages": {
-    ".": {
+    "lib/harper-core": {
       "release-type": "rust",
-      "package-name": "harper",
+      "package-name": "harper-core",
+      "changelog-path": "CHANGELOG.md",
+      "prerelease": false
+    },
+    "lib/harper-ui": {
+      "release-type": "rust",
+      "package-name": "harper-ui",
       "changelog-path": "CHANGELOG.md",
       "prerelease": false
     }


### PR DESCRIPTION
# Update release-please configuration for workspace structure

## Changes
- Update release-please-config.json to target individual crates (harper-core and harper-ui)
- Update .release-please-manifest.json to track versions for each workspace package
- Configure release-please to handle each crate independently

## Why
After modularizing the project into a workspace structure, the release-please configuration needed to be updated to properly handle the individual crates rather than the root package.

## Testing
The configuration has been updated to match the new workspace structure, which should allow release-please to correctly generate changelogs and version updates for each crate.