### PR TITLE
chore: set rust release-type for harper-core and harper-ui packages

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,12 @@
       "changelog-path": "CHANGELOG.md",
       "prerelease": false
     },
-    "lib/harper-core": {},
-    "lib/harper-ui": {}
+    "lib/harper-core": {
+      "release-type": "rust"
+    },
+    "lib/harper-ui": {
+      "release-type": "rust"
+    }
   },
   "changelog-sections": [
     { "type": "feat", "section": "Features" },


### PR DESCRIPTION
# Fix release-please detecting sub-crates as node instead of rust

## Problem
Release-please was inferring 'node' release-type for lib/harper-core and lib/harper-ui, looking for package.json instead of Cargo.toml.

## Solution
Explicitly set "release-type": "rust" for both sub-crate packages in release-please-config.json.

## Testing
Configuration now correctly identifies rust packages and should process Cargo.toml files properly.