### PR TITLE
chore: split release workflow for harper-core and harper-ui packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,22 @@ on:
       - main
 
 jobs:
-  release:
+  release-harper-core:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          package-manifest: lib/harper-core/Cargo.toml
           config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
+
+  release-harper-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          package-manifest: lib/harper-ui/Cargo.toml
+          config-file: release-please-config.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,11 +2,13 @@
   "packages": {
     "lib/harper-core": {
       "release-type": "rust",
+      "package-manifest": "Cargo.toml",
       "changelog-path": "CHANGELOG.md",
       "prerelease": false
     },
     "lib/harper-ui": {
       "release-type": "rust",
+      "package-manifest": "Cargo.toml",
       "changelog-path": "CHANGELOG.md",
       "prerelease": false
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,15 +1,14 @@
 {
   "packages": {
-    ".": {
+    "lib/harper-core": {
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
       "prerelease": false
     },
-    "lib/harper-core": {
-      "release-type": "rust"
-    },
     "lib/harper-ui": {
-      "release-type": "rust"
+      "release-type": "rust",
+      "changelog-path": "CHANGELOG.md",
+      "prerelease": false
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
# Split release-please workflow into separate jobs for harper-core and harper-ui

## Problem
The release-please workflow was incorrectly configured to process the root workspace manifest, causing failures with the error 'is not a package manifest (might be a workspace)'.

## Solution
- Removed the root `.` package configuration from release-please-config.json
- Split the single release job into two separate jobs: `release-harper-core` and `release-harper-ui`
- Each job now explicitly targets its respective package manifest
- Added proper changelog paths and package manifest configurations for both libraries
- Removed the now unnecessary manifest-file parameter

## Testing
The updated configuration properly targets only the actual package manifests in the lib directory, avoiding the workspace manifest error.