### PR TITLE
feat: add workspace crate for benchmarking and integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,26 +1301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "harper"
-version = "0.3.4"
-dependencies = [
- "criterion",
- "harper-core",
- "harper-ui",
- "lazy_static",
- "num_cpus",
- "rand 0.8.5",
- "ratatui",
- "regex",
- "rusqlite",
- "serde_json",
- "syntect",
- "tempfile",
- "tokio",
- "wait-timeout",
-]
-
-[[package]]
 name = "harper-core"
 version = "0.3.4"
 dependencies = [
@@ -1382,6 +1362,26 @@ dependencies = [
  "tokio",
  "turul-mcp-client",
  "uuid",
+]
+
+[[package]]
+name = "harper-workspace"
+version = "0.3.4"
+dependencies = [
+ "criterion",
+ "harper-core",
+ "harper-ui",
+ "lazy_static",
+ "num_cpus",
+ "rand 0.8.5",
+ "ratatui",
+ "regex",
+ "rusqlite",
+ "serde_json",
+ "syntect",
+ "tempfile",
+ "tokio",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +339,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +407,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +442,31 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "clipboard-win"
@@ -534,6 +604,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1195,6 +1301,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "harper"
+version = "0.3.4"
+dependencies = [
+ "criterion",
+ "harper-core",
+ "harper-ui",
+ "lazy_static",
+ "num_cpus",
+ "rand 0.8.5",
+ "ratatui",
+ "regex",
+ "rusqlite",
+ "serde_json",
+ "syntect",
+ "tempfile",
+ "tokio",
+ "wait-timeout",
+]
+
+[[package]]
 name = "harper-core"
 version = "0.3.4"
 dependencies = [
@@ -1207,6 +1333,7 @@ dependencies = [
  "chrono",
  "colored",
  "config",
+ "criterion",
  "ctr",
  "dirs",
  "dotenvy",
@@ -1312,6 +1439,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1699,6 +1832,26 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2109,6 +2262,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2380,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -2461,6 +2630,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,6 +2792,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2604,8 +2803,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2623,6 +2832,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2657,7 +2869,7 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "strum",
@@ -2709,7 +2921,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "strum",
@@ -2734,7 +2946,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -2746,7 +2958,7 @@ dependencies = [
  "paste",
  "profiling",
  "rand 0.9.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.17",
  "v_frame",
@@ -3558,6 +3770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3835,7 +4057,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
@@ -3924,6 +4146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,34 @@
 [workspace]
 members = ["lib/harper-core", "lib/harper-ui"]
 resolver = "2"
+
+[package]
+name = "harper"
+version = "0.3.4"
+edition = "2021"
+rust-version = "1.85.0"
+authors = ["Harper Contributors"]
+license = "Apache-2.0"
+description = "Harper AI assistant"
+
+[lib]
+name = "harper"
+path = "src/lib.rs"
+
+[dependencies]
+harper-core = { path = "lib/harper-core" }
+harper-ui = { path = "lib/harper-ui" }
+
+[dev-dependencies]
+tempfile = "3.3.0"
+lazy_static = "1.4"
+regex = "1.10"
+criterion = "0.5"
+rusqlite = { version = "0.37.0", features = ["bundled"] }
+rand = "0.8"
+ratatui = "0.30"
+syntect = { version = "5.3", features = ["parsing", "html"] }
+tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }
+wait-timeout = "0.2"
+num_cpus = "1.16"
+serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = ["lib/harper-core", "lib/harper-ui"]
 resolver = "2"
 
 [package]
-name = "harper"
+name = "harper-workspace"
 version = "0.3.4"
 edition = "2021"
 rust-version = "1.85.0"
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 description = "Harper AI assistant"
 
 [lib]
-name = "harper"
+name = "harper_workspace"
 path = "src/lib.rs"
 
 [dependencies]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,9 @@ COPY Cargo.toml Cargo.lock ./
 # Copy workspace crates
 COPY lib ./lib
 
+# Copy root crate source
+COPY src ./src
+
 # Build application
 RUN cargo build --release
 
@@ -45,6 +48,7 @@ COPY config ./config
 
 # Copy workspace and tests
 COPY lib ./lib
+COPY src ./src
 COPY tests ./tests
 
     # Run E2E tests in debug mode as some tests may not work in release.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ COPY lib ./lib
 COPY src ./src
 
 # Build application
-RUN cargo build --release
+RUN cargo build --release -p harper-ui --bin harper
 
 # Test stage
 FROM rust:1.92.0 AS tester

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -65,6 +65,7 @@ version = "0.53"
 
 [dev-dependencies]
 tempfile = "3.3.0"
+criterion = "0.5"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,16 @@
+// Copyright 2025 harpertoken
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use harper_core::*;
+pub use harper_ui::*;

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use harper::*;
+use harper_workspace::*;
 use rusqlite::Connection;
 use std::fs;
 use tempfile::NamedTempFile;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -799,7 +799,9 @@ server_url = "http://localhost:5000"
 
         // Build the command
         let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
-        let binary_path = std::path::Path::new(&target_dir)
+        let binary_path = std::env::current_dir()
+            .unwrap()
+            .join(&target_dir)
             .join(profile)
             .join("harper");
         let mut command = Command::new(binary_path);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use harper::*;
+use harper_workspace::*;
 use rand::Rng;
 use regex::Regex;
 use rusqlite::Connection;
@@ -472,7 +472,7 @@ fn test_message_creation() {
 
 #[tokio::test]
 async fn test_web_search_mock() {
-    use harper::utils::web_search;
+    use harper_workspace::utils::web_search;
 
     // Skip this test in CI environments where network access might be restricted
     if std::env::var("CI").is_ok() {
@@ -832,7 +832,7 @@ server_url = "http://localhost:5000"
         let mut child = command.spawn().expect("Failed to start binary");
 
         // Send quit command using the constant
-        use harper::core::constants::{menu, messages};
+        use harper_workspace::core::constants::{menu, messages};
 
         let quit_command = format!(
             "{}
@@ -1063,7 +1063,7 @@ Full output:
 
     #[test]
     fn test_syntax_highlighting_parsing() {
-        use harper::interfaces::ui::widgets::parse_content_with_code;
+        use harper_workspace::interfaces::ui::widgets::parse_content_with_code;
         use ratatui::style::Color;
         use syntect::highlighting::ThemeSet;
         use syntect::parsing::SyntaxSet;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -784,7 +784,11 @@ server_url = "http://localhost:5000"
         }
 
         // Build the binary first
-        let profile = if cfg!(debug_assertions) { "debug" } else { "release" };
+        let profile = if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        };
         let mut build_cmd = std::process::Command::new("cargo");
         build_cmd.args(["build", "-p", "harper-ui", "--bin", "harper"]);
         if profile == "release" {
@@ -795,7 +799,9 @@ server_url = "http://localhost:5000"
 
         // Build the command
         let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
-        let binary_path = std::path::Path::new(&target_dir).join(profile).join("harper");
+        let binary_path = std::path::Path::new(&target_dir)
+            .join(profile)
+            .join("harper");
         let mut command = Command::new(binary_path);
 
         // Set the working directory to the temp directory so it finds the config file

--- a/tests/integration/performance_test.rs
+++ b/tests/integration/performance_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
-use harper::*;
+use harper_workspace::*;
 use rusqlite::Connection;
 use std::hint::black_box;
 use std::thread;

--- a/tests/integration/performance_test.rs
+++ b/tests/integration/performance_test.rs
@@ -20,6 +20,7 @@ use std::thread;
 use std::time::Duration;
 use tempfile::NamedTempFile;
 
+#[allow(dead_code)]
 fn setup_database(size: usize) -> (Connection, String) {
     let temp_file = NamedTempFile::new().unwrap();
     let conn = Connection::open(temp_file.path()).unwrap();
@@ -39,6 +40,7 @@ fn setup_database(size: usize) -> (Connection, String) {
     (conn, temp_file.path().to_str().unwrap().to_string())
 }
 
+#[allow(dead_code)]
 fn save_messages_benchmark(c: &mut Criterion) {
     let sizes = [1, 10, 100, 1000];
 
@@ -72,6 +74,7 @@ fn save_messages_benchmark(c: &mut Criterion) {
     }
 }
 
+#[allow(dead_code)]
 fn load_history_benchmark(c: &mut Criterion) {
     let sizes = [1, 10, 100, 1000, 10_000];
 
@@ -116,6 +119,7 @@ fn load_history_benchmark(c: &mut Criterion) {
     }
 }
 
+#[allow(dead_code)]
 fn concurrent_access_benchmark(c: &mut Criterion) {
     let num_threads = num_cpus::get();
     let messages_per_thread = 100;
@@ -160,6 +164,7 @@ fn concurrent_access_benchmark(c: &mut Criterion) {
     });
 }
 
+#[allow(dead_code)]
 fn large_message_benchmark(c: &mut Criterion) {
     let sizes = [1_000, 10_000, 100_000];
 

--- a/tests/integration/security_test.rs
+++ b/tests/integration/security_test.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use harper::*;
+use harper_workspace::*;
 use rusqlite::Connection;
 use tempfile::NamedTempFile;
 

--- a/tests/session_service_test.rs
+++ b/tests/session_service_test.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use harper::core::error::HarperResult;
-use harper::core::io_traits::{Input, Output};
-use harper::memory::session_service::SessionService;
+use harper_workspace::core::error::HarperResult;
+use harper_workspace::core::io_traits::{Input, Output};
+use harper_workspace::memory::session_service::SessionService;
 use rusqlite::Connection;
 use tempfile::NamedTempFile;
 

--- a/tests/tools_test.rs
+++ b/tests/tools_test.rs
@@ -14,7 +14,7 @@
 
 //! Unit tests for tool modules
 
-use harper::tools::parsing;
+use harper_workspace::tools::parsing;
 
 #[test]
 fn test_extract_tool_arg() {


### PR DESCRIPTION
# Create root package with re-exports to enable integration tests

- Rename integration_test.rs to integration.rs for --test integration
- Add necessary dependencies for tests
- Fix binary path in E2E tests
- Allow dead code in performance benchmarks
- Fix clippy needless borrow