### PR TITLE
fix: check if CHANGELOG.md exists before modifying

### DIFF
--- a/.github/workflows/fix-changelog.yml
+++ b/.github/workflows/fix-changelog.yml
@@ -18,8 +18,12 @@ jobs:
 
       - name: Fix extra blank line in CHANGELOG.md
         run: |
-          # Remove extra blank line after the first version header
-          sed -i '/^## \[.*\](.*) (.*)$/{n;/^$/d;}' CHANGELOG.md
+          if [ -f CHANGELOG.md ]; then
+            # Remove extra blank line after the first version header
+            sed -i '/^## \[.*\](.*) (.*)$/{n;/^$/d;}' CHANGELOG.md
+          else
+            echo "CHANGELOG.md not found, skipping."
+          fi
 
       - name: Check for changes
         id: check


### PR DESCRIPTION
# Add check for CHANGELOG.md existence before running sed in fix-changelog workflow

Modified the fix-changelog GitHub workflow to check if CHANGELOG.md exists before attempting to modify it. This prevents the workflow from failing when the file is not present, displaying a message instead that the file was not found and skipping the operation.