### PR TITLE
fix(gemini): update authentication header to x-goog-api-key


### DIFF
--- a/lib/harper-core/src/core/llm_client.rs
+++ b/lib/harper-core/src/core/llm_client.rs
@@ -245,11 +245,10 @@ pub async fn call_llm(
 ")}]
                 });
             }
-            let url = config.base_url.clone();
+            let url = format!("{}?key={}", config.base_url, config.api_key);
             client
                 .post(&url)
                 .header(CONTENT_TYPE, "application/json")
-                .header(AUTHORIZATION, format!("Bearer {}", config.api_key))
                 .json(&body)
                 .send()
                 .await?

--- a/lib/harper-core/src/core/llm_client.rs
+++ b/lib/harper-core/src/core/llm_client.rs
@@ -245,10 +245,11 @@ pub async fn call_llm(
 ")}]
                 });
             }
-            let url = format!("{}?key={}", config.base_url, config.api_key);
+            let url = config.base_url.clone();
             client
                 .post(&url)
                 .header(CONTENT_TYPE, "application/json")
+                .header("x-goog-api-key", &config.api_key)
                 .json(&body)
                 .send()
                 .await?


### PR DESCRIPTION
### **PR title**

**fix(gemini): update authentication header to x-goog-api-key**

---

### **PR description**

This PR updates the Gemini API authentication method to use the `x-goog-api-key` header instead of the `Authorization` header with a Bearer token. The client now passes the raw API key directly, aligning with Gemini’s documented authentication requirements.

#### Why this change?

Gemini uses API keys for authentication rather than OAuth or token-based mechanisms. The previous implementation treated the API key as a Bearer token, which does not match how the Gemini API expects credentials and can result in authentication failures.

Using `x-goog-api-key`:

* Matches Google’s standard API key authentication pattern
* Avoids confusion between API keys and token-based authentication
* Aligns with the official Generative AI documentation
* Reduces the risk of misconfiguration

The Bearer-based approach was incorrect for Gemini’s API key model, and this change brings the implementation in line with expected usage.