### PR TITLE
ci: add workflow to automatically lock merged PRs

### DIFF
--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -1,0 +1,17 @@
+name: Lock Merged PRs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  lock:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Lock PR
+        run: gh pr lock ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Lock Merged PRs

This PR adds a GitHub Actions workflow that automatically locks pull requests after they are merged. The workflow runs when a PR is closed and merged, using the GitHub CLI to lock the PR and prevent further comments.