### PR TITLE
fix: add repository parameter to PR lock command

### DIFF
--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Lock PR
-        run: gh pr lock ${{ github.event.pull_request.number }}
+        run: gh pr lock ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added the `--repo` flag to the GitHub CLI command in the PR locking workflow to explicitly specify which repository to operate on. This ensures the command works correctly in the GitHub Actions environment by using `${{ github.repository }}` as the repository parameter.