### PR TITLE
ci: add Rust auto-fix workflow for PR comments

### DIFF
--- a/.github/workflows/rust-auto-fix.yml
+++ b/.github/workflows/rust-auto-fix.yml
@@ -1,0 +1,65 @@
+name: Rust Auto-Fix Bot
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rust-auto-fix:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/rust-fix')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+    
+    - name: Get PR info
+      id: pr
+      run: |
+        pr_number=${{ github.event.issue.number }}
+        gh pr checkout $pr_number
+        echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Install Rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: rustfmt, clippy
+    
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential pkg-config libsqlite3-dev
+    
+    - name: Apply Rust fixes
+      run: |
+        comment="${{ github.event.comment.body }}"
+        if [[ "$comment" == *"/rust-fix fmt"* ]]; then
+          cargo fmt
+          echo "✅ Applied cargo fmt"
+        fi
+        if [[ "$comment" == *"/rust-fix clippy"* ]]; then
+          cargo clippy --fix --allow-dirty --allow-staged
+          echo "✅ Applied clippy auto-fixes"
+        fi
+        if [[ "$comment" == *"/rust-fix all"* ]]; then
+          cargo fmt
+          cargo clippy --fix --allow-dirty --allow-staged
+          echo "✅ Applied all Rust fixes (fmt + clippy)"
+        fi
+    
+    - name: Commit and push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "Rust Auto-Fix Bot"
+        if git diff --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
+        git add .
+        git commit -m "🦀 Auto-fix: ${{ github.event.comment.body }}"
+        git push

--- a/.github/workflows/rust-auto-fix.yml
+++ b/.github/workflows/rust-auto-fix.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
-    
+
     - name: Get PR info
       id: pr
       run: |
@@ -24,17 +24,17 @@ jobs:
         echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         components: rustfmt, clippy
-    
+
     - name: Install system dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential pkg-config libsqlite3-dev
-    
+
     - name: Apply Rust fixes
       run: |
         comment="${{ github.event.comment.body }}"
@@ -51,7 +51,7 @@ jobs:
           cargo clippy --fix --allow-dirty --allow-staged
           echo "✅ Applied all Rust fixes (fmt + clippy)"
         fi
-    
+
     - name: Commit and push changes
       run: |
         git config --local user.email "action@github.com"

--- a/.github/workflows/rust-auto-fix.yml
+++ b/.github/workflows/rust-auto-fix.yml
@@ -4,8 +4,47 @@ on:
     types: [created]
 
 jobs:
-  rust-auto-fix:
+  rust-auto-fix-request:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/rust-fix')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - name: Check what fixes are requested
+      id: check
+      run: |
+        comment="${{ github.event.comment.body }}"
+        fixes=""
+        if [[ "$comment" == *"/rust-fix fmt"* ]]; then
+          fixes="cargo fmt"
+        fi
+        if [[ "$comment" == *"/rust-fix clippy"* ]]; then
+          fixes="${fixes:+$fixes + }clippy --fix"
+        fi
+        if [[ "$comment" == *"/rust-fix all"* ]]; then
+          fixes="cargo fmt + clippy --fix"
+        fi
+        echo "fixes=$fixes" >> $GITHUB_OUTPUT
+
+    - name: Comment confirmation
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: |
+              🦀 **Rust Auto-Fix Bot**
+
+              I'll apply: `${{ steps.check.outputs.fixes }}`
+
+              Reply with `/confirm` to proceed or `/cancel` to abort.
+          })
+
+  rust-auto-fix-execute:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/confirm')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,21 +74,35 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential pkg-config libsqlite3-dev
 
+    - name: Get previous bot comment
+      id: prev
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const comments = await github.rest.issues.listComments({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          const botComment = comments.data.reverse().find(c =>
+            c.user.login === 'github-actions[bot]' &&
+            c.body.includes('Rust Auto-Fix Bot')
+          );
+          if (botComment) {
+            const fixes = botComment.body.match(/I'll apply: `([^`]+)`/)?.[1] || '';
+            core.setOutput('fixes', fixes);
+          }
+
     - name: Apply Rust fixes
       run: |
-        comment="${{ github.event.comment.body }}"
-        if [[ "$comment" == *"/rust-fix fmt"* ]]; then
+        fixes="${{ steps.prev.outputs.fixes }}"
+        if [[ "$fixes" == *"cargo fmt"* ]]; then
           cargo fmt
           echo "✅ Applied cargo fmt"
         fi
-        if [[ "$comment" == *"/rust-fix clippy"* ]]; then
+        if [[ "$fixes" == *"clippy"* ]]; then
           cargo clippy --fix --allow-dirty --allow-staged
           echo "✅ Applied clippy auto-fixes"
-        fi
-        if [[ "$comment" == *"/rust-fix all"* ]]; then
-          cargo fmt
-          cargo clippy --fix --allow-dirty --allow-staged
-          echo "✅ Applied all Rust fixes (fmt + clippy)"
         fi
 
     - name: Commit and push changes
@@ -61,5 +114,5 @@ jobs:
           exit 0
         fi
         git add .
-        git commit -m "🦀 Auto-fix: ${{ github.event.comment.body }}"
+        git commit -m "🦀 Auto-fix: ${{ steps.prev.outputs.fixes }}"
         git push


### PR DESCRIPTION
## Why (brief):
- Adds automated Rust code formatting and linting via PR comments → feature addition
- Reduces manual work for maintainers applying cargo fmt/clippy fixes → workflow improvement  
- Provides confirmation step to prevent accidental changes → safety enhancement

## Usage:
1. Comment `/rust-fix fmt`, `/rust-fix clippy`, or `/rust-fix all` on any PR
2. Bot replies with confirmation of what it will apply
3. Reply `/confirm` to execute or `/cancel` to abort
4. Bot applies fixes and commits changes to PR branch

## Implementation:
- GitHub Actions workflow with two jobs (request + execute)
- Uses `cargo fmt` and `cargo clippy --fix`
- Commits with 🦀 emoji for easy identification