### PR TITLE
fix: prevent multiple api keys from overwriting each other

### DIFF
--- a/lib/harper-core/src/runtime/config.rs
+++ b/lib/harper-core/src/runtime/config.rs
@@ -117,6 +117,26 @@ impl HarperConfig {
     ) -> HarperResult<()> {
         let mut temp_builder = std::mem::take(builder);
 
+        // Check for multiple API keys and prevent conflicts
+        let mut found_keys = Vec::new();
+        
+        if env::var("OPENAI_API_KEY").is_ok_and(|k| !k.trim().is_empty()) {
+            found_keys.push("OPENAI_API_KEY");
+        }
+        if env::var("SAMBASTUDIO_API_KEY").is_ok_and(|k| !k.trim().is_empty()) {
+            found_keys.push("SAMBASTUDIO_API_KEY");
+        }
+        if env::var("GEMINI_API_KEY").is_ok_and(|k| !k.trim().is_empty()) {
+            found_keys.push("GEMINI_API_KEY");
+        }
+
+        if found_keys.len() > 1 {
+            return Err(HarperError::Config(format!(
+                "Multiple API keys found: {}. Please set only one API key at a time.",
+                found_keys.join(", ")
+            )));
+        }
+
         // Map OPENAI_API_KEY to api settings
         if let Ok(key) = env::var("OPENAI_API_KEY") {
             if !key.trim().is_empty() {

--- a/lib/harper-core/src/runtime/config.rs
+++ b/lib/harper-core/src/runtime/config.rs
@@ -119,7 +119,7 @@ impl HarperConfig {
 
         // Check for multiple API keys and prevent conflicts
         let mut found_keys = Vec::new();
-        
+
         if env::var("OPENAI_API_KEY").is_ok_and(|k| !k.trim().is_empty()) {
             found_keys.push("OPENAI_API_KEY");
         }

--- a/lib/harper-core/src/runtime/config.rs
+++ b/lib/harper-core/src/runtime/config.rs
@@ -118,17 +118,11 @@ impl HarperConfig {
         let mut temp_builder = std::mem::take(builder);
 
         // Check for multiple API keys and prevent conflicts
-        let mut found_keys = Vec::new();
-
-        if env::var("OPENAI_API_KEY").is_ok_and(|k| !k.trim().is_empty()) {
-            found_keys.push("OPENAI_API_KEY");
-        }
-        if env::var("SAMBASTUDIO_API_KEY").is_ok_and(|k| !k.trim().is_empty()) {
-            found_keys.push("SAMBASTUDIO_API_KEY");
-        }
-        if env::var("GEMINI_API_KEY").is_ok_and(|k| !k.trim().is_empty()) {
-            found_keys.push("GEMINI_API_KEY");
-        }
+        let api_key_vars = ["OPENAI_API_KEY", "SAMBASTUDIO_API_KEY", "GEMINI_API_KEY"];
+        let found_keys: Vec<_> = api_key_vars
+            .into_iter()
+            .filter(|key_name| env::var(key_name).is_ok_and(|k| !k.trim().is_empty()))
+            .collect();
 
         if found_keys.len() > 1 {
             return Err(HarperError::Config(format!(


### PR DESCRIPTION
## Why (brief):
- Configuration now validates multiple API keys to prevent silent overwrites → bug fix
- Added clear error message when multiple API keys are detected → behavior change
- Prevents unexpected provider switching due to environment variable conflicts → bug fix