### PR TITLE
refactor: remove code duplication in error display

### DIFF
--- a/lib/harper-core/src/core/error.rs
+++ b/lib/harper-core/src/core/error.rs
@@ -61,17 +61,7 @@ impl std::error::Error for HarperError {}
 impl HarperError {
     /// Get formatted error message for display
     pub fn display_message(&self) -> String {
-        match self {
-            HarperError::Config(msg) => format!("Configuration error: {}", msg),
-            HarperError::Database(msg) => format!("Database error: {}", msg),
-            HarperError::Api(msg) => format!("API error: {}", msg),
-            HarperError::Mcp(msg) => format!("MCP error: {}", msg),
-            HarperError::Crypto(msg) => format!("Cryptography error: {}", msg),
-            HarperError::Io(msg) => format!("I/O error: {}", msg),
-            HarperError::File(msg) => format!("File operation error: {}", msg),
-            HarperError::Command(msg) => format!("Command execution error: {}", msg),
-            HarperError::WebSearch(msg) => format!("Web search error: {}", msg),
-        }
+        self.to_string()
     }
 
     /// Get colored error message for CLI

--- a/lib/harper-core/src/core/error.rs
+++ b/lib/harper-core/src/core/error.rs
@@ -60,13 +60,14 @@ impl std::error::Error for HarperError {}
 
 impl HarperError {
     /// Get formatted error message for display
+    #[deprecated(note = "Please use `to_string()` instead")]
     pub fn display_message(&self) -> String {
         self.to_string()
     }
 
     /// Get colored error message for CLI
     pub fn cli_message(&self) -> colored::ColoredString {
-        self.display_message().red()
+        self.to_string().red()
     }
 }
 

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -47,7 +47,7 @@ fn load_sessions_into_state(app: &mut TuiApp, session_service: &SessionService) 
             app.state = AppState::Sessions(session_infos, 0);
         }
         Err(e) => {
-            app.set_error_message(format!("Error loading sessions: {}", e.display_message()));
+            app.set_error_message(format!("Error loading sessions: {}", e));
         }
     }
 }
@@ -66,7 +66,7 @@ fn load_export_sessions_into_state(app: &mut TuiApp, session_service: &SessionSe
             app.state = AppState::ExportSessions(session_infos, 0);
         }
         Err(e) => {
-            app.set_error_message(format!("Error loading sessions: {}", e.display_message()));
+            app.set_error_message(format!("Error loading sessions: {}", e));
         }
     }
 }
@@ -199,10 +199,7 @@ fn handle_enter(app: &mut TuiApp, session_service: &SessionService) -> EventResu
                         });
                     }
                     Err(e) => {
-                        app.set_error_message(format!(
-                            "Error loading session: {}",
-                            e.display_message()
-                        ));
+                        app.set_error_message(format!("Error loading session: {}", e));
                     }
                 }
             }
@@ -212,9 +209,7 @@ fn handle_enter(app: &mut TuiApp, session_service: &SessionService) -> EventResu
                 let session = &sessions[*selected];
                 match session_service.export_session_by_id(&session.id) {
                     Ok(path) => app.set_info_message(format!("Session exported to {}", path)),
-                    Err(e) => {
-                        app.set_error_message(format!("Export failed: {}", e.display_message()))
-                    }
+                    Err(e) => app.set_error_message(format!("Export failed: {}", e)),
                 }
                 app.state = AppState::Menu(0);
             }


### PR DESCRIPTION
## Why (brief):
- Error display method now uses Display implementation instead of duplicating logic → refactor
- Eliminates 10 lines of duplicate error formatting code → code cleanup  
- Ensures consistent error messages across all usage patterns → maintainability improvement