### PR TITLE
fix: yaml syntax error in rust-auto-fix workflow

### DIFF
--- a/.github/workflows/rust-auto-fix.yml
+++ b/.github/workflows/rust-auto-fix.yml
@@ -35,12 +35,11 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: |
-              🦀 **Rust Auto-Fix Bot**
+            body: `🦀 **Rust Auto-Fix Bot**
 
-              I'll apply: `${{ steps.check.outputs.fixes }}`
+          I'll apply: \`${{ steps.check.outputs.fixes }}\`
 
-              Reply with `/confirm` to proceed or `/cancel` to abort.
+          Reply with \`/confirm\` to proceed or \`/cancel\` to abort.`
           })
 
   rust-auto-fix-execute:


### PR DESCRIPTION
## Why (brief):
- Replace YAML multiline string with JavaScript template literal in github-script action → bug fix
- Fixes SyntaxError: Unexpected token '|' causing workflow failure → bug fix
- Ensures proper string interpolation and multiline handling in GitHub Actions → behavior change