### PR TITLE
feat: audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ create a new feature branch
 Harper shows the command.
 You decide if it runs.
 
+Need to review what ran? Type `/audit` (or `/audit 25 failed approved`) any time to print the latest shell commands filtered by limit/status/approval, with exit codes and runtimes tied to the current session.
+
 ---
 
 ## Providers

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -272,6 +272,8 @@ fn log_operation(op: &OperationLog) {
 }
 ```
 
+Harper now persists shell executions to a `command_logs` table (session ID, command text, approval state, exit code, runtime, and stdout/stderr previews), ensuring every approved or rejected command is audit-able alongside the chat transcript. Operators can review the last `n` entries interactively via `/audit` (defaults to 10, e.g., `/audit 25 failed approved`) and see a summary in the session viewer/export flow.
+
 ### Session Tracking
 ```rust
 struct AgentSession {

--- a/lib/harper-core/src/tools/shell.rs
+++ b/lib/harper-core/src/tools/shell.rs
@@ -18,15 +18,28 @@
 //! with safety checks and user approval.
 
 use crate::core::{error::HarperError, ApiConfig};
+use crate::memory::storage::{self, CommandLogRecord};
 use crate::runtime::config::ExecPolicyConfig;
 use colored::*;
+use rusqlite::Connection;
 use std::io;
+use std::time::Instant;
+
+const OUTPUT_PREVIEW_LIMIT: usize = 512;
+
+/// Context for persisting command audit logs
+pub struct CommandAuditContext<'a> {
+    pub conn: &'a Connection,
+    pub session_id: Option<&'a str>,
+    pub source: &'a str,
+}
 
 /// Execute a shell command with safety checks
 pub fn execute_command(
     response: &str,
     _config: &ApiConfig,
     exec_policy: &ExecPolicyConfig,
+    audit_ctx: Option<&CommandAuditContext>,
 ) -> crate::core::error::HarperResult<String> {
     let command_str = if let Some(pos) = response.find(' ') {
         response[pos..].trim_start().trim_end_matches(']')
@@ -35,6 +48,18 @@ pub fn execute_command(
     };
 
     if command_str.is_empty() {
+        maybe_log_command(
+            audit_ctx,
+            command_str,
+            "invalid",
+            true,
+            false,
+            None,
+            None,
+            None,
+            None,
+            Some("No command provided".to_string()),
+        );
         return Err(HarperError::Command("No command provided".to_string()));
     }
 
@@ -44,11 +69,21 @@ pub fn execute_command(
         ';', '|', '&', '`', '$', '(', ')', '<', '>', '*', '?', '[', ']', '{', '}', '!', '~',
     ];
     if command_str.chars().any(|c| dangerous_chars.contains(&c)) {
-        return Err(HarperError::Command(
-            "Command contains potentially dangerous shell metacharacters. \
-             Only basic commands without shell features are allowed."
-                .to_string(),
-        ));
+        let message = "Command contains potentially dangerous shell metacharacters. \
+             Only basic commands without shell features are allowed.";
+        maybe_log_command(
+            audit_ctx,
+            command_str,
+            "blocked",
+            true,
+            false,
+            None,
+            None,
+            None,
+            None,
+            Some(message.to_string()),
+        );
+        return Err(HarperError::Command(message.to_string()));
     }
 
     // Additional check for common dangerous patterns
@@ -78,33 +113,60 @@ pub fn execute_command(
 
     for pattern in &dangerous_patterns {
         if command_str.contains(pattern) {
-            return Err(HarperError::Command(format!(
+            let err = format!(
                 "Command contains potentially dangerous pattern: '{}'. \
                         This command is not allowed for security reasons.",
                 pattern
-            )));
+            );
+            maybe_log_command(
+                audit_ctx,
+                command_str,
+                "blocked",
+                true,
+                false,
+                None,
+                None,
+                None,
+                None,
+                Some(err.clone()),
+            );
+            return Err(HarperError::Command(err));
         }
     }
 
     // Check exec policy
     let mut requires_approval = true;
+    let mut approved = false;
 
     if let Some(blocked) = &exec_policy.blocked_commands {
         if blocked.iter().any(|cmd| command_str.starts_with(cmd)) {
-            return Err(HarperError::Command(format!(
-                "Command '{}' is blocked by exec policy.",
-                command_str
-            )));
+            let err = format!("Command '{}' is blocked by exec policy.", command_str);
+            maybe_log_command(
+                audit_ctx,
+                command_str,
+                "blocked",
+                requires_approval,
+                false,
+                None,
+                None,
+                None,
+                None,
+                Some(err.clone()),
+            );
+            return Err(HarperError::Command(err));
         }
     }
 
     if let Some(allowed) = &exec_policy.allowed_commands {
         if allowed.iter().any(|cmd| command_str.starts_with(cmd)) {
             requires_approval = false;
+            approved = true;
         } else {
             // If allowed list is set, only allowed commands are permitted without approval
             requires_approval = true;
         }
+    } else {
+        approved = !requires_approval;
     }
 
     // Ask for approval if required
@@ -117,8 +179,21 @@ pub fn execute_command(
         let mut approval = String::new();
         io::stdin().read_line(&mut approval)?;
         if !approval.trim().eq_ignore_ascii_case("y") {
+            maybe_log_command(
+                audit_ctx,
+                command_str,
+                "cancelled",
+                requires_approval,
+                false,
+                None,
+                None,
+                None,
+                None,
+                Some("User rejected command".to_string()),
+            );
             return Ok("Command execution cancelled by user".to_string());
         }
+        approved = true;
     } else {
         println!(
             "{} Executing allowed command: {}",
@@ -133,17 +208,108 @@ pub fn execute_command(
         command_str.magenta()
     );
 
+    let start = Instant::now();
     let output = std::process::Command::new("sh")
         .arg("-c")
         .arg(command_str)
         .output()
-        .map_err(|e| HarperError::Command(format!("Failed to execute command: {}", e)))?;
+        .map_err(|e| {
+            let err_msg = format!("Failed to execute command: {}", e);
+            maybe_log_command(
+                audit_ctx,
+                command_str,
+                "error",
+                requires_approval,
+                approved,
+                None,
+                None,
+                None,
+                None,
+                Some(err_msg.clone()),
+            );
+            HarperError::Command(err_msg)
+        })?;
+    let duration_ms = start.elapsed().as_millis() as i64;
+    let exit_code = output.status.code();
+    let stdout_preview = bytes_to_preview(&output.stdout);
+    let stderr_preview = bytes_to_preview(&output.stderr);
 
     let result = if output.status.success() {
-        String::from_utf8_lossy(&output.stdout).to_string()
+        let out = String::from_utf8_lossy(&output.stdout).to_string();
+        maybe_log_command(
+            audit_ctx,
+            command_str,
+            "succeeded",
+            requires_approval,
+            approved,
+            exit_code,
+            Some(duration_ms),
+            stdout_preview,
+            stderr_preview,
+            None,
+        );
+        out
     } else {
-        String::from_utf8_lossy(&output.stderr).to_string()
+        let err_output = String::from_utf8_lossy(&output.stderr).to_string();
+        maybe_log_command(
+            audit_ctx,
+            command_str,
+            "failed",
+            requires_approval,
+            approved,
+            exit_code,
+            Some(duration_ms),
+            stdout_preview,
+            stderr_preview,
+            Some("Command exited with non-zero status".to_string()),
+        );
+        err_output
     };
 
     Ok(result)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn maybe_log_command(
+    audit_ctx: Option<&CommandAuditContext>,
+    command: &str,
+    status: &str,
+    requires_approval: bool,
+    approved: bool,
+    exit_code: Option<i32>,
+    duration_ms: Option<i64>,
+    stdout_preview: Option<String>,
+    stderr_preview: Option<String>,
+    error_message: Option<String>,
+) {
+    if let Some(ctx) = audit_ctx {
+        let record = CommandLogRecord::new(
+            ctx.session_id,
+            command,
+            ctx.source,
+            requires_approval,
+            approved,
+            status,
+            exit_code,
+            duration_ms,
+            stdout_preview,
+            stderr_preview,
+            error_message,
+        );
+        if let Err(err) = storage::insert_command_log(ctx.conn, &record) {
+            eprintln!("Warning: failed to persist command log: {}", err);
+        }
+    }
+}
+
+fn bytes_to_preview(bytes: &[u8]) -> Option<String> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(bytes);
+    let mut preview = text.chars().take(OUTPUT_PREVIEW_LIMIT).collect::<String>();
+    if text.chars().count() > OUTPUT_PREVIEW_LIMIT {
+        preview.push('…');
+    }
+    Some(preview)
 }

--- a/tests/command_log_test.rs
+++ b/tests/command_log_test.rs
@@ -1,0 +1,62 @@
+// Copyright 2025 harpertoken
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use harper_workspace::core::{ApiConfig, ApiProvider};
+use harper_workspace::memory::storage;
+use harper_workspace::runtime::config::ExecPolicyConfig;
+use harper_workspace::tools::shell::{self, CommandAuditContext};
+use rusqlite::Connection;
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_execute_command_persists_audit_log() {
+    let temp_file = NamedTempFile::new().expect("temp db");
+    let conn = Connection::open(temp_file.path()).expect("open db");
+    storage::init_db(&conn).expect("init db");
+
+    let api_config = ApiConfig {
+        provider: ApiProvider::OpenAI,
+        api_key: String::new(),
+        base_url: String::new(),
+        model_name: String::new(),
+    };
+
+    let exec_policy = ExecPolicyConfig {
+        allowed_commands: Some(vec!["echo".to_string()]),
+        blocked_commands: None,
+    };
+
+    let audit_ctx = CommandAuditContext {
+        conn: &conn,
+        session_id: Some("test-session"),
+        source: "test_harness",
+    };
+
+    let output = shell::execute_command(
+        "[RUN_COMMAND echo audit-log]",
+        &api_config,
+        &exec_policy,
+        Some(&audit_ctx),
+    )
+    .expect("command should succeed");
+    assert!(output.contains("audit-log"));
+
+    let entries =
+        storage::load_command_logs_for_session(&conn, "test-session", 5).expect("load logs");
+    assert_eq!(entries.len(), 1);
+    let entry = &entries[0];
+    assert!(entry.command.contains("echo"));
+    assert_eq!(entry.status, "succeeded");
+    assert!(entry.approved);
+}


### PR DESCRIPTION
## Work Log

- Added persistent command-audit logging: schema, insert/read helpers, audit-aware shell execution, `/audit [limit status=… approval=…]` parsing, and inline summaries plus exported report sections  
  (lib/harper-core/src/memory/storage/mod.rs, lib/harper-core/src/tools/shell.rs, lib/harper-core/src/tools/mod.rs, lib/harper-core/src/agent/chat.rs, lib/harper-core/src/memory/session_service.rs).

- Updated docs & tests to describe the guardrail and verify log-writing + session-view summaries  
  (README.md, docs/AGENTS.md, tests/session_service_test.rs, tests/command_log_test.rs).

- Verified targeted tests pass locally:
  - cargo test -p harper-core parse_audit_no_args
  - cargo test -p harper-core parse_audit_shorthand_tokens
  - cargo test -p harper-core test_execute_command_persists_audit_log
  - cargo test -p harper-core test_list_sessions_empty
  - cargo test -p harper-core test_list_sessions_with_audit_summary