### PR TITLE
feat: add homebrew formula for harper-ai

### DIFF
--- a/formula/harper-ai.rb
+++ b/formula/harper-ai.rb
@@ -1,0 +1,37 @@
+class HarperAi < Formula
+  desc "AI for the terminal - translates natural language into reviewed, executable commands"
+  homepage "https://github.com/harpertoken/harper"
+  version "0.4.0"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/harpertoken/harper/archive/refs/tags/0.4.0.tar.gz"
+      sha256 "b5ecf8227c2fb6510aa51d2c6454d80b8bad075e571456131dac1007a38bfef9"
+    else
+      url "https://github.com/harpertoken/harper/archive/refs/tags/0.4.0.tar.gz"
+      sha256 "b5ecf8227c2fb6510aa51d2c6454d80b8bad075e571456131dac1007a38bfef9"
+    end
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "build", "--release", "--manifest-path=Cargo.toml"
+    
+    # Check both possible locations for binaries
+    if File.exist?("bin/harper")
+      bin.install "bin/harper" => "harper"
+      bin.install "bin/harper-batch" => "harper-batch" if File.exist?("bin/harper-batch")
+    elsif File.exist?("target/release/harper")
+      bin.install "target/release/harper" => "harper"
+      bin.install "target/release/harper-batch" => "harper-batch" if File.exist?("target/release/harper-batch")
+    else
+      raise "Binary not found in expected location"
+    end
+  end
+
+  test do
+    assert_match "Harper", shell_output("#{bin}/harper --version")
+  end
+end


### PR DESCRIPTION
## Why

* Add a Homebrew tap for easy macOS installation
* Avoid conflict with existing Homebrew `harper` (grammar checker)

<details>
<summary>Changes</summary>

* Added `formula/harper-ai.rb`
* Created Homebrew tap repository `harpertoken/homebrew-tap`
* Installed binaries remain `harper` and `harper-batch`

</details>

<details>
<summary>Testing</summary>

### Install via Homebrew tap

```bash
brew tap harpertoken/homebrew-tap
brew install harper-ai
```

### Install log

```text
==> Tapping harpertoken/homebrew-tap
Cloning into '/opt/homebrew/Library/Taps/harpertoken/homebrew-tap'...
Tapped 1 formula (13 files, 6.2KB).

==> Installing harper-ai
==> Fetching downloads for: harper-ai
✔︎ Formula harper-ai (0.4.0)
==> Installing dependencies for harpertoken/tap/harper-ai: libgit2, z3, llvm, rust
==> cargo build --release
🍺  /opt/homebrew/Cellar/harper-ai/0.4.0: 8 files, 10.7MB, built in 1m 25s
```

### Verify binaries

```bash
harper --version
harper-batch --version
```

</details>

<details>
<summary>Installation (User-facing)</summary>

```bash
brew tap harpertoken/homebrew-tap
brew install harper-ai
```

</details>

<details>
<summary>Alternative: Direct formula install (not recommended)</summary>

```bash
# This method does not work - Homebrew requires a tap
brew install --formula \
https://raw.githubusercontent.com/harpertoken/harper/main/formula/harper-ai.rb
```

</details>

<details>
<summary>Notes</summary>

* Formula named `harper-ai` to avoid Homebrew core conflict
* Tap named `harpertoken/homebrew-tap` (Homebrew naming convention)
* Installed binaries remain `harper` and `harper-batch`

</details>