### PR TITLE
fix: simplify release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,23 +6,11 @@ on:
       - main
 
 jobs:
-  release-harper-core:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          package-manifest: lib/harper-core/Cargo.toml
           config-file: release-please-config.json
-
-  release-harper-ui:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          package-manifest: lib/harper-ui/Cargo.toml
-          config-file: release-please-config.json
-          skip-github-release: true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,8 @@
       "prerelease": false
     }
   },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-v-in-tag": false,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Why

Two issues:

1. Wrong parameter: Used `package-manifest` but release-please-action v4 expects `config-file` to point to `release-please-config.json` which already contains the package paths

2. Separate jobs: Had `release-harper-core` and `release-harper-ui` as separate jobs, causing conflicts with "untagged, merged release PRs outstanding"

The fix simplifies to a single job using just `config-file: release-please-config.json`.

## Additional Issue

Commit messages not following conventional format - the logs showed:
```
❯ commit could not be parsed: af294d57adfc60533be4bbe68268784d61211e5c trigger ci re-run after merge conflict resolution
❯ commit could not be parsed: 7f45becd0ce1735beb78b7233de7a40fe6989188 summary of recent improvements
```

Release-please needs commits like `feat:`, `fix:`, `chore:`, etc. to determine version bumps.

The fix should help it run without errors, but for proper releases, commits need to follow conventional commits format.

## Changes
- Changed `package-manifest` to use `config-file` only
- Simplified to single release job instead of separate harper-core and harper-ui jobs
- Added `$schema` and `include-v-in-tag: false` to release-please-config.json

## Testing
- Workflow should now run without warnings