### PR TITLE
fix: update release-please config to fix component matching

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,19 +2,20 @@
   "packages": {
     "lib/harper-core": {
       "release-type": "rust",
-      "package-manifest": "Cargo.toml",
+      "package-name": "harper-core",
       "changelog-path": "CHANGELOG.md",
       "prerelease": false
     },
     "lib/harper-ui": {
       "release-type": "rust",
-      "package-manifest": "Cargo.toml",
+      "package-name": "harper-ui",
       "changelog-path": "CHANGELOG.md",
       "prerelease": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": false,
+  "separate-pull-requests": false,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Why

Release-please was showing warnings:
```
⚠ Found release tag with component '', but not configured in manifest
⚠ There are untagged, merged release PRs outstanding - aborting
```

The config was missing proper `package-name` for each component.

## Changes

- Removed `package-manifest` (not needed for rust type)
- Added `package-name` for each package
- Added `separate-pull-requests: false` to avoid conflicts