### PR TITLE
fix: release-please config v2

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,18 +4,21 @@
       "release-type": "rust",
       "package-name": "harper-core",
       "changelog-path": "CHANGELOG.md",
-      "prerelease": false
+      "prerelease": false,
+      "tag": "harper-core-${version}"
     },
     "lib/harper-ui": {
       "release-type": "rust",
       "package-name": "harper-ui",
       "changelog-path": "CHANGELOG.md",
-      "prerelease": false
+      "prerelease": false,
+      "tag": "harper-ui-${version}"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": false,
   "separate-pull-requests": false,
+  "pullRequestTitlePattern": "chore: release ${component} ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Why
- Release-please was not working due to:
  - Pull request title pattern not matching
  - Tags not properly configured for components

## Changes
- Added `tag` for each package: `harper-core-${version}` and `harper-ui-${version}`
- Added `pullRequestTitlePattern: "chore: release ${component} ${version}"`

## Testing
- After merging, the release workflow should work properly