### PR TITLE
feat: add screenpipe integration for screen/audio search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "harper-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "arboard",
@@ -1702,6 +1702,7 @@ dependencies = [
  "tokio",
  "tower",
  "turul-mcp-client",
+ "urlencoding",
  "uuid",
  "windows-sys 0.60.2",
  "windows-targets 0.53.5",
@@ -1722,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "harper-ui"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "colored",
@@ -2378,9 +2379,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4798,6 +4799,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -32,6 +32,7 @@ block-padding = "0.3"
 hex-literal = "0.4.1"
 rustyline = "14.0"
 image = "0.25.6"
+urlencoding = "2.1"
 
 # Dependency resolution
 [dependencies.base64]

--- a/lib/harper-core/src/core/constants.rs
+++ b/lib/harper-core/src/core/constants.rs
@@ -181,6 +181,10 @@ pub mod tools {
     #[allow(dead_code)]
     pub const IMAGE_RESIZE: &str = "[IMAGE_RESIZE";
 
+    /// Screenpipe search prefix
+    #[allow(dead_code)]
+    pub const SCREENPIPE: &str = "[SCREENPIPE";
+
     /// Command suffix
     #[allow(dead_code)]
     pub const COMMAND_SUFFIX: &str = "]";

--- a/lib/harper-core/src/tools/mod.rs
+++ b/lib/harper-core/src/tools/mod.rs
@@ -24,6 +24,7 @@ pub mod filesystem;
 pub mod git;
 pub mod github;
 pub mod image;
+pub mod screenpipe;
 pub mod shell;
 pub mod todo;
 pub mod web;
@@ -193,6 +194,12 @@ impl<'a> ToolService<'a> {
                 image::resize_image(response)
             })
             .await
+        } else if response.to_uppercase().starts_with(tools::SCREENPIPE) {
+            let search_result = screenpipe::search_screenpipe(response).await?;
+            let final_response = self
+                .call_llm_after_tool(client, history, &search_result)
+                .await?;
+            Ok(Some((final_response, search_result)))
         } else {
             Ok(None)
         }

--- a/lib/harper-core/src/tools/screenpipe.rs
+++ b/lib/harper-core/src/tools/screenpipe.rs
@@ -1,0 +1,177 @@
+// Copyright 2025 harpertoken
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Screenpipe tool
+//!
+//! This module provides functionality for searching screenpipe's screen/audio history.
+
+use crate::core::error::HarperError;
+use crate::tools::parsing;
+use colored::*;
+use reqwest::Client;
+use serde::Deserialize;
+
+const DEFAULT_SCREENPIPE_URL: &str = "http://localhost:3030";
+const DEFAULT_LIMIT: usize = 10;
+
+#[derive(Debug, Deserialize)]
+struct ScreenpipeSearchResponse {
+    data: Vec<ScreenpipeItem>,
+    #[serde(default)]
+    pagination: Option<ScreenpipePagination>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct ScreenpipeItem {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    app_name: Option<String>,
+    #[serde(default)]
+    window_title: Option<String>,
+    #[serde(default)]
+    timestamp: Option<String>,
+    #[serde(default)]
+    r#type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+struct ScreenpipePagination {
+    #[serde(default)]
+    limit: Option<usize>,
+    #[serde(default)]
+    offset: Option<usize>,
+    #[serde(default)]
+    total: Option<usize>,
+}
+
+pub async fn search_screenpipe(response: &str) -> crate::core::error::HarperResult<String> {
+    let args = parsing::extract_tool_args(response, "[SCREENPIPE", 3)?;
+
+    let query = &args[0];
+    let content_type = if args.len() > 1 && !args[1].is_empty() {
+        &args[1]
+    } else {
+        "ocr"
+    };
+    let limit = if args.len() > 2 && !args[2].is_empty() {
+        args[2].parse().unwrap_or(DEFAULT_LIMIT)
+    } else {
+        DEFAULT_LIMIT
+    };
+
+    let screenpipe_url =
+        std::env::var("SCREENPIPE_URL").unwrap_or_else(|_| DEFAULT_SCREENPIPE_URL.to_string());
+
+    let url = format!(
+        "{}/search?q={}&content_type={}&limit={}",
+        screenpipe_url,
+        urlencoding::encode(query),
+        content_type,
+        limit
+    );
+
+    println!(
+        "{} Searching screenpipe: query='{}', type='{}', limit={}",
+        "System:".bold().magenta(),
+        query.magenta(),
+        content_type.magenta(),
+        limit
+    );
+
+    let client = Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| HarperError::Command(format!("Failed to create HTTP client: {}", e)))?;
+
+    let response = client.get(&url).send().await.map_err(|e| {
+        if e.is_connect() {
+            HarperError::Command(format!(
+                "Could not connect to screenpipe at {}. Is screenpipe running?",
+                screenpipe_url
+            ))
+        } else {
+            HarperError::Command(format!("Screenpipe request failed: {}", e))
+        }
+    })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(HarperError::Command(format!(
+            "Screenpipe API error ({}): {}",
+            status, body
+        )));
+    }
+
+    let search_result: ScreenpipeSearchResponse = response
+        .json()
+        .await
+        .map_err(|e| HarperError::Command(format!("Failed to parse screenpipe response: {}", e)))?;
+
+    if search_result.data.is_empty() {
+        return Ok(format!("No results found for query: '{}'", query));
+    }
+
+    let mut output = format!(
+        "Found {} result(s) for '{}':\n\n",
+        search_result.data.len(),
+        query
+    );
+
+    for (i, item) in search_result.data.iter().enumerate() {
+        output.push_str(&format!("--- Result {} ---\n", i + 1));
+
+        if let Some(ref timestamp) = item.timestamp {
+            output.push_str(&format!("Time: {}\n", timestamp));
+        }
+        if let Some(ref app) = item.app_name {
+            output.push_str(&format!("App: {}\n", app));
+        }
+        if let Some(ref window) = item.window_title {
+            output.push_str(&format!("Window: {}\n", window));
+        }
+
+        let empty_string = String::new();
+        let text = item
+            .text
+            .as_ref()
+            .or(item.content.as_ref())
+            .unwrap_or(&empty_string);
+        if !text.is_empty() {
+            let truncated = if text.len() > 500 {
+                format!("{}...", &text[..500])
+            } else {
+                text.clone()
+            };
+            output.push_str(&format!("Content: {}\n", truncated));
+        }
+
+        output.push('\n');
+    }
+
+    if let Some(ref pagination) = search_result.pagination {
+        if let Some(total) = pagination.total {
+            output.push_str(&format!("Total matches: {}\n", total));
+        }
+    }
+
+    Ok(output)
+}


### PR DESCRIPTION
## Summary
- Add screenpipe tool to query screenpipe's REST API directly
- Support searching OCR text and audio transcriptions from screenpipe
- New `[SCREENPIPE query content_type limit]` tool syntax

## Usage
```
[SCREENPIPE meeting notes ocr 5]
```

This queries screenpipe (running on localhost:3030) for matching screen/audio content.

## Testing
- Built successfully with `cargo build --release`