### PR TITLE
fix: tool calls for openai/sambanova

### DIFF
--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -486,7 +486,7 @@ fn handle_tab(app: &mut TuiApp) {
         } else if chat_state.input.starts_with('/') {
             // Command completion
             if chat_state.completion_candidates.is_empty() {
-                let commands = vec!["/help", "/quit", "/clear", "/exit"];
+                let commands = vec!["/help", "/quit", "/clear", "/exit", "/audit"];
                 for cmd in commands {
                     if cmd.starts_with(&chat_state.input) {
                         chat_state.completion_candidates.push(cmd.to_string());


### PR DESCRIPTION
Please note: we will be needing a follow up to fully soothing this...

## Summary

- Fix tool call parsing for OpenAI/Sambanova providers (read from `tool_calls` array instead of just `content`)
- Add tool name parsing for OpenAI array format (`function.name`)
- Add database migration to remove FK constraints from `messages` and `command_logs` tables
- Add `/audit` to command completion

## Details

### Issue
Tool calls (shell commands, file operations, etc.) were not being executed when using OpenAI or Sambanova as the AI provider, while they worked correctly with Gemini.

### Root Cause
1. **llm_client.rs**: The code only read from `message.content`, but OpenAI/Sambanova returns tool calls in `message.tool_calls` (an array)
2. **tools/mod.rs**: The code checked for `"tool"` key or `"name"` key, but OpenAI tool calls come as an array with `function.name`

### API Response Formats

**OpenAI/Sambanova:**
```json
{
  "choices": [{
    "message": {
      "tool_calls": [{
        "function": {
          "name": "run_command",
          "arguments": "{\"command\": \"ls\"}"
        }
      }]
    }
  }]
}
```

**Gemini:**
```json
{
  "candidates": [{
    "content": {
      "parts": [{
        "functionCall": {
          "name": "run_command",
          "args": {"command": "ls"}
        }
      }]
    }
  }]
}
```

Fixes #143