### PR TITLE
ci: add pr size check workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,10 +38,21 @@ A clear and concise description of what you expected to happen.
 ## Actual Behavior
 What actually happened.
 
+## Root Cause
+Explain what is causing the bug. Include code snippets if relevant.
+
+## API Response Format (if applicable)
+If this is an AI provider issue, include the actual API response format:
+```json
+// Expected format
+// Actual format
+```
+
 ## Environment
 - OS: [e.g., macOS, Linux, Windows]
 - Rust Version: [e.g., 1.82.0]
 - Harper Version: [e.g., v0.1.7]
+- AI Provider: [e.g., OpenAI, Sambanova, Gemini]
 
 ## Additional Context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,8 +44,8 @@ Explain what is causing the bug. Include code snippets if relevant.
 ## API Response Format (if applicable)
 If this is an AI provider issue, include the actual API response format:
 ```json
-// Expected format
-// Actual format
+// Paste the expected JSON response below this line
+// Paste the actual JSON response after the expected one
 ```
 
 ## Environment

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,28 @@
+## Summary
+Brief description of changes (1-2 sentences)
+
+## Details
+
+### Issue
+Reference the issue this fixes (e.g., Fixes #123)
+
+### Root Cause
+Explain what was causing the bug.
+
+### Changes Made
+- Change 1 → change type
+- Change 2 → change type
+- Change 3 → change type
+
+### Testing
+- [ ] Tested with OpenAI
+- [ ] Tested with Sambanova
+- [ ] Tested with Gemini
+- [ ] Added unit tests (if applicable)
+
 ## Why (brief):
 - Brief description of changes → change type
 - Another change description → change type
-- Third change if applicable → change type
 
 <!-- Examples:
 - Tools menu options are now implemented and functional → behavior change

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,20 +12,15 @@ Explain what was causing the bug.
 ### Changes Made
 - Change 1 → change type
 - Change 2 → change type
-- Change 3 → change type
+
+<!-- Examples:
+- Tools menu options are now implemented → behavior change
+- Fixed non-functional menu actions → bug fix
+- Updated proc-macro2 dependency → build change
+-->
 
 ### Testing
 - [ ] Tested with OpenAI
 - [ ] Tested with Sambanova
 - [ ] Tested with Gemini
 - [ ] Added unit tests (if applicable)
-
-## Why (brief):
-- Brief description of changes → change type
-- Another change description → change type
-
-<!-- Examples:
-- Tools menu options are now implemented and functional → behavior change
-- Previously non-functional menu actions are fixed → bug fix
-- Updated proc-macro2 dependency → build / dependency change
--->

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -1,0 +1,131 @@
+name: Check PR size
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to check (optional)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'harpertoken'
+    steps:
+      - name: Get PR data for manual trigger
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number
+        id: get_pr
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const { data } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ github.event.inputs.pr_number }}
+            });
+            return JSON.stringify(data);
+
+      - name: Evaluate PR size
+        if: github.event_name == 'pull_request_target' || (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number)
+        uses: actions/github-script@v7
+        env:
+          PR_JSON: ${{ steps.get_pr.outputs.result }}
+        with:
+          script: |
+            const pr = context.payload.pull_request || JSON.parse(process.env.PR_JSON || '{}');
+            if (!pr || !pr.number) {
+              core.setFailed('Unable to resolve PR data. For workflow_dispatch, pass a valid pr_number.');
+              return;
+            }
+
+            // Check for draft PRs and bots
+            const isDraft = !!pr.draft;
+            const login = pr.user.login;
+            const isBot = pr.user.type === 'Bot' || /\[bot\]$/.test(login);
+
+            if (isDraft || isBot) {
+              core.info('Draft or bot PR – skipping size enforcement');
+              return;
+            }
+
+            const totalChanges = pr.additions + pr.deletions;
+            core.info(`PR contains ${pr.additions} additions and ${pr.deletions} deletions (${totalChanges} total)`);
+
+            const sizeLabel =
+              totalChanges < 50   ? 'size/XS' :
+              totalChanges < 150  ? 'size/S'  :
+              totalChanges < 600  ? 'size/M'  :
+              totalChanges < 1000 ? 'size/L'  : 'size/XL';
+
+            // Re-fetch labels to avoid acting on stale payload data
+            const { data: freshIssue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: pr.number
+            });
+            const currentLabels = (freshIssue.labels || []).map(l => l.name);
+
+            // Remove old size labels before adding new one
+            const allSizeLabels = ['size/XS', 'size/S', 'size/M', 'size/L', 'size/XL'];
+            const toRemove = currentLabels.filter(name => allSizeLabels.includes(name) && name !== sizeLabel);
+
+            for (const name of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  name
+                });
+              } catch (_) {
+                // Ignore if already removed
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: pr.number,
+              labels: [sizeLabel]
+            });
+
+            // Check if PR author is a maintainer
+            let authorPerm = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: pr.user.login,
+              });
+              authorPerm = data.permission || 'none';
+            } catch (_) {
+              // User might not have any permissions
+            }
+
+            core.info(`Author permission: ${authorPerm}`);
+            const isMaintainer = ['admin', 'maintain'].includes(authorPerm); // Stricter maintainer definition
+
+            // Check for bypass label (using fresh labels)
+            const hasBypass = currentLabels.includes('bypass:size-limit');
+
+            const MAX_LINES = 1000;
+            if (totalChanges > MAX_LINES) {
+              if (isMaintainer || hasBypass) {
+                core.info(`${isMaintainer ? 'Maintainer' : 'Bypass label'} - allowing large PR with ${totalChanges} lines`);
+              } else {
+                core.setFailed(
+                  `This PR contains ${totalChanges} lines of changes, which exceeds the maximum of ${MAX_LINES} lines. ` +
+                  `Please split this into smaller, focused pull requests.`
+                );
+              }
+            }

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -1,3 +1,4 @@
+# Adapted from: https://github.com/google/langextract
 name: Check PR size
 
 on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
  "bitflags 2.11.0",
  "crc32fast",


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to check PR size and add size labels.

## Details

### Features
- Checks PR size on open, sync, and reopen events
- Adds size labels: `size/XS`, `size/S`, `size/M`, `size/L`, `size/XL`
- Allows maintainers (admin/maintain) to bypass the 1000 line limit
- Supports `bypass:size-limit` label for regular contributors
- Skips draft PRs and bot PRs
- Can be manually triggered with a PR number

### Size Thresholds
- XS: < 50 lines
- S: < 150 lines
- M: < 600 lines
- L: < 1000 lines
- XL: >= 1000 lines (blocked unless bypassed)