### PR TITLE
feat(ci): add deps scope to commitlint

### DIFF
--- a/ci/commitlint.config.js
+++ b/ci/commitlint.config.js
@@ -23,6 +23,7 @@ module.exports = {
         'build',
         'chore',
         'ci',
+        'deps',
         'docs',
         'feat',
         'fix',


### PR DESCRIPTION
## Summary
- Add `deps` type to commitlint configuration to allow dependency-related commits

## Related
Closes #154