### PR TITLE
ci: add dependabot[bot] to signed

### DIFF
--- a/signed.json
+++ b/signed.json
@@ -1,7 +1,7 @@
 {
   "signed": [
     "bniladridas",
-    "harper-release-bot",
-    "dependabot[bot]"
+    "dependabot[bot]",
+    "harper-release-bot"
   ]
 }

--- a/signed.json
+++ b/signed.json
@@ -1,6 +1,7 @@
 {
   "signed": [
     "bniladridas",
-    "harper-release-bot"
+    "harper-release-bot",
+    "dependabot[bot]"
   ]
 }


### PR DESCRIPTION
## Summary
- Add `dependabot[bot]` to signed.json to allow dependabot commits