### PR TITLE
fix: resolve q key conflict in tui chat

### DIFF
--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -147,13 +147,6 @@ pub fn handle_event(
                         ));
                     }
                 }
-                KeyCode::Char('q') => {
-                    if matches!(app.state, AppState::Chat(..)) {
-                        app.state = AppState::Menu(0);
-                    } else {
-                        return EventResult::Quit;
-                    }
-                }
                 KeyCode::Esc => match &app.state {
                     AppState::Menu(_) => {}
                     AppState::Chat(_) => app.state = AppState::Menu(0),


### PR DESCRIPTION
This PR fixes a regression where the 'q' key was being intercepted for quitting even while in Chat mode. It ensures 'q' can be typed normally in chat while still allowing the app to be closed from the menu.