### PR TITLE
feat: add async git status helper

### DIFF
--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -21,7 +21,7 @@ reqwest = { version = "0.12.20", features = ["json", "native-tls"] }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "process"] }
 tower = "0.5"
 uuid = { version = "1.17.0", features = ["v4"] }
 ring = "0.17.14"

--- a/lib/harper-core/src/tools/git.rs
+++ b/lib/harper-core/src/tools/git.rs
@@ -55,6 +55,33 @@ pub fn git_status() -> crate::core::error::HarperResult<String> {
     Ok(result)
 }
 
+/// Get git status asynchronously
+pub async fn git_status_async() -> crate::core::error::HarperResult<String> {
+    let output = tokio::process::Command::new("git")
+        .arg("status")
+        .arg("--porcelain")
+        .output()
+        .await
+        .map_err(|e| HarperError::Command(format!("Failed to run git status: {}", e)))?;
+
+    let result = if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.trim().is_empty() {
+            "Git working directory is clean".to_string()
+        } else {
+            format!(
+                "Git status:
+{}",
+                stdout
+            )
+        }
+    } else {
+        String::from_utf8_lossy(&output.stderr).to_string()
+    };
+
+    Ok(result)
+}
+
 /// Show git diff
 pub fn git_diff() -> crate::core::error::HarperResult<String> {
     let output = std::process::Command::new("git")


### PR DESCRIPTION
## Summary
Add async version of git_status helper using tokio::process::Command.

This is a prerequisite for making the gather_sidebar_entries function async, which will prevent UI blocking during git status operations.