### PR TITLE
[chore] point Bazel workflows to maintained action

### DIFF
--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Bazel
-        uses: bazelbuild/setup-bazel@v4
+        uses: bazel-contrib/setup-bazel@v0.15.0
       - name: Build with Bazel
         run: bazel build :harper_bin --repo_env=CARGO_BAZEL_REPIN=1
       - name: Test Bazel build

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Bazel
-        uses: bazelbuild/setup-bazelisk@v3
+        uses: bazelbuild/setup-bazel@v4
       - name: Build with Bazel
         run: bazel build :harper_bin --repo_env=CARGO_BAZEL_REPIN=1
       - name: Test Bazel build

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Bazel
-        uses: bazel-contrib/setup-bazel@v0.15.0
+        uses: bazel-contrib/setup-bazel@0.15.0
       - name: Build with Bazel
         run: bazel build :harper_bin --repo_env=CARGO_BAZEL_REPIN=1
       - name: Test Bazel build

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -19,7 +19,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Bazel
-        uses: bazel-contrib/setup-bazel@v0.15.0
+        uses: bazel-contrib/setup-bazel@0.15.0
 
       - name: Update Cargo.lock
         run: cargo update

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -19,7 +19,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Bazel
-        uses: bazelbuild/setup-bazelisk@v3
+        uses: bazelbuild/setup-bazel@v4
 
       - name: Update Cargo.lock
         run: cargo update

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -19,7 +19,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Bazel
-        uses: bazelbuild/setup-bazel@v4
+        uses: bazel-contrib/setup-bazel@v0.15.0
 
       - name: Update Cargo.lock
         run: cargo update


### PR DESCRIPTION
## Summary
- replace the archived bazelbuild/setup-bazelisk action with bazel-contrib/setup-bazel@0.15.0 so GitHub can actually fetch the setup action (the old path is 404 and was causing cache-restore warnings)
- keep the rest of the build and lockfile jobs unchanged; only the setup action reference moves to the maintained repo

<details>
<summary>Sandbox note</summary>
This PR was opened from a Codex session where Git couldn’t write inside `.git/refs/heads` because the sandbox kept re-applying the macOS `com.apple.provenance` attribute. Every `git checkout -b ...` or `touch .git/refs/heads/*` failed with “Operation not permitted” even after we cleared the attribute. Switching to a fresh session with elevated commands allowed us to create the branch/push; this is captured here for transparency.
</details>

## Testing
- workflows lint via pre-commit
- push triggered GitHub Actions to resolve the new action
