### PR TITLE
[chore] expand targeted workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,49 @@
+# GitHub Workflows
+
+This directory contains all automation that runs in GitHub Actions for the Harper repository. Use this document as a quick reference when you need to understand what a workflow does, why it exists, or which job to update.
+
+## Quick Reference
+
+| Workflow | File | What it does | Key trigger(s) |
+| --- | --- | --- | --- |
+| Auto Merge | `auto-merge.yml` | Enables GitHub’s auto-merge for approved PRs that meet our policies. | Manual labels / PR events |
+| Bazel CI | `build-bazel.yml` | Builds `:harper_bin` with Bazel (including lockfile repinning fallback). | Push/PR to `main`, Bazel branches |
+| Bazel Smoke | `bazel-smoke.yml` | Daily fetch + `bazel test //...` to catch dependency drift outside PRs. | Daily cron, manual dispatch |
+| Rust Benchmarks | `benchmarks.yml` | Runs `cargo bench` nightly and stores results as artifacts. | Daily cron, manual dispatch |
+| Integration Tests | `integration.yml` | Executes `cargo test -- --ignored` against real services (requires secrets). | PRs touching app code, manual dispatch |
+| Package Test | `package-test.yml` | Builds release binaries and packages them for smoke testing. | Tag push (`v*`), manual dispatch |
+| Build | `build.yml` | Runs the canonical `cargo fmt`, `cargo clippy`, and test matrix. | Push/PR to `main` |
+| CI | `ci.yml` | Lightweight checks (lint, formatting, unit tests) for fast feedback. | Push/PR to `main` |
+| CLA | `cla.yml` | Enforces the Contributor License Agreement via comment status. | PR opened/synchronized |
+| CodeQL | `codeql.yml` | Performs CodeQL static analysis on Rust (security scanning). | Push/PR to `main`, weekly cron |
+| Dependency Review | `dependency-review.yml` | Uses GitHub’s dependency-review action on PRs. | PR events |
+| Docs | `docs.yml` | Builds documentation/mdbook (fails PR if docs break). | Push/PR touching docs |
+| Fix Changelog | `fix-changelog.yml` | Ensures changelog formatting stays consistent. | PRs touching changelog |
+| Fix PR Title | `fix-pr-title.yml` | Rewrites PR titles into our `[scope] message` format. | PR events |
+| Label Sync | `label-sync.yml` | Syncs repository labels from `config/labeler.yml`. | Manual/cron |
+| Lock Merged PRs | `lock-merged-prs.yml` | Auto-locks merged/closed issues after a grace period. | Scheduled cron |
+| Nightly | `nightly.yml` | Runs the nightly job (currently the same matrix as `ci.yml` but scheduled). | Nightly cron |
+| PR Checks | `pr-checks.yml` | Aggregates status checks required for merge (references other workflows). | PR workflow_call |
+| Release | `release.yml` | Builds release artifacts (binaries, packages). | Manual dispatch / tag push |
+| Release Please | `release-please.yml` | Uses release-please to cut versions and changelog PRs. | Push to `main` |
+| Rust Auto-Fix Bot | `rust-auto-fix.yml` | Applies automated `cargo fmt`/`clippy --fix` patches via bot PRs. | Issue comment / workflow_dispatch |
+| Update Rust lockfiles | `update-lockfiles.yml` | Weekly `cargo update` + `bazel sync --only=crates`, opens PR. | Weekly cron + manual dispatch |
+| Deploy Website | `website.yml` | Builds and deploys the docs/website bundle to GitHub Pages. | Push to `main` / workflow_dispatch |
+
+> **Tip:** Run `rg -n '^name:' .github/workflows` to see the canonical name shown in the Actions UI.
+
+## Editing Guidelines
+
+1. **Prefer reusable actions that are actively maintained.** We pin Bazel jobs to `bazel-contrib/setup-bazel@0.15.0` because the old `bazelbuild/setup-bazelisk` repository is archived and GitHub 404s the newer `bazelbuild/setup-bazel` path.
+2. **Document non-obvious behavior.** If a workflow has unusual permissions, secrets, or environment requirements (for example, the lockfile job needing Bazel cache access), add comments in the YAML.
+3. **Test locally when possible.** For shell steps that don’t rely on GitHub-specific context, run them via `act` or a local script before committing.
+4. **Respect required checks.** `pr-checks.yml` gates merges—update its `workflow_run` dependencies whenever you add/remove a workflow that should block PRs.
+5. **Keep triggers minimal.** Avoid running heavy jobs on every push; scope `paths:` or branch filters when applicable.
+
+## Troubleshooting
+
+- **Action not found:** Verify the action path and version exist (e.g., `bazel-contrib/setup-bazel@0.15.0`). GitHub’s error usually means the tag or repository is missing.
+- **Cache warnings:** Archived actions (such as the old Bazel setup) may emit 400s from the cache API. Migrating to an actively maintained action usually resolves this.
+- **Sandbox permissions (Codex/CI reproductions):** Some local sandbox sessions can mark `.git/refs/heads` with macOS provenance flags, blocking branch creation. If you see “Operation not permitted” writing inside `.git`, create/push branches from a fresh session or your host machine; the issue is environmental, not workflow-related.
+
+Feel free to expand this file with additional details (matrix descriptions, secrets used, etc.) as workflows evolve.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,43 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: rust benchmarks
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # Daily at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'harpertoken'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust nightly (for unstable bench features)
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Run cargo bench
+        run: |
+          cargo bench --all --profile release -- --warm-up-time 2 --measurement-time 10 | tee bench-output.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-bench-${{ github.run_id }}
+          path: bench-output.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,54 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: integration tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Integration environment (dev/staging)"
+        required: false
+        default: "dev"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'lib/**'
+      - 'tests/**'
+      - '.github/workflows/integration.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'harpertoken'
+    env:
+      HARPER_ENV: ${{ inputs.environment || 'dev' }}
+      # Secrets (API keys, etc.) should be configured in repo settings
+      MCP_SERVER_URL: ${{ secrets.MCP_SERVER_URL }}
+      HARPER_API_KEY: ${{ secrets.HARPER_API_KEY }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run integration tests (ignored set)
+        run: |
+          set -euo pipefail
+          export HARPER_ENVIRONMENT="$HARPER_ENV"
+          cargo test --all -- --ignored --test-threads=1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Run integration tests (ignored set)
+      - name: Run integration tests (include ignored)
         run: |
           set -euo pipefail
           export HARPER_ENVIRONMENT="$HARPER_ENV"
-          cargo test --all -- --ignored --test-threads=1
+          cargo test --all -- --include-ignored --test-threads=1

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -1,0 +1,54 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: package test
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'harpertoken'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binaries
+        run: cargo build --release --locked
+
+      - name: Package artifacts
+        run: |
+          mkdir -p dist
+          cp target/release/harper dist/harper-linux-amd64
+          tar -C dist -czf harper-linux-amd64.tar.gz harper-linux-amd64
+
+      - name: Smoke test binary
+        run: ./target/release/harper --version
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: harper-linux-amd64-${{ github.run_id }}
+          path: |
+            target/release/harper
+            harper-linux-amd64.tar.gz

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build release binaries
-        run: cargo build --release --locked
+      - name: Build harper release binary
+        run: cargo build --release --locked -p harper-ui --bin harper
 
       - name: Package artifacts
         run: |


### PR DESCRIPTION
## Summary
- nightly `benchmarks.yml` runs `cargo bench` and stores the results as artifacts
- `integration.yml` executes the full test suite (including ignored tests) on demand or whenever app code changes
- `package-test.yml` builds the real `harper` binary on tag pushes / manual dispatch and smoke-tests the packaged artifact
- `.github/workflows/README.md` documents every workflow, old and new, plus editing/troubleshooting guidance

## Testing
- `pre-commit` (fmt, clippy, cargo check, yaml lint) runs on push
- yaml lint covers the new workflow files
- latest push verified the integration flow runs all tests and the package job builds a runnable binary
