### PR TITLE
[chore] ensure workflow edits trigger build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches: [main, develop]
     paths:
+      - '.github/workflows/**'
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'


### PR DESCRIPTION
## Summary
- ensure the build workflow runs whenever `.github/workflows/**` changes land on `main`/`develop` by adding the workflows directory to its `push.paths`
- that way, merges that only touch workflow files still execute the build job on the default branches

## Testing
- pre-commit (fmt, clippy, cargo check, yaml lint) runs on push
- verified new `push.paths` entry locally; future merges editing workflows will automatically exercise the build workflow
