### PR TITLE
[ci] rerun tests after auto-merge

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,6 +12,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | Rust Benchmarks | `benchmarks.yml` | Runs `cargo bench` nightly and stores results as artifacts. | Daily cron, manual dispatch |
 | Integration Tests | `integration.yml` | Executes `cargo test -- --ignored` against real services (requires secrets). | PRs touching app code, manual dispatch |
 | Package Test | `package-test.yml` | Builds release binaries and packages them for smoke testing. | Tag push (`v*`), manual dispatch |
+| Post Auto Merge CI | `post-auto-merge-ci.yml` | Re-runs fmt/clippy/tests on `main` after Auto Merge completes to spot issues reusing PR commits. | Completion of Auto Merge workflow |
 | Build | `build.yml` | Runs the canonical `cargo fmt`, `cargo clippy`, and test matrix. | Push/PR to `main` |
 | CI | `ci.yml` | Lightweight checks (lint, formatting, unit tests) for fast feedback. | Push/PR to `main` |
 | CLA | `cla.yml` | Enforces the Contributor License Agreement via comment status. | PR opened/synchronized |

--- a/.github/workflows/post-auto-merge-ci.yml
+++ b/.github/workflows/post-auto-merge-ci.yml
@@ -1,0 +1,81 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: post auto-merge ci
+
+on:
+  workflow_run:
+    workflows: ["Auto Merge"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  post-merge-ci:
+    if: github.repository_owner == 'harpertoken' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine merged PR and commit
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prs = context.payload.workflow_run.pull_requests || [];
+            if (prs.length === 0) {
+              core.notice('No pull request associated with this workflow run; skipping.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+            const prNumber = prs[0].number;
+            core.info(`Associated PR #${prNumber}`);
+            for (let i = 0; i < 20; i++) {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              if (data.merged) {
+                core.info(`PR #${prNumber} merged as ${data.merge_commit_sha}`);
+                core.setOutput('skip', 'false');
+                core.setOutput('merge_sha', data.merge_commit_sha);
+                return;
+              }
+              core.info('PR not merged yet. Waiting 15s...');
+              await new Promise((resolve) => setTimeout(resolve, 15000));
+            }
+            core.setFailed(`PR #${prNumber} was not merged within the wait window.`);
+      - name: Checkout merged commit
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.merge_sha || 'main' }}
+
+      - name: Install Rust
+        if: steps.pr.outputs.skip != 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Post-merge cargo fmt
+        if: steps.pr.outputs.skip != 'true'
+        run: cargo fmt --all -- --check
+
+      - name: Post-merge cargo clippy
+        if: steps.pr.outputs.skip != 'true'
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Post-merge cargo test
+        if: steps.pr.outputs.skip != 'true'
+        run: cargo test --all --all-features


### PR DESCRIPTION
We now have a follow-up check that re-runs fmt/clippy/tests after GitHub’s Auto Merge workflow finishes. The new `post-auto-merge-ci.yml` listens for the Auto Merge workflow run to complete, waits until the PR is actually merged, checks out the merge commit (or `main` as a fallback), and runs the usual `cargo fmt --check`, `cargo clippy`, and `cargo test`. This ensures we still see a fresh CI signal on `main` even though Auto Merge reuses the PR head commit. The workflow is documented in `.github/workflows/README.md` alongside the rest of our automation, and pre-commit (fmt/clippy/check/yaml) covered the changes locally.
