### PR TITLE
[ci] fix post-merge pr lookup

### DIFF
--- a/.github/workflows/post-auto-merge-ci.yml
+++ b/.github/workflows/post-auto-merge-ci.yml
@@ -34,13 +34,31 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prs = context.payload.workflow_run.pull_requests || [];
-            if (prs.length === 0) {
-              core.notice('No pull request associated with this workflow run; skipping.');
-              core.setOutput('skip', 'true');
-              return;
+            const run = context.payload.workflow_run;
+            let prNumber = undefined;
+            const prs = run.pull_requests || [];
+            if (prs.length > 0) {
+              prNumber = prs[0].number;
+            } else {
+              core.info('No pull_request payload info; attempting to locate PR via commit SHA.');
+              const headSha = run.head_sha;
+              if (!headSha) {
+                core.notice('Workflow run has no head SHA. Skipping.');
+                core.setOutput('skip', 'true');
+                return;
+              }
+              const commitPRs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+              if (commitPRs.data.length === 0) {
+                core.notice('No PR found for commit. Skipping.');
+                core.setOutput('skip', 'true');
+                return;
+              }
+              prNumber = commitPRs.data[0].number;
             }
-            const prNumber = prs[0].number;
             core.info(`Associated PR #${prNumber}`);
             for (let i = 0; i < 20; i++) {
               const { data } = await github.rest.pulls.get({


### PR DESCRIPTION
The post-auto-merge workflow sometimes triggers without `workflow_run.pull_requests` populated (GitHub omits it for `pull_request_target`). This change falls back to locating the PR via the Auto Merge run's head SHA (`listPullRequestsAssociatedWithCommit`) so we can fetch the merge commit and rerun fmt/clippy/tests. Pre-commit (fmt/clippy/check/yaml) covered the change.
