### PR TITLE
[ci] ensure lock workflow triggers on auto-merge

### DIFF
--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -3,6 +3,8 @@ name: Lock Merged PRs
 on:
   pull_request:
     types: [closed]
+  pull_request_target:
+    types: [closed]
 
 jobs:
   lock:


### PR DESCRIPTION
## Summary
- add  (closed) to the lock workflow so PRs closed via Auto Merge still run the lock job

## Testing
- pre-commit (fmt/clippy/check/yaml) on push