### PR TITLE
[ci] introduce cli integration smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +526,17 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.1",
  "piper",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1057,6 +1083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,11 +1786,13 @@ dependencies = [
 name = "harper-workspace"
 version = "0.7.0"
 dependencies = [
+ "assert_cmd",
  "criterion",
  "harper-core",
  "harper-ui",
  "lazy_static",
  "num_cpus",
+ "predicates",
  "rand 0.9.2",
  "ratatui",
  "regex",
@@ -2692,6 +2735,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3275,6 +3324,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -4371,6 +4450,12 @@ checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "termwiz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ harper-core = { path = "lib/harper-core" }
 harper-ui = { path = "lib/harper-ui" }
 
 [dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"
 tempfile = "3.3.0"
 lazy_static = "1.4"
 regex = "1.10"

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "f38364e2635da1e8c175f34eef1284b46ab6270415a7ce979f8902ec195b94fd",
+  "checksum": "fdc006a53f222c0de9af77c5aaf09398cd55ca092111f2751b5aba0377a87111",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -883,6 +883,108 @@
         },
         "edition": "2015",
         "version": "0.2.1"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "assert_cmd 2.2.0": {
+      "name": "assert_cmd",
+      "version": "2.2.0",
+      "package_url": "https://github.com/assert-rs/assert_cmd.git",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/assert_cmd/2.2.0/download",
+          "sha256": "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "assert_cmd",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "assert_cmd",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "anstyle 1.0.14",
+              "target": "anstyle"
+            },
+            {
+              "id": "assert_cmd 2.2.0",
+              "target": "build_script_build"
+            },
+            {
+              "id": "bstr 1.12.1",
+              "target": "bstr"
+            },
+            {
+              "id": "predicates 3.1.4",
+              "target": "predicates"
+            },
+            {
+              "id": "predicates-core 1.0.10",
+              "target": "predicates_core"
+            },
+            {
+              "id": "predicates-tree 1.0.13",
+              "target": "predicates_tree"
+            },
+            {
+              "id": "wait-timeout 0.2.1",
+              "target": "wait_timeout"
+            }
+          ],
+          "selects": {
+            "cfg(any())": [
+              {
+                "id": "libc 0.2.183",
+                "target": "libc"
+              }
+            ]
+          }
+        },
+        "edition": "2024",
+        "version": "2.2.0"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ]
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -3022,6 +3124,67 @@
         "version": "1.6.2"
       },
       "license": "Apache-2.0 OR MIT",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "bstr 1.12.1": {
+      "name": "bstr",
+      "version": "1.12.1",
+      "package_url": "https://github.com/BurntSushi/bstr",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/bstr/1.12.1/download",
+          "sha256": "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "bstr",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "bstr",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "default",
+            "std",
+            "unicode"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "memchr 2.8.0",
+              "target": "memchr"
+            },
+            {
+              "id": "regex-automata 0.4.14",
+              "target": "regex_automata"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.12.1"
+      },
+      "license": "MIT OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -6417,6 +6580,44 @@
       ],
       "license_file": "LICENSE"
     },
+    "difflib 0.4.0": {
+      "name": "difflib",
+      "version": "0.4.0",
+      "package_url": "https://github.com/DimaKudosh/difflib",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/difflib/0.4.0/download",
+          "sha256": "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "difflib",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "difflib",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.4.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": null
+    },
     "digest 0.10.7": {
       "name": "digest",
       "version": "0.10.7",
@@ -8522,6 +8723,61 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "float-cmp 0.10.0": {
+      "name": "float-cmp",
+      "version": "0.10.0",
+      "package_url": "https://github.com/mikedilger/float-cmp",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/float-cmp/0.10.0/download",
+          "sha256": "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "float_cmp",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "float_cmp",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default",
+            "num-traits",
+            "ratio"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "num-traits 0.2.19",
+              "target": "num_traits"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.10.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
     "fnv 1.0.7": {
       "name": "fnv",
       "version": "1.0.7",
@@ -10602,6 +10858,10 @@
         "deps_dev": {
           "common": [
             {
+              "id": "assert_cmd 2.2.0",
+              "target": "assert_cmd"
+            },
+            {
               "id": "criterion 0.5.1",
               "target": "criterion"
             },
@@ -10612,6 +10872,10 @@
             {
               "id": "num_cpus 1.17.0",
               "target": "num_cpus"
+            },
+            {
+              "id": "predicates 3.1.4",
+              "target": "predicates"
             },
             {
               "id": "rand 0.9.2",
@@ -16773,6 +17037,44 @@
       ],
       "license_file": "LICENSE"
     },
+    "normalize-line-endings 0.3.0": {
+      "name": "normalize-line-endings",
+      "version": "0.3.0",
+      "package_url": "https://github.com/derekdreery/normalize-line-endings",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/normalize-line-endings/0.3.0/download",
+          "sha256": "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "normalize_line_endings",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "normalize_line_endings",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2015",
+        "version": "0.3.0"
+      },
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
+      "license_file": "LICENSE"
+    },
     "num 0.4.3": {
       "name": "num",
       "version": "0.4.3",
@@ -20427,6 +20729,176 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "predicates 3.1.4": {
+      "name": "predicates",
+      "version": "3.1.4",
+      "package_url": "https://github.com/assert-rs/predicates-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/predicates/3.1.4/download",
+          "sha256": "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "predicates",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "predicates",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "color",
+            "default",
+            "diff",
+            "float-cmp",
+            "normalize-line-endings",
+            "regex"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "anstyle 1.0.14",
+              "target": "anstyle"
+            },
+            {
+              "id": "difflib 0.4.0",
+              "target": "difflib"
+            },
+            {
+              "id": "float-cmp 0.10.0",
+              "target": "float_cmp"
+            },
+            {
+              "id": "normalize-line-endings 0.3.0",
+              "target": "normalize_line_endings"
+            },
+            {
+              "id": "predicates-core 1.0.10",
+              "target": "predicates_core"
+            },
+            {
+              "id": "regex 1.12.3",
+              "target": "regex"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "3.1.4"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "predicates-core 1.0.10": {
+      "name": "predicates-core",
+      "version": "1.0.10",
+      "package_url": "https://github.com/assert-rs/predicates-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/predicates-core/1.0.10/download",
+          "sha256": "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "predicates_core",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "predicates_core",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "1.0.10"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "predicates-tree 1.0.13": {
+      "name": "predicates-tree",
+      "version": "1.0.13",
+      "package_url": "https://github.com/assert-rs/predicates-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/predicates-tree/1.0.13/download",
+          "sha256": "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "predicates_tree",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "predicates_tree",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "predicates-core 1.0.10",
+              "target": "predicates_core"
+            },
+            {
+              "id": "termtree 0.5.1",
+              "target": "termtree"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.0.13"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "prettyplease 0.2.37": {
       "name": "prettyplease",
       "version": "0.2.37",
@@ -22782,6 +23254,7 @@
           "common": [
             "alloc",
             "dfa-onepass",
+            "dfa-search",
             "hybrid",
             "meta",
             "nfa-backtrack",
@@ -27583,6 +28056,44 @@
         "MIT"
       ],
       "license_file": "LICENSE"
+    },
+    "termtree 0.5.1": {
+      "name": "termtree",
+      "version": "0.5.1",
+      "package_url": "https://github.com/rust-cli/termtree",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/termtree/0.5.1/download",
+          "sha256": "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "termtree",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "termtree",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2021",
+        "version": "0.5.1"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE-MIT"
     },
     "termwiz 0.23.3": {
       "name": "termwiz",
@@ -38113,9 +38624,11 @@
     "windows-targets 0.53.5"
   ],
   "direct_dev_deps": [
+    "assert_cmd 2.2.0",
     "criterion 0.5.1",
     "lazy_static 1.5.0",
     "num_cpus 1.17.0",
+    "predicates 3.1.4",
     "rand 0.9.2",
     "regex 1.12.3",
     "tempfile 3.27.0",

--- a/tests/integration_cli_test.rs
+++ b/tests/integration_cli_test.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 harpertoken
+// Licensed under the Apache License, Version 2.0
+// See top-level LICENSE files for details.
+
+use assert_cmd::Command;
+use harper_core::core::constants;
+
+#[test]
+fn harper_cli_reports_exact_version() -> Result<(), Box<dyn std::error::Error>> {
+    let expected = format!("harper v{}", constants::VERSION);
+
+    let assert = Command::cargo_bin("harper")?
+        .arg("--version")
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+    assert_eq!(
+        stdout.trim(),
+        expected,
+        "CLI returned unexpected version string"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Introduces a simple CLI integration smoke test using `assert_cmd` and `predicates`. The ignored test `tests/integration_cli_test.rs` launches `harper --version` via `cargo_bin`, giving the integration workflow a meaningful scenario when we run `cargo test --test integration_cli_test -- --ignored`. Pre-commit (fmt/clippy/check/yaml) and the new integration test were executed locally.
