### PR TITLE
[feat] auto-merge-now label for immediate merge without waiting for checks

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,17 +8,35 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Waits for all required checks to pass before merging
   auto-merge:
     runs-on: ubuntu-latest
     if: >
       contains(github.event.pull_request.labels.*.name, 'auto-merge') &&
+      !contains(github.event.pull_request.labels.*.name, 'auto-merge-now') &&
       github.event.pull_request.draft == false &&
       github.repository_owner == 'harpertoken'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Enable auto-merge
+      - name: Enable auto-merge (wait for checks)
         run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Merges immediately without waiting for checks
+  auto-merge-now:
+    runs-on: ubuntu-latest
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'auto-merge-now') &&
+      github.event.pull_request.draft == false &&
+      github.repository_owner == 'harpertoken'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Merge immediately
+        run: gh pr merge --squash --admin "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/normalize-pr-description.yml
+++ b/.github/workflows/normalize-pr-description.yml
@@ -59,12 +59,19 @@ jobs:
               .map(l => l.replace(/^[-*]\s*/, '').replace(/^#+\s*/, '').trim())
               .filter(Boolean);
 
-            // Wrap technical tokens (filenames, CLI flags, workflow names, paths) in backticks
-            // if not already wrapped
+            // Wrap technical tokens in backticks if not already wrapped:
+            // filenames with extensions, --flags, and tokens inside parens like (fmt/clippy/...)
             function wrapTech(text) {
-              return text.replace(/(?<!`)(\b[\w.-]+\.(yml|rs|toml|md|json|sh|ts|js|py)\b|--[\w-]+|`[^`]+`)/g, (m) => {
-                return m.startsWith('`') ? m : '`' + m + '`';
+              // Wrap filenames with known extensions
+              text = text.replace(/(?<!`)(\b[\w.-]+\.(yml|rs|toml|md|json|sh|ts|js|py)\b)/g, '`$1`');
+              // Wrap --flags
+              text = text.replace(/(?<!`)(\-\-[\w-]+)/g, '`$1`');
+              // Wrap slash-separated tokens inside parens e.g. (fmt/clippy/check/yaml)
+              text = text.replace(/\(([^)]+\/[^)]+)\)/g, (_, inner) => {
+                const wrapped = inner.split('/').map(t => t.trim()).map(t => t.startsWith('`') ? t : '`' + t + '`').join('/');
+                return '(' + wrapped + ')';
               });
+              return text;
             }
 
             const summarySentence = bullets


### PR DESCRIPTION
splits the auto-merge workflow into two jobs: auto-merge waits for checks, auto-merge-now merges immediately. adds auto-merge-now label with red color. pre-commit (fmt/clippy/check/yaml) covered the changes.
