### PR TITLE
[fix] improve ci reliability, workflow hygiene, and auto-merge controls

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,55 @@
+{
+  "name": "Main Branch Protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "CI (ubuntu-latest)"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -30,6 +30,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | Release | `release.yml` | Builds release artifacts (binaries, packages). | Manual dispatch / tag push |
 | Release Please | `release-please.yml` | Uses release-please to cut versions and changelog PRs. | Push to `main` |
 | Rust Auto-Fix Bot | `rust-auto-fix.yml` | Applies automated `cargo fmt`/`clippy --fix` patches via bot PRs. | Issue comment / workflow_dispatch |
+| Cancel Runs Bot | `cancel-runs.yml` | Cancels in-progress and queued GitHub Actions runs when `/cancel-runs` is commented on PRs, then posts completion details with collapsible sections. | Issue comment on PRs |
 | Update Rust lockfiles | `update-lockfiles.yml` | Weekly `cargo update` + `bazel sync --only=crates`, opens PR. | Weekly cron + manual dispatch |
 | Deploy Website | `website.yml` | Builds and deploys the docs/website bundle to GitHub Pages. | Push to `main` / workflow_dispatch |
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,14 +9,14 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | Apply Rulesets | `apply-rulesets.yml` | Applies branch ruleset definitions from `.github/rulesets/*.json` to GitHub. Edit `main-branch-protection.json` to change rules; the workflow syncs them on push. | Push to `main` touching rulesets, manual dispatch |
 | Auto Merge | `auto-merge.yml` | Three jobs: `auto-merge` enables GitHub's built-in auto-merge (waits for `CI (ubuntu-latest)` + 1 review); `auto-merge-now` merges immediately via `BYPASS_TOKEN` bypassing ruleset checks; `cancel-auto-merge` disables queued auto-merge when the `auto-merge` label is removed. | `labeled`/`unlabeled`/PR events |
 | Bazel CI | `build-bazel.yml` | Builds `:harper_bin` with Bazel (including lockfile repinning fallback). | Push/PR to `main`, Bazel branches |
-| Bazel Smoke | `bazel-smoke.yml` | Daily fetch + `bazel test //...` to catch dependency drift outside PRs. | Daily cron, manual dispatch |
+| Bazel Smoke | `bazel-smoke.yml` | Daily `bazel test //...` to catch dependency drift outside PRs. | Daily cron, manual dispatch |
 | Rust Benchmarks | `benchmarks.yml` | Runs `cargo bench` nightly and stores results as artifacts. | Daily cron, manual dispatch |
 | Integration Tests | `integration.yml` | Executes `cargo test -- --ignored` against real services (requires secrets). | PRs touching app code, manual dispatch |
 | Package Test | `package-test.yml` | Builds release binaries and packages them for smoke testing. | Tag push (`v*`), manual dispatch |
 | Post Auto Merge CI | `post-auto-merge-ci.yml` | Re-runs fmt/clippy/tests on `main` after Auto Merge completes; also locks the merged PR via `gh pr lock`. | Completion of Auto Merge workflow |
 | Normalize PR Description | `normalize-pr-description.yml` | Rewrites `## Summary`/`## Testing` bullet-style PR bodies into a single paragraph with backtick-wrapped technical terms. Skips forks and dependabot. | PR opened/edited/ready_for_review |
 | Build | `build.yml` | Runs the canonical `cargo fmt`, `cargo clippy`, and test matrix. | Push/PR to `main` |
-| CI | `ci.yml` | Lightweight checks (lint, formatting, unit tests) for fast feedback. | Push/PR to `main` |
+| CI | `ci.yml` | Lint, formatting, unit tests, and integration tests (builds binary first). | Push/PR to `main` |
 | CLA | `cla.yml` | Enforces the Contributor License Agreement via comment status. | PR opened/synchronized |
 | CodeQL | `codeql.yml` | Performs CodeQL static analysis on Rust (security scanning). | Push/PR to `main`, weekly cron |
 | Dependency Review | `dependency-review.yml` | Uses GitHub's dependency-review action on PRs. | PR events |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -35,6 +35,8 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 
 > **Tip:** Run `rg -n '^name:' .github/workflows` to see the canonical name shown in the Actions UI.
 
+> **Naming convention:** Workflow `name:` fields describe *what* the workflow does (`CI`, `Build`, `Rust Benchmarks`). Platform/architecture granularity (`ubuntu-latest`, `macos-latest`, `windows-latest`, `aarch64`, `x86_64`) belongs in job or matrix names inside the workflow — e.g. `CI (ubuntu-latest)` — not in the top-level workflow name.
+
 ## Labels
 
 | Label | Color | Purpose |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,23 +6,25 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 
 | Workflow | File | What it does | Key trigger(s) |
 | --- | --- | --- | --- |
-| Auto Merge | `auto-merge.yml` | Enables GitHub’s auto-merge for approved PRs that meet our policies. | Manual labels / PR events |
+| Apply Rulesets | `apply-rulesets.yml` | Applies branch ruleset definitions from `.github/rulesets/*.json` to GitHub. Edit `main-branch-protection.json` to change rules; the workflow syncs them on push. | Push to `main` touching rulesets, manual dispatch |
+| Auto Merge | `auto-merge.yml` | Three jobs: `auto-merge` enables GitHub's built-in auto-merge (waits for `CI (ubuntu-latest)` + 1 review); `auto-merge-now` merges immediately via `BYPASS_TOKEN` bypassing ruleset checks; `cancel-auto-merge` disables queued auto-merge when the `auto-merge` label is removed. | `labeled`/`unlabeled`/PR events |
 | Bazel CI | `build-bazel.yml` | Builds `:harper_bin` with Bazel (including lockfile repinning fallback). | Push/PR to `main`, Bazel branches |
 | Bazel Smoke | `bazel-smoke.yml` | Daily fetch + `bazel test //...` to catch dependency drift outside PRs. | Daily cron, manual dispatch |
 | Rust Benchmarks | `benchmarks.yml` | Runs `cargo bench` nightly and stores results as artifacts. | Daily cron, manual dispatch |
 | Integration Tests | `integration.yml` | Executes `cargo test -- --ignored` against real services (requires secrets). | PRs touching app code, manual dispatch |
 | Package Test | `package-test.yml` | Builds release binaries and packages them for smoke testing. | Tag push (`v*`), manual dispatch |
-| Post Auto Merge CI | `post-auto-merge-ci.yml` | Re-runs fmt/clippy/tests on `main` after Auto Merge completes to spot issues reusing PR commits. | Completion of Auto Merge workflow |
+| Post Auto Merge CI | `post-auto-merge-ci.yml` | Re-runs fmt/clippy/tests on `main` after Auto Merge completes; also locks the merged PR via `gh pr lock`. | Completion of Auto Merge workflow |
+| Normalize PR Description | `normalize-pr-description.yml` | Rewrites `## Summary`/`## Testing` bullet-style PR bodies into a single paragraph with backtick-wrapped technical terms. Skips forks and dependabot. | PR opened/edited/ready_for_review |
 | Build | `build.yml` | Runs the canonical `cargo fmt`, `cargo clippy`, and test matrix. | Push/PR to `main` |
 | CI | `ci.yml` | Lightweight checks (lint, formatting, unit tests) for fast feedback. | Push/PR to `main` |
 | CLA | `cla.yml` | Enforces the Contributor License Agreement via comment status. | PR opened/synchronized |
 | CodeQL | `codeql.yml` | Performs CodeQL static analysis on Rust (security scanning). | Push/PR to `main`, weekly cron |
-| Dependency Review | `dependency-review.yml` | Uses GitHub’s dependency-review action on PRs. | PR events |
+| Dependency Review | `dependency-review.yml` | Uses GitHub's dependency-review action on PRs. | PR events |
 | Docs | `docs.yml` | Builds documentation/mdbook (fails PR if docs break). | Push/PR touching docs |
 | Fix Changelog | `fix-changelog.yml` | Ensures changelog formatting stays consistent. | PRs touching changelog |
-| Fix PR Title | `fix-pr-title.yml` | Rewrites PR titles into our `[scope] message` format. | PR events |
+| Fix PR Title | `fix-pr-title.yml` | Rewrites PR titles into `[scope] message` format and lowercases the description part. | PR events |
 | Label Sync | `label-sync.yml` | Syncs repository labels from `config/labeler.yml`. | Manual/cron |
-| Lock Merged PRs | `lock-merged-prs.yml` | Auto-locks merged/closed issues after a grace period. | Scheduled cron |
+| Lock Merged PRs | `lock-merged-prs.yml` | Locks PRs after manual merge. Auto Merge path is handled by `post-auto-merge-ci.yml`. | PR closed |
 | Nightly | `nightly.yml` | Runs the nightly job (currently the same matrix as `ci.yml` but scheduled). | Nightly cron |
 | PR Checks | `pr-checks.yml` | Aggregates status checks required for merge (references other workflows). | PR workflow_call |
 | Release | `release.yml` | Builds release artifacts (binaries, packages). | Manual dispatch / tag push |
@@ -33,18 +35,37 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 
 > **Tip:** Run `rg -n '^name:' .github/workflows` to see the canonical name shown in the Actions UI.
 
+## Labels
+
+| Label | Color | Purpose |
+| --- | --- | --- |
+| `auto-merge` | green | Enables GitHub's built-in auto-merge; waits for `CI (ubuntu-latest)` and 1 approving review before squash-merging. Remove the label to cancel a queued merge. |
+| `auto-merge-now` | red | Merges immediately via `BYPASS_TOKEN`, bypassing ruleset status-check and review requirements. Use with caution. |
+
+## Branch Ruleset
+
+The `main` branch is protected by the **Main Branch Protection** ruleset (ID `11608827`). Its definition lives in `.github/rulesets/main-branch-protection.json` and is applied automatically by `apply-rulesets.yml` on every push that touches it. To change a rule, edit the JSON and merge to `main`.
+
+Current rules:
+- No deletion or force-push to `main`
+- Squash or rebase merge only
+- 1 approving review required
+- `CI (ubuntu-latest)` must pass
+- Bypass: OrganizationAdmin (always)
+
 ## Editing Guidelines
 
 1. **Prefer reusable actions that are actively maintained.** We pin Bazel jobs to `bazel-contrib/setup-bazel@0.15.0` because the old `bazelbuild/setup-bazelisk` repository is archived and GitHub 404s the newer `bazelbuild/setup-bazel` path.
 2. **Document non-obvious behavior.** If a workflow has unusual permissions, secrets, or environment requirements (for example, the lockfile job needing Bazel cache access), add comments in the YAML.
-3. **Test locally when possible.** For shell steps that don’t rely on GitHub-specific context, run them via `act` or a local script before committing.
+3. **Test locally when possible.** For shell steps that don't rely on GitHub-specific context, run them via `act` or a local script before committing.
 4. **Respect required checks.** `pr-checks.yml` gates merges—update its `workflow_run` dependencies whenever you add/remove a workflow that should block PRs.
 5. **Keep triggers minimal.** Avoid running heavy jobs on every push; scope `paths:` or branch filters when applicable.
 
 ## Troubleshooting
 
-- **Action not found:** Verify the action path and version exist (e.g., `bazel-contrib/setup-bazel@0.15.0`). GitHub’s error usually means the tag or repository is missing.
+- **Action not found:** Verify the action path and version exist (e.g., `bazel-contrib/setup-bazel@0.15.0`). GitHub's error usually means the tag or repository is missing.
 - **Cache warnings:** Archived actions (such as the old Bazel setup) may emit 400s from the cache API. Migrating to an actively maintained action usually resolves this.
-- **Sandbox permissions (Codex/CI reproductions):** Some local sandbox sessions can mark `.git/refs/heads` with macOS provenance flags, blocking branch creation. If you see “Operation not permitted” writing inside `.git`, create/push branches from a fresh session or your host machine; the issue is environmental, not workflow-related.
+- **`auto-merge-now` fails with ruleset violation:** Ensure `BYPASS_TOKEN` secret is set to a PAT from an org admin account with `repo` scope. The `GITHUB_TOKEN` cannot bypass rulesets.
+- **Sandbox permissions (Codex/CI reproductions):** Some local sandbox sessions can mark `.git/refs/heads` with macOS provenance flags, blocking branch creation. If you see "Operation not permitted" writing inside `.git`, create/push branches from a fresh session or your host machine; the issue is environmental, not workflow-related.
 
 Feel free to expand this file with additional details (matrix descriptions, secrets used, etc.) as workflows evolve.

--- a/.github/workflows/apply-rulesets.yml
+++ b/.github/workflows/apply-rulesets.yml
@@ -1,0 +1,42 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Apply Rulesets
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/rulesets/*.json
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'harpertoken'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Apply main-branch-protection ruleset
+        run: |
+          RULESET_ID=11608827
+          gh api repos/${{ github.repository }}/rulesets/$RULESET_ID \
+            --method PUT \
+            --header "Accept: application/vnd.github+json" \
+            --input .github/rulesets/main-branch-protection.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.BYPASS_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -55,4 +55,4 @@ jobs:
         run: gh pr merge --squash --admin "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BYPASS_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -25,7 +25,23 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Merges immediately without waiting for checks
+  # Cancels auto-merge when the auto-merge label is removed
+  cancel-auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.action == 'unlabeled' &&
+      github.event.label.name == 'auto-merge' &&
+      github.event.pull_request.draft == false &&
+      github.repository_owner == 'harpertoken'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Disable auto-merge
+        run: gh pr merge --disable-auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   auto-merge-now:
     runs-on: ubuntu-latest
     if: >

--- a/.github/workflows/bazel-smoke.yml
+++ b/.github/workflows/bazel-smoke.yml
@@ -1,0 +1,39 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bazel Smoke
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'harpertoken'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@0.15.0
+
+      - name: Fetch external dependencies
+        run: bazel fetch //...
+
+      - name: Bazel test smoke suite
+        run: bazel test //... --build_tests_only --repo_env=CARGO_BAZEL_REPIN=1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: rust benchmarks
+name: Rust Benchmarks
 
 on:
   schedule:

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -16,7 +16,7 @@ name: Bazel CI
 
 on:
   push:
-    branches: [ main, add-bazel-support ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -16,7 +16,7 @@ name: Bazel CI
 
 on:
   push:
-    branches: [ main, add-bazel-support, "fix/**" ]
+    branches: [ main, add-bazel-support ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: bazel ci
+name: Bazel CI
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: build
+name: Build
 
 on:
   push:

--- a/.github/workflows/cancel-runs.yml
+++ b/.github/workflows/cancel-runs.yml
@@ -1,0 +1,77 @@
+name: Cancel Runs Bot
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  cancel-runs:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/cancel-runs') && github.repository_owner == 'harpertoken'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: write
+    steps:
+    - name: Cancel in-progress runs
+      id: cancel-in-progress
+      run: |
+        # Get in-progress run IDs
+        in_progress_ids=$(gh run list --status in_progress --json databaseId --jq '.[].databaseId' || echo "")
+        if [ -n "$in_progress_ids" ]; then
+          echo "Canceling in-progress runs: $in_progress_ids"
+          echo "$in_progress_ids" | xargs -I{} gh run cancel {}
+          echo "canceled_runs=$in_progress_ids" >> $GITHUB_OUTPUT
+        else
+          echo "No in-progress runs found"
+          echo "canceled_runs=" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cancel queued runs
+      id: cancel-queued
+      run: |
+        # Get queued run IDs
+        queued_ids=$(gh run list --status queued --json databaseId --jq '.[].databaseId' || echo "")
+        if [ -n "$queued_ids" ]; then
+          echo "Canceling queued runs: $queued_ids"
+          echo "$queued_ids" | xargs -I{} gh run cancel {} 2>/dev/null || true
+          echo "canceled_runs=$queued_ids" >> $GITHUB_OUTPUT
+        else
+          echo "No queued runs found"
+          echo "canceled_runs=" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Post completion comment
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const inProgressRuns = process.env.IN_PROGRESS_RUNS || '';
+          const queuedRuns = process.env.QUEUED_RUNS || '';
+
+          let whatItDid = '';
+          if (inProgressRuns) {
+            whatItDid += 'Canceled in-progress runs: ' + inProgressRuns + '\n\n';
+          } else {
+            whatItDid += 'No in-progress runs found\n\n';
+          }
+          if (queuedRuns) {
+            whatItDid += 'Canceled queued runs: ' + queuedRuns;
+          } else {
+            whatItDid += 'No queued runs found';
+          }
+
+          const body = 'done\n\n<details>\n<summary>What it did</summary>\n\n' + whatItDid + '\n\n</details>\n\n<details>\n<summary>What it can do and how to use</summary>\n\nThis bot cancels in-progress and queued GitHub Actions runs.\n\n**Commands:**\n- `/cancel-runs` - Cancels all in-progress and queued workflow runs\n\n**Note:** This action cannot be undone. Use with caution.\n</details>';
+
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          });
+      env:
+        IN_PROGRESS_RUNS: ${{ steps.cancel-in-progress.outputs.canceled_runs }}
+        QUEUED_RUNS: ${{ steps.cancel-queued.outputs.canceled_runs }}

--- a/.github/workflows/cancel-runs.yml
+++ b/.github/workflows/cancel-runs.yml
@@ -13,7 +13,17 @@ jobs:
       actions: write
       pull-requests: write
     steps:
+    - name: Check if help request
+      id: check
+      run: |
+        if [[ "${{ github.event.comment.body }}" == *help* ]]; then
+          echo "is_help=true" >> $GITHUB_OUTPUT
+        else
+          echo "is_help=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Cancel in-progress runs
+      if: steps.check.outputs.is_help == 'false'
       id: cancel-in-progress
       run: |
         # Get in-progress run IDs
@@ -30,6 +40,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Cancel queued runs
+      if: steps.check.outputs.is_help == 'false'
       id: cancel-queued
       run: |
         # Get queued run IDs
@@ -49,22 +60,28 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
+          const isHelp = process.env.IS_HELP === 'true';
           const inProgressRuns = process.env.IN_PROGRESS_RUNS || '';
           const queuedRuns = process.env.QUEUED_RUNS || '';
 
-          let whatItDid = '';
-          if (inProgressRuns) {
-            whatItDid += 'Canceled in-progress runs: ' + inProgressRuns + '\n\n';
+          let body;
+          if (isHelp) {
+            body = '<details>\n<summary>What it can do and how to use</summary>\n\nThis bot cancels in-progress and queued GitHub Actions runs.\n\n**Commands:**\n- `/cancel-runs` - Cancels all in-progress and queued workflow runs\n- `/cancel-runs help` - Shows this help message\n\n**Note:** Cancellation cannot be undone. Use with caution.\n</details>';
           } else {
-            whatItDid += 'No in-progress runs found\n\n';
-          }
-          if (queuedRuns) {
-            whatItDid += 'Canceled queued runs: ' + queuedRuns;
-          } else {
-            whatItDid += 'No queued runs found';
-          }
+            let whatItDid = '';
+            if (inProgressRuns) {
+              whatItDid += 'Canceled in-progress runs: ' + inProgressRuns + '\n\n';
+            } else {
+              whatItDid += 'No in-progress runs found\n\n';
+            }
+            if (queuedRuns) {
+              whatItDid += 'Canceled queued runs: ' + queuedRuns;
+            } else {
+              whatItDid += 'No queued runs found';
+            }
 
-          const body = 'done\n\n<details>\n<summary>What it did</summary>\n\n' + whatItDid + '\n\n</details>\n\n<details>\n<summary>What it can do and how to use</summary>\n\nThis bot cancels in-progress and queued GitHub Actions runs.\n\n**Commands:**\n- `/cancel-runs` - Cancels all in-progress and queued workflow runs\n\n**Note:** This action cannot be undone. Use with caution.\n</details>';
+            body = 'done\n\n<details>\n<summary>What it did</summary>\n\n' + whatItDid + '\n\n</details>\n\n<details>\n<summary>What it can do and how to use</summary>\n\nThis bot cancels in-progress and queued GitHub Actions runs.\n\n**Commands:**\n- `/cancel-runs` - Cancels all in-progress and queued workflow runs\n- `/cancel-runs help` - Shows this help message\n\n**Note:** This action cannot be undone. Use with caution.\n</details>';
+          }
 
           await github.rest.issues.createComment({
             issue_number: context.issue.number,
@@ -73,5 +90,6 @@ jobs:
             body: body
           });
       env:
+        IS_HELP: ${{ steps.check.outputs.is_help }}
         IN_PROGRESS_RUNS: ${{ steps.cancel-in-progress.outputs.canceled_runs }}
         QUEUED_RUNS: ${{ steps.cancel-queued.outputs.canceled_runs }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: ci
+name: CI
 on:
   push:
     branches: [ main, develop ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
       env:
         RUST_LOG: debug
     - name: Run integration tests
-      run: cargo test --all-features --workspace --verbose -- --test-threads=1
+      run: |
+        cargo build --all-features --workspace
+        cargo test --all-features --workspace --verbose -- --ignored --test-threads=1
       env:
         RUST_LOG: debug
     - name: Build in release mode

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,4 @@
-name: "Dependency Review"
+name: Dependency Review
 on: [pull_request]
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: docs
+name: Docs
 
 on:
   push:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: integration tests
+name: Integration Tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: nightly
+name: Nightly
 
 on:
   schedule:

--- a/.github/workflows/normalize-pr-description.yml
+++ b/.github/workflows/normalize-pr-description.yml
@@ -23,13 +23,13 @@ permissions:
 
 jobs:
   normalize:
-    # Only run for PRs from within the org (not forks, not dependabot)
     if: |
       github.repository_owner == 'harpertoken' &&
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'app/dependabot'
     runs-on: ubuntu-latest
+
     steps:
       - name: Normalize description to paragraph style
         uses: actions/github-script@v7
@@ -38,13 +38,12 @@ jobs:
             const pr = context.payload.pull_request;
             const body = pr.body || '';
 
-            // Already paragraph style: no ## headers at the start
-            if (!body.trimStart().startsWith('##')) {
-              core.info('PR description already in paragraph style. Skipping.');
+            // Only run if Summary section exists
+            if (!/##\s*Summary/i.test(body)) {
+              core.info('No ## Summary section found. Skipping.');
               return;
             }
 
-            // Parse ## Summary bullets and ## Testing line into a paragraph
             const summaryMatch = body.match(/##\s*Summary\s*\n([\s\S]*?)(?=\n##|$)/i);
             const testingMatch = body.match(/##\s*Testing\s*\n([\s\S]*?)(?=\n##|$)/i);
 
@@ -53,24 +52,28 @@ jobs:
               return;
             }
 
-            // Convert bullet list to sentences, stripping any stray markdown headers
             const bullets = summaryMatch[1]
-              .split('\n')
+              .split(/\r?\n/)
               .map(l => l.replace(/^[-*]\s*/, '').replace(/^#+\s*/, '').trim())
               .filter(Boolean);
 
-            // Wrap technical tokens in backticks if not already wrapped:
-            // filenames with extensions, --flags, and tokens inside parens like (fmt/clippy/...)
             function wrapTech(text) {
-              // Wrap filenames with known extensions
-              text = text.replace(/(?<!`)(\b[\w.-]+\.(yml|rs|toml|md|json|sh|ts|js|py)\b)/g, '`$1`');
-              // Wrap --flags
+              text = text.replace(
+                /(?<!`)(\b[\w.-]+\.(yml|rs|toml|md|json|sh|ts|js|py)\b)(?!`)/g,
+                '`$1`'
+              );
+
               text = text.replace(/(?<!`)(\-\-[\w-]+)/g, '`$1`');
-              // Wrap slash-separated tokens inside parens e.g. (fmt/clippy/check/yaml)
+
               text = text.replace(/\(([^)]+\/[^)]+)\)/g, (_, inner) => {
-                const wrapped = inner.split('/').map(t => t.trim()).map(t => t.startsWith('`') ? t : '`' + t + '`').join('/');
+                const wrapped = inner
+                  .split('/')
+                  .map(t => t.trim())
+                  .map(t => t.startsWith('`') ? t : '`' + t + '`')
+                  .join('/');
                 return '(' + wrapped + ')';
               });
+
               return text;
             }
 
@@ -78,12 +81,17 @@ jobs:
               .map(b => wrapTech(b.endsWith('.') ? b : b + '.'))
               .join(' ');
 
-            // Extract testing sentence if present
             const testingLines = testingMatch
-              ? testingMatch[1].split('\n').map(l => l.replace(/^[-*]\s*/, '').replace(/^#+\s*/, '').trim()).filter(Boolean)
+              ? testingMatch[1]
+                  .split(/\r?\n/)
+                  .map(l => l.replace(/^[-*]\s*/, '').replace(/^#+\s*/, '').trim())
+                  .filter(Boolean)
               : [];
+
             const testingSentence = testingLines.length
-              ? wrapTech(testingLines[0].endsWith('.') ? testingLines[0] : testingLines[0] + '.')
+              ? testingLines
+                  .map(l => wrapTech(l.endsWith('.') ? l : l + '.'))
+                  .join(' ')
               : 'Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.';
 
             const newBody = `${summarySentence} ${testingSentence}\n`;

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: package test
+name: Package Test
 
 on:
   push:

--- a/.github/workflows/post-auto-merge-ci.yml
+++ b/.github/workflows/post-auto-merge-ci.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: post auto-merge ci
+name: Post Auto-Merge CI
 
 on:
   workflow_run:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@
 #
 # Licensed under the Apache License, Version 2.0
 
-name: pr-checks
+name: PR Checks
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tarpaulin-report.html
 
 # Bazel build artifacts
 bazel-*
+!.github/workflows/bazel-*.yml
 bazel-bin/
 bazel-out/
 bazel-testlogs/

--- a/tests/integration_cli_test.rs
+++ b/tests/integration_cli_test.rs
@@ -6,6 +6,7 @@ use assert_cmd::Command;
 use harper_core::core::constants;
 
 #[test]
+#[ignore = "requires built harper binary; run with --ignored after cargo build"]
 fn harper_cli_reports_exact_version() -> Result<(), Box<dyn std::error::Error>> {
     let expected = format!("harper v{}", constants::VERSION);
 


### PR DESCRIPTION
Adds cancel-auto-merge job to `auto`-merge.yml`` that fires when auto-merge label is removed. Switches auto-merge-now to use BYPASS_TOKEN PAT to bypass ruleset checks. Tracks main branch ruleset in .github/rulesets/`main`-branch-protection.json`` with `apply`-rulesets.yml`` to sync on push. Updates workflows `README.md` with new workflows, labels table, and ruleset docs. Adds cancel runs bot workflow to cancel in-progress and queued GitHub Actions runs via `/cancel-runs` PR comments, with collapsible completion details, and `/cancel-runs help` for usage info. Marks harper_cli_reports_exact_version as ignored and fixes `ci.yml` to build before running `--ignored` integration tests. Normalizes all workflow names to title case. Fixes `bazel`-smoke.yml`` being caught by the bazel-* gitignore pattern via negation rule. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.
