### PR TITLE
[fix] lowercase message in type: format

### DIFF
--- a/.github/workflows/fix-pr-title.yml
+++ b/.github/workflows/fix-pr-title.yml
@@ -37,8 +37,10 @@ jobs:
           if [[ "$PR_TITLE" =~ ^([a-zA-Z]+):[[:space:]]+(.*) ]]; then
             TYPE="${BASH_REMATCH[1]}"
             MSG="${BASH_REMATCH[2]}"
+            LOWER_MSG=$(echo "$MSG" | tr '[:upper:]' '[:lower:]')
+            LOWER_MSG=$(echo "$LOWER_MSG" | sed 's/^add //')
 
-            NEW_TITLE="[$TYPE] $MSG"
+            NEW_TITLE="[$TYPE] $LOWER_MSG"
 
             echo "Original: $PR_TITLE"
             echo "New: $NEW_TITLE"


### PR DESCRIPTION
Fix the fix-pr-title workflow to lowercase the message part when converting from `Type: message` format to `[Type] message` format. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.

<details>
<summary>Available Bot Commands</summary>

**Cancel Runs Bot:**
- `/cancel-runs` - Cancels in-progress and queued GitHub Actions runs
- `/cancel-runs help` - Shows help for the cancel runs bot

**Rust Auto-Fix Bot:**
- `/rust-fix fmt` - Applies cargo fmt
- `/rust-fix clippy` - Applies clippy auto-fixes
- `/rust-fix all` - Applies both fmt and clippy

</details>
