### PR TITLE
[fix] concurrency to cancel-runs

### DIFF
--- a/.github/workflows/cancel-runs.yml
+++ b/.github/workflows/cancel-runs.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: cancel-runs-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   cancel-runs:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/cancel-runs') && github.repository_owner == 'harpertoken'


### PR DESCRIPTION
Add concurrency group to cancel-runs workflow to prevent multiple queued instances. Set cancel-in-progress: true to cancel stale runs when new /cancel-runs is called. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.

<details>
<summary>Available Bot Commands</summary>

**Cancel Runs Bot:**
- `/cancel-runs` - Cancels in-progress and queued GitHub Actions runs
- `/cancel-runs help` - Shows help for the cancel runs bot

**Rust Auto-Fix Bot:**
- `/rust-fix fmt` - Applies cargo fmt
- `/rust-fix clippy` - Applies clippy auto-fixes
- `/rust-fix all` - Applies both fmt and clippy

</details>
