### PR TITLE
[feat] integrate scheduler and cache alignment utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.3.0",
+ "fastrand 2.4.0",
  "futures-lite 2.6.1",
  "pin-project-lite",
  "slab",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -773,7 +773,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "toml",
- "winnow 1.0.0",
+ "winnow 1.0.1",
  "yaml-rust2",
 ]
 
@@ -1355,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "fax"
@@ -1558,7 +1558,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand 2.4.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -1952,9 +1952,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1967,7 +1967,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2056,12 +2055,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2096,15 +2096,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2116,15 +2116,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2210,9 +2210,9 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2291,9 +2291,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2346,9 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2418,9 +2418,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2497,9 +2497,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -3190,19 +3190,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand 2.3.0",
+ "fastrand 2.4.0",
  "futures-io",
 ]
 
@@ -3304,9 +3298,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3841,9 +3835,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
  "bitflags 2.11.0",
  "once_cell",
@@ -4074,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4157,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4423,7 +4417,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand 2.4.0",
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
@@ -4597,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4617,9 +4611,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -4634,9 +4628,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4682,15 +4676,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4701,9 +4695,9 @@ checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4721,11 +4715,11 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4814,9 +4808,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turul-mcp-client"
-version = "0.3.27"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee7a619124401e20797ad39961a295a9a0866077b8753511357fd07890d85beb"
+checksum = "986da0e962e5ba30b4fd050bde39f9b9b0989853d64574b5664ad02bc96fb2e1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4831,7 +4825,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "turul-mcp-json-rpc-server 0.3.27",
+ "turul-mcp-json-rpc-server 0.3.31",
  "turul-mcp-protocol",
  "url",
 ]
@@ -4851,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "turul-mcp-json-rpc-server"
-version = "0.3.27"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd1d79361c0c0f6a8bb3c7ac630398dff04ebd242613d7d249da156d06cfd3"
+checksum = "429efd9effc97d7b4f6eaae34645265fcf3798901a57a9c810375706fe6d3f0f"
 dependencies = [
  "async-trait",
  "futures",
@@ -4864,24 +4858,24 @@ dependencies = [
 
 [[package]]
 name = "turul-mcp-protocol"
-version = "0.3.27"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7052c63fcbe77b78149960c1b807985678b69e5f85fd6c606fbc02107cd47a"
+checksum = "e757731abce7bccb36410f720876ebdcebe307f46a7198dc5269e2fe92af264a"
 dependencies = [
  "turul-mcp-protocol-2025-11-25",
 ]
 
 [[package]]
 name = "turul-mcp-protocol-2025-11-25"
-version = "0.3.27"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77264a3124d38e60a64ff7143c745ce76fcb6367bf309a431d4794b37949625"
+checksum = "de2c9400221c48c66e1f182e0bf1d1ce77fdd520e305e6f8f629b7e45ccd6922"
 dependencies = [
  "async-trait",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "turul-mcp-json-rpc-server 0.3.27",
+ "turul-mcp-json-rpc-server 0.3.31",
 ]
 
 [[package]]
@@ -5088,9 +5082,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5101,9 +5095,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5111,9 +5105,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5121,9 +5115,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5134,9 +5128,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5190,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5619,9 +5613,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -5716,9 +5710,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x11rb"
@@ -5775,9 +5769,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5786,9 +5780,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5884,18 +5878,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5911,9 +5905,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5922,9 +5916,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5933,9 +5927,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lib/harper-core/src/agent/chat.rs
+++ b/lib/harper-core/src/agent/chat.rs
@@ -20,10 +20,11 @@ use crate::agent::intent::{route_intent, DeterministicIntent};
 use crate::agent::offline_shell::plan_offline_shell_commands;
 use crate::agent::prompt::PromptBuilder;
 use crate::core::cache::{ApiCacheKey, ApiResponseCache};
-use crate::core::error::HarperError;
+use crate::core::error::{HarperError, HarperResult};
 use crate::core::{ApiConfig, Message};
 use crate::memory::storage::CommandLogEntry;
 use crate::runtime::config::ExecPolicyConfig;
+use crate::runtime::scheduler::{TaskPriority, TaskScheduler};
 use crate::tools::shell::CommandAuditContext;
 use crate::tools::ToolService;
 
@@ -41,6 +42,7 @@ use rustyline::Helper;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
+use std::time::{Duration, Instant};
 use turul_mcp_client::{McpClient, ResourceContent};
 
 #[derive(Debug)]
@@ -50,6 +52,12 @@ enum CommandAction {
     Audit(AuditParams),
     Custom(String),
     Unknown(String),
+}
+
+#[derive(Debug, Clone)]
+enum ChatBackgroundTask {
+    TodoReminder,
+    AuditRefresh { session_id: String },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -181,11 +189,15 @@ pub struct ChatService<'a> {
     custom_commands: HashMap<String, String>,
     exec_policy: ExecPolicyConfig,
     approver: Option<Arc<dyn UserApproval>>,
+    background_tasks: TaskScheduler<ChatBackgroundTask>,
+    todo_reminder_armed: bool,
+    last_audit_refresh: Option<Instant>,
 }
 
 #[allow(dead_code)]
 impl<'a> ChatService<'a> {
     const AUDIT_LOG_LIMIT: usize = 10;
+    const AUDIT_REFRESH_DEBOUNCE: Duration = Duration::from_secs(3);
 
     /// Create a new chat service
     pub fn new(
@@ -207,6 +219,9 @@ impl<'a> ChatService<'a> {
             custom_commands,
             exec_policy,
             approver: None,
+            background_tasks: TaskScheduler::new(),
+            todo_reminder_armed: false,
+            last_audit_refresh: None,
         }
     }
 
@@ -233,6 +248,9 @@ impl<'a> ChatService<'a> {
                 blocked_commands: None,
             },
             approver: None,
+            background_tasks: TaskScheduler::new(),
+            todo_reminder_armed: false,
+            last_audit_refresh: None,
         }
     }
 
@@ -262,6 +280,8 @@ impl<'a> ChatService<'a> {
         web_search_enabled: bool,
         session_id: &str,
     ) -> Result<(), HarperError> {
+        self.schedule_todo_reminder();
+        self.poll_background_tasks(session_id);
         // Handle slash commands locally
         if let Some(command) = user_msg.strip_prefix('/') {
             let response = match command {
@@ -304,6 +324,7 @@ impl<'a> ChatService<'a> {
             .try_handle_deterministic_intent(&processed_msg, session_id)
             .await?
         {
+            self.notify_command_activity(session_id);
             self.add_assistant_message(history, session_id, &local_response)?;
             self.trim_history(history);
             return Ok(());
@@ -321,6 +342,7 @@ impl<'a> ChatService<'a> {
             .await?;
         self.add_assistant_message(history, session_id, &response)?;
         self.trim_history(history);
+        self.poll_background_tasks(session_id);
         Ok(())
     }
 
@@ -509,6 +531,7 @@ impl<'a> ChatService<'a> {
         let (mut history, session_id) = self.create_session(web_search_enabled).await?;
 
         self.display_session_start();
+        self.schedule_todo_reminder();
 
         self.run_chat_loop(&session_id, &mut history, web_search_enabled)
             .await
@@ -536,6 +559,108 @@ impl<'a> ChatService<'a> {
         );
     }
 
+    fn schedule_todo_reminder(&mut self) {
+        if self.todo_reminder_armed {
+            return;
+        }
+        self.todo_reminder_armed = true;
+        self.background_tasks.schedule_in(
+            ChatBackgroundTask::TodoReminder,
+            Duration::from_secs(45),
+            TaskPriority::LOW,
+        );
+    }
+
+    fn notify_command_activity(&mut self, session_id: &str) {
+        let now = Instant::now();
+        if let Some(last) = self.last_audit_refresh {
+            if now.duration_since(last) < Self::AUDIT_REFRESH_DEBOUNCE {
+                return;
+            }
+        }
+        self.last_audit_refresh = Some(now);
+        self.background_tasks.schedule_in(
+            ChatBackgroundTask::AuditRefresh {
+                session_id: session_id.to_string(),
+            },
+            Duration::from_millis(1200),
+            TaskPriority::HIGH,
+        );
+    }
+
+    fn poll_background_tasks(&mut self, default_session_id: &str) {
+        let ready = self.background_tasks.drain_ready(Instant::now());
+        for item in ready {
+            match item.payload {
+                ChatBackgroundTask::TodoReminder => {
+                    self.todo_reminder_armed = false;
+                    if let Err(err) = self.emit_todo_reminder() {
+                        eprintln!("Warning: failed to load todos for reminder: {}", err);
+                    }
+                    self.schedule_todo_reminder();
+                }
+                ChatBackgroundTask::AuditRefresh { session_id } => {
+                    let target = if session_id.is_empty() {
+                        default_session_id.to_string()
+                    } else {
+                        session_id
+                    };
+                    self.emit_quick_audit_refresh(&target);
+                }
+            }
+        }
+    }
+
+    fn emit_todo_reminder(&self) -> HarperResult<()> {
+        let todos = crate::memory::storage::load_todos(self.conn)?;
+        if todos.is_empty() {
+            return Ok(());
+        }
+
+        println!(
+            "
+{} Pending todos ({} total):",
+            "Reminder:".bold().cyan(),
+            todos.len()
+        );
+        for (_, desc) in todos.iter().take(3) {
+            println!("  - {}", desc);
+        }
+        if todos.len() > 3 {
+            println!("  …and {} more", todos.len() - 3);
+        }
+        Ok(())
+    }
+
+    fn emit_quick_audit_refresh(&self, session_id: &str) {
+        match self.fetch_command_logs(session_id, 3) {
+            Ok(entries) if !entries.is_empty() => {
+                println!(
+                    "
+{} Latest commands:",
+                    "Audit:".bold().cyan()
+                );
+                for entry in entries {
+                    let approval_state = if entry.requires_approval {
+                        if entry.approved {
+                            "approved"
+                        } else {
+                            "rejected"
+                        }
+                    } else {
+                        "auto"
+                    };
+                    println!(
+                        "  [{} | {} | {:?}] {}",
+                        entry.status, approval_state, entry.exit_code, entry.command
+                    );
+                }
+            }
+            Ok(_) => {}
+            Err(err) => eprintln!("Warning: failed to refresh audit summary: {}", err),
+        }
+    }
+
     /// Run the chat loop
     async fn run_chat_loop(
         &mut self,
@@ -544,6 +669,7 @@ impl<'a> ChatService<'a> {
         web_search_enabled: bool,
     ) -> Result<(), HarperError> {
         loop {
+            self.poll_background_tasks(session_id);
             let user_input = self.get_user_input()?;
             if self.should_exit(&user_input) {
                 self.display_session_end();
@@ -569,6 +695,7 @@ impl<'a> ChatService<'a> {
                     Ok(result) => println!("{} {}", "Shell:".bold().cyan(), result.cyan()),
                     Err(e) => println!("{} {}", "Error:".bold().red(), e),
                 }
+                self.notify_command_activity(session_id);
                 continue;
             }
 
@@ -686,17 +813,6 @@ impl<'a> ChatService<'a> {
         let mut executed_tool_calls: HashSet<String> = HashSet::new();
         let mut last_tool_content: Option<String> = None;
 
-        let mut tool_service = ToolService::new(
-            self.conn,
-            self.config,
-            &self.exec_policy,
-            self.mcp_client,
-            Some(session_id),
-        );
-        if let Some(approver) = &self.approver {
-            tool_service = tool_service.with_approver(approver.clone());
-        }
-
         for _ in 0..MAX_TOOL_ROUNDS {
             let clean_response = Self::sanitize_model_response(&response);
             let tool_signature = Self::tool_call_signature(&clean_response);
@@ -707,16 +823,29 @@ impl<'a> ChatService<'a> {
                 }
                 break;
             }
-            let tool_option = tool_service
-                .handle_tool_use(
-                    &client,
-                    &history_for_llm,
-                    &clean_response,
-                    web_search_enabled,
-                )
-                .await?;
+            let tool_option = {
+                let mut tool_service = ToolService::new(
+                    self.conn,
+                    self.config,
+                    &self.exec_policy,
+                    self.mcp_client,
+                    Some(session_id),
+                );
+                if let Some(approver) = &self.approver {
+                    tool_service = tool_service.with_approver(approver.clone());
+                }
+                tool_service
+                    .handle_tool_use(
+                        &client,
+                        &history_for_llm,
+                        &clean_response,
+                        web_search_enabled,
+                    )
+                    .await?
+            };
 
             if let Some((tool_result, tool_content)) = tool_option {
+                self.notify_command_activity(session_id);
                 executed_tool_calls.insert(dedupe_key);
                 last_tool_content = Some(tool_content.clone());
                 let tool_message = Message {
@@ -835,7 +964,7 @@ impl<'a> ChatService<'a> {
     }
 
     async fn try_handle_offline_shell_proxy(
-        &self,
+        &mut self,
         user_msg: &str,
         session_id: &str,
     ) -> Result<Option<String>, HarperError> {
@@ -866,6 +995,7 @@ impl<'a> ChatService<'a> {
                 sections.push(format!("$ {}\n{}", command, output.trim_end()));
             }
         }
+        self.notify_command_activity(session_id);
         Ok(Some(sections.join("\n\n")))
     }
 

--- a/lib/harper-core/src/lib.rs
+++ b/lib/harper-core/src/lib.rs
@@ -29,7 +29,8 @@ pub use agent::chat::*;
 #[allow(unused_imports)]
 pub use tools::*;
 
-// Re-export memory functions
+// Re-export memory utilities
+pub use memory::cache::*;
 pub use memory::storage::*;
 
 // Re-export runtime

--- a/lib/harper-core/src/memory/cache.rs
+++ b/lib/harper-core/src/memory/cache.rs
@@ -1,0 +1,268 @@
+// Copyright 2026 harpertoken
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cache-aware primitives used by Harper's memory subsystem.
+//!
+//! These helpers provide an ergonomic way to store frequently accessed data on
+//! 64-byte boundaries (a common CPU cache-line size) so read/write workloads do
+//! not suffer from false sharing or misaligned loads.
+
+use std::io::{self, Write};
+use std::ops::{Deref, DerefMut};
+
+pub const CACHE_LINE_BYTES: usize = 64;
+
+#[repr(align(64))]
+#[derive(Debug, Clone, Copy)]
+struct CacheLine {
+    bytes: [u8; CACHE_LINE_BYTES],
+}
+
+impl CacheLine {
+    const fn new() -> Self {
+        Self {
+            bytes: [0; CACHE_LINE_BYTES],
+        }
+    }
+
+    fn as_ptr(&self) -> *const u8 {
+        self.bytes.as_ptr()
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.bytes.as_mut_ptr()
+    }
+}
+
+impl Default for CacheLine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wraps any type so its address is aligned to a cache line boundary.
+#[repr(align(64))]
+#[derive(Debug)]
+pub struct CacheAligned<T> {
+    inner: T,
+}
+
+impl<T> CacheAligned<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    pub fn as_ptr(&self) -> *const T {
+        &self.inner
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        &mut self.inner
+    }
+}
+
+impl<T: Clone> Clone for CacheAligned<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T: Copy> Copy for CacheAligned<T> {}
+
+impl<T: Default> Default for CacheAligned<T> {
+    fn default() -> Self {
+        Self {
+            inner: T::default(),
+        }
+    }
+}
+
+impl<T> Deref for CacheAligned<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for CacheAligned<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// A byte buffer whose start address is always cache-line aligned.
+#[derive(Debug, Clone)]
+pub struct CacheAlignedBuffer {
+    lines: Vec<CacheLine>,
+    len: usize,
+}
+
+impl CacheAlignedBuffer {
+    pub fn new(len: usize) -> Self {
+        let mut buffer = Self {
+            lines: Vec::new(),
+            len,
+        };
+        buffer.ensure_capacity(len.max(1));
+        buffer
+    }
+
+    pub fn with_capacity(bytes: usize) -> Self {
+        let mut buffer = Self {
+            lines: Vec::new(),
+            len: 0,
+        };
+        buffer.ensure_capacity(bytes.max(1));
+        buffer
+    }
+
+    pub fn from_slice(data: &[u8]) -> Self {
+        let mut buffer = Self::new(data.len());
+        buffer.as_mut_slice().copy_from_slice(data);
+        buffer
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.lines.len() * CACHE_LINE_BYTES
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.raw_ptr(), self.len) }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.raw_mut_ptr(), self.len) }
+    }
+
+    pub fn resize(&mut self, new_len: usize) {
+        let old_len = self.len;
+        self.ensure_capacity(new_len.max(1));
+        self.len = new_len;
+        if new_len > old_len {
+            self.as_mut_slice()[old_len..new_len].fill(0);
+        }
+    }
+
+    pub fn fill(&mut self, value: u8) {
+        self.as_mut_slice().fill(value);
+    }
+
+    pub fn write_bytes(&mut self, bytes: &[u8]) {
+        self.resize(bytes.len());
+        self.as_mut_slice().copy_from_slice(bytes);
+    }
+
+    pub fn append_bytes(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        let start = self.len;
+        self.resize(self.len + bytes.len());
+        self.as_mut_slice()[start..start + bytes.len()].copy_from_slice(bytes);
+    }
+
+    fn ensure_capacity(&mut self, target_len: usize) {
+        let needed_lines = target_len.div_ceil(CACHE_LINE_BYTES);
+        if needed_lines > self.lines.len() {
+            self.lines.resize_with(needed_lines, CacheLine::default);
+        }
+        if self.len > target_len {
+            self.len = target_len;
+        }
+    }
+
+    fn raw_ptr(&self) -> *const u8 {
+        debug_assert!(
+            !self.lines.is_empty(),
+            "CacheAlignedBuffer must reserve at least one line"
+        );
+        self.lines[0].as_ptr()
+    }
+
+    fn raw_mut_ptr(&mut self) -> *mut u8 {
+        debug_assert!(
+            !self.lines.is_empty(),
+            "CacheAlignedBuffer must reserve at least one line"
+        );
+        self.lines[0].as_mut_ptr()
+    }
+}
+
+impl Write for CacheAlignedBuffer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.append_bytes(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_aligned_wrapper_aligns_memory() {
+        let wrapped = CacheAligned::new([0u8; 32]);
+        let addr = wrapped.as_ptr() as usize;
+        assert_eq!(addr % CACHE_LINE_BYTES, 0);
+    }
+
+    #[test]
+    fn buffer_resizes_and_retains_alignment() {
+        let mut buffer = CacheAlignedBuffer::new(16);
+        let ptr = buffer.as_slice().as_ptr() as usize;
+        assert_eq!(ptr % CACHE_LINE_BYTES, 0);
+
+        buffer.resize(256);
+        assert_eq!(buffer.len(), 256);
+        assert!(buffer.capacity() >= 256);
+        let new_ptr = buffer.as_slice().as_ptr() as usize;
+        assert_eq!(new_ptr % CACHE_LINE_BYTES, 0);
+    }
+
+    #[test]
+    fn write_and_read_round_trip() {
+        let payload = b"hello cache";
+        let mut buffer = CacheAlignedBuffer::with_capacity(512);
+        buffer.write_bytes(payload);
+        assert_eq!(buffer.as_slice(), payload);
+    }
+
+    #[test]
+    fn append_via_write_trait_accumulates_bytes() {
+        use std::io::Write as _;
+        let mut buffer = CacheAlignedBuffer::with_capacity(64);
+        write!(&mut buffer, "abc").unwrap();
+        write!(&mut buffer, "123").unwrap();
+        assert_eq!(buffer.as_slice(), b"abc123");
+    }
+}

--- a/lib/harper-core/src/memory/mod.rs
+++ b/lib/harper-core/src/memory/mod.rs
@@ -17,5 +17,6 @@
 //! This module handles storage and retrieval of conversation history,
 //! session management, and long-term memory.
 
+pub mod cache;
 pub mod session_service;
 pub mod storage;

--- a/lib/harper-core/src/memory/session_service.rs
+++ b/lib/harper-core/src/memory/session_service.rs
@@ -19,6 +19,8 @@
 
 use crate::core::error::{HarperError, HarperResult};
 use crate::core::io_traits::{Input, Output};
+use crate::core::Message;
+use crate::memory::cache::CacheAlignedBuffer;
 use crate::memory::storage::{
     load_command_logs_for_session, load_history, load_latest_command_log,
 };
@@ -26,7 +28,6 @@ use chrono::Local;
 use colored::*;
 use rusqlite::Connection;
 use serde_json;
-use std::fs::File;
 use std::io::Write;
 use std::sync::Arc;
 
@@ -221,17 +222,10 @@ impl<'a> SessionService<'a> {
             let json = serde_json::to_string_pretty(&history)?;
             std::fs::write(&output_path, json)?;
         } else {
-            let mut file = File::create(&output_path)?;
-            for msg in &history {
-                writeln!(
-                    &mut file,
-                    "[{}] {}: {}",
-                    Local::now().format("%Y-%m-%d %H:%M:%S"),
-                    msg.role,
-                    msg.content.replace('\n', "\n  ")
-                )?;
-            }
-            self.write_audit_section(&mut file, &session_id)?;
+            let mut buffer = CacheAlignedBuffer::with_capacity(history.len() * 128);
+            self.write_transcript(&mut buffer, &history)?;
+            self.write_audit_section(&mut buffer, &session_id)?;
+            std::fs::write(&output_path, buffer.as_slice())?;
         }
 
         self.output.println(&format!(
@@ -256,19 +250,25 @@ impl<'a> SessionService<'a> {
         let default_filename = format!("harper_export_{}", session_id);
         let output_path = format!("{}.txt", default_filename);
 
-        let mut file = File::create(&output_path)?;
-        for msg in &history {
+        let mut buffer = CacheAlignedBuffer::with_capacity(history.len() * 128);
+        self.write_transcript(&mut buffer, &history)?;
+        self.write_audit_section(&mut buffer, session_id)?;
+        std::fs::write(&output_path, buffer.as_slice())?;
+
+        Ok(output_path)
+    }
+
+    fn write_transcript<W: Write>(&self, writer: &mut W, history: &[Message]) -> HarperResult<()> {
+        for msg in history {
             writeln!(
-                &mut file,
+                writer,
                 "[{}] {}: {}",
                 Local::now().format("%Y-%m-%d %H:%M:%S"),
                 msg.role,
                 msg.content.replace('\n', "\n  ")
             )?;
         }
-        self.write_audit_section(&mut file, session_id)?;
-
-        Ok(output_path)
+        Ok(())
     }
 
     fn print_audit_summary(&self, session_id: &str, limit: usize) -> HarperResult<()> {
@@ -313,16 +313,16 @@ impl<'a> SessionService<'a> {
         Ok(())
     }
 
-    fn write_audit_section(&self, file: &mut File, session_id: &str) -> HarperResult<()> {
+    fn write_audit_section<W: Write>(&self, writer: &mut W, session_id: &str) -> HarperResult<()> {
         let entries =
             load_command_logs_for_session(self.conn, session_id, Self::AUDIT_EXPORT_LIMIT)?;
         writeln!(
-            file,
+            writer,
             "\n---\nCommand Audit (last {} commands):",
             Self::AUDIT_EXPORT_LIMIT
         )?;
         if entries.is_empty() {
-            writeln!(file, "No commands were recorded for this session.")?;
+            writeln!(writer, "No commands were recorded for this session.")?;
             return Ok(());
         }
 
@@ -345,7 +345,7 @@ impl<'a> SessionService<'a> {
                 .map(|ms| format!("{} ms", ms))
                 .unwrap_or_else(|| "-".to_string());
             writeln!(
-                file,
+                writer,
                 "[{}] {} [{} | {} | {}] {}",
                 Local::now().format("%Y-%m-%d %H:%M:%S"),
                 entry.command,

--- a/lib/harper-core/src/runtime/mod.rs
+++ b/lib/harper-core/src/runtime/mod.rs
@@ -18,4 +18,5 @@
 //! and other runtime infrastructure.
 
 pub mod config;
+pub mod scheduler;
 pub mod utils;

--- a/lib/harper-core/src/runtime/scheduler.rs
+++ b/lib/harper-core/src/runtime/scheduler.rs
@@ -1,0 +1,203 @@
+// Copyright 2026 harpertoken
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cooperative task scheduler built on top of `BinaryHeap`.
+//!
+//! This module supplies a deterministic priority queue that Harper can use
+//! to coordinate background operations (command dispatch, MCP sessions,
+//! telemetry flushes, etc.).
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::time::{Duration, Instant};
+
+/// Represents the urgency of a task. Higher numbers mean higher priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TaskPriority(u8);
+
+impl TaskPriority {
+    pub const LOW: Self = Self(25);
+    pub const NORMAL: Self = Self(50);
+    pub const HIGH: Self = Self(75);
+    pub const CRITICAL: Self = Self(100);
+
+    pub fn new(level: u8) -> Self {
+        Self(level)
+    }
+
+    pub fn as_u8(self) -> u8 {
+        self.0
+    }
+}
+
+impl Default for TaskPriority {
+    fn default() -> Self {
+        Self::NORMAL
+    }
+}
+
+/// Public handle returned for ready tasks.
+#[derive(Debug)]
+pub struct ScheduledItem<T> {
+    pub priority: TaskPriority,
+    pub deadline: Instant,
+    pub payload: T,
+}
+
+#[derive(Debug)]
+pub struct TaskScheduler<T> {
+    heap: BinaryHeap<HeapEntry<T>>,
+    sequence: u64,
+}
+
+impl<T> TaskScheduler<T> {
+    pub fn new() -> Self {
+        Self {
+            heap: BinaryHeap::new(),
+            sequence: 0,
+        }
+    }
+
+    pub fn schedule_at(&mut self, payload: T, deadline: Instant, priority: TaskPriority) {
+        self.push_entry(payload, deadline, priority);
+    }
+
+    pub fn schedule_in(&mut self, payload: T, delay: Duration, priority: TaskPriority) {
+        self.push_entry(payload, Instant::now() + delay, priority);
+    }
+
+    pub fn pop_ready(&mut self, now: Instant) -> Option<ScheduledItem<T>> {
+        if matches!(self.heap.peek(), Some(head) if head.deadline <= now) {
+            self.heap.pop().map(|entry| ScheduledItem {
+                priority: entry.priority,
+                deadline: entry.deadline,
+                payload: entry.payload,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn drain_ready(&mut self, now: Instant) -> Vec<ScheduledItem<T>> {
+        let mut ready = Vec::new();
+        while let Some(item) = self.pop_ready(now) {
+            ready.push(item);
+        }
+        ready
+    }
+
+    pub fn peek_deadline(&self) -> Option<Instant> {
+        self.heap.peek().map(|entry| entry.deadline)
+    }
+
+    pub fn len(&self) -> usize {
+        self.heap.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.heap.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.heap.clear();
+    }
+
+    fn push_entry(&mut self, payload: T, deadline: Instant, priority: TaskPriority) {
+        self.sequence = self.sequence.wrapping_add(1);
+        self.heap.push(HeapEntry {
+            priority,
+            deadline,
+            payload,
+            sequence: self.sequence,
+        });
+    }
+}
+
+impl<T> Default for TaskScheduler<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+struct HeapEntry<T> {
+    priority: TaskPriority,
+    deadline: Instant,
+    payload: T,
+    sequence: u64,
+}
+
+impl<T> PartialEq for HeapEntry<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.priority == other.priority
+            && self.deadline == other.deadline
+            && self.sequence == other.sequence
+    }
+}
+
+impl<T> Eq for HeapEntry<T> {}
+
+impl<T> PartialOrd for HeapEntry<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for HeapEntry<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.priority
+            .cmp(&other.priority)
+            .then_with(|| other.deadline.cmp(&self.deadline))
+            .then_with(|| other.sequence.cmp(&self.sequence))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pop_returns_highest_priority_then_deadline() {
+        let mut scheduler = TaskScheduler::new();
+        let base = Instant::now();
+        scheduler.schedule_at("low", base + Duration::from_secs(5), TaskPriority::LOW);
+        scheduler.schedule_at("high", base + Duration::from_secs(10), TaskPriority::HIGH);
+        scheduler.schedule_at("urgent", base + Duration::from_secs(2), TaskPriority::HIGH);
+
+        let ready = scheduler.pop_ready(base + Duration::from_secs(3));
+        assert_eq!(ready.unwrap().payload, "urgent");
+    }
+
+    #[test]
+    fn drain_ready_respects_deadlines() {
+        let mut scheduler = TaskScheduler::new();
+        let base = Instant::now();
+        scheduler.schedule_at(1, base + Duration::from_millis(5), TaskPriority::LOW);
+        scheduler.schedule_at(2, base + Duration::from_millis(10), TaskPriority::LOW);
+        scheduler.schedule_at(3, base + Duration::from_millis(15), TaskPriority::LOW);
+
+        let drained = scheduler.drain_ready(base + Duration::from_millis(12));
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].payload, 1);
+        assert_eq!(drained[1].payload, 2);
+    }
+
+    #[test]
+    fn schedule_in_uses_relative_deadline() {
+        let mut scheduler = TaskScheduler::new();
+        scheduler.schedule_in("soon", Duration::from_millis(5), TaskPriority::NORMAL);
+        assert!(scheduler.peek_deadline().is_some());
+        assert_eq!(scheduler.len(), 1);
+    }
+}

--- a/lib/harper-core/src/tools/filesystem.rs
+++ b/lib/harper-core/src/tools/filesystem.rs
@@ -18,6 +18,7 @@
 //! searching files with user approval.
 
 use crate::core::error::{HarperError, HarperResult};
+use crate::memory::cache::CacheAlignedBuffer;
 use crate::tools::parsing;
 use colored::*;
 use std::io::{self, Write};
@@ -90,7 +91,7 @@ pub async fn write_file(
         path.magenta()
     );
 
-    std::fs::write(path, content)
+    write_cache_aligned(path, content.as_bytes())
         .map_err(|e| HarperError::Command(format!("Failed to write file {}: {}", path, e)))?;
 
     Ok(format!(
@@ -149,8 +150,14 @@ pub async fn search_replace(
     let new_content = content.replace(old_string, new_string);
     let replacements = content.matches(old_string).count();
 
-    std::fs::write(path, &new_content)
+    write_cache_aligned(path, new_content.as_bytes())
         .map_err(|e| HarperError::Command(format!("Failed to write file {}: {}", path, e)))?;
 
     Ok(format!("Replaced {} occurrences in {}", replacements, path))
+}
+
+fn write_cache_aligned(path: &str, bytes: &[u8]) -> std::io::Result<()> {
+    let mut buffer = CacheAlignedBuffer::with_capacity(bytes.len());
+    buffer.write_bytes(bytes);
+    std::fs::write(path, buffer.as_slice())
 }


### PR DESCRIPTION
add BinaryHeap-based task scheduler and hook it into chat background workflows. introduce cache-aligned buffer utilities and reuse them for transcript exports and filesystem writes. ensure clippy/fmt clean and branch rebased onto latest main. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.

<details>
<summary>Available Bot Commands</summary>

**Cancel Runs Bot:**
- `/cancel-runs` - Cancels in-progress and queued GitHub Actions runs
- `/cancel-runs help` - Shows help for the cancel runs bot

**Rust Auto-Fix Bot:**
- `/rust-fix fmt` - Applies cargo fmt
- `/rust-fix clippy` - Applies clippy auto-fixes
- `/rust-fix all` - Applies both fmt and clippy

</details>
