### PR TITLE
[fix] collapse if blocks into match guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -4985,9 +4985,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -339,37 +339,34 @@ fn handle_enter(app: &mut TuiApp, session_service: &SessionService) -> EventResu
                 _ => {}
             }
         }
-        AppState::Chat(chat_state) => {
-            if !chat_state.input.is_empty() {
-                let message = chat_state.input.clone();
-                // Clear input
-                chat_state.input = String::new();
-                return EventResult::SendMessage(message);
-            }
+        AppState::Chat(chat_state) if !chat_state.input.is_empty() => {
+            let message = chat_state.input.clone();
+            chat_state.input = String::new();
+            return EventResult::SendMessage(message);
         }
-        AppState::Sessions(sessions, selected) => {
-            if !sessions.is_empty() && *selected < sessions.len() {
-                let session = &sessions[*selected];
-                match session_service.view_session_data(&session.id) {
-                    Ok(messages) => {
-                        app.state = AppState::Chat(create_chat_state(session.id.clone(), messages));
-                        return EventResult::GatherSidebarEntries;
-                    }
-                    Err(e) => {
-                        app.set_error_message(format!("Error loading session: {}", e));
-                    }
+        AppState::Sessions(sessions, selected)
+            if !sessions.is_empty() && *selected < sessions.len() =>
+        {
+            let session = &sessions[*selected];
+            match session_service.view_session_data(&session.id) {
+                Ok(messages) => {
+                    app.state = AppState::Chat(create_chat_state(session.id.clone(), messages));
+                    return EventResult::GatherSidebarEntries;
+                }
+                Err(e) => {
+                    app.set_error_message(format!("Error loading session: {}", e));
                 }
             }
         }
-        AppState::ExportSessions(sessions, selected) => {
-            if !sessions.is_empty() && *selected < sessions.len() {
-                let session = &sessions[*selected];
-                match session_service.export_session_by_id(&session.id) {
-                    Ok(path) => app.set_info_message(format!("Session exported to {}", path)),
-                    Err(e) => app.set_error_message(format!("Export failed: {}", e)),
-                }
-                app.state = AppState::Menu(0);
+        AppState::ExportSessions(sessions, selected)
+            if !sessions.is_empty() && *selected < sessions.len() =>
+        {
+            let session = &sessions[*selected];
+            match session_service.export_session_by_id(&session.id) {
+                Ok(path) => app.set_info_message(format!("Session exported to {}", path)),
+                Err(e) => app.set_error_message(format!("Export failed: {}", e)),
             }
+            app.state = AppState::Menu(0);
         }
         AppState::Tools(selected) => match *selected {
             0 => handle_web_search(app),

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -78,10 +78,11 @@ fi
 # 2. Clippy Linting
 echo ""
 print_status "INFO" "2. Running Clippy linter..."
-if cargo clippy --all-targets --all-features --workspace -- -D warnings 2>&1; then
+if cargo clippy --all-targets --all-features --workspace --quiet -- -D warnings 2>/dev/null; then
     print_status "PASS" "Clippy linting passed"
 else
     print_status "FAIL" "Clippy reported issues that need attention"
+    echo "→ Tip: run 'cargo clippy' locally to inspect them calmly"
     exit 1
 fi
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -78,11 +78,10 @@ fi
 # 2. Clippy Linting
 echo ""
 print_status "INFO" "2. Running Clippy linter..."
-if cargo clippy --all-targets --all-features --workspace --quiet -- -D warnings 2>/dev/null; then
+if cargo clippy --all-targets --all-features --workspace -- -D warnings 2>&1; then
     print_status "PASS" "Clippy linting passed"
 else
-print_status "FAIL" "Clippy reported issues that need attention"
-echo "→ Tip: run 'cargo clippy' locally to inspect them calmly"
+    print_status "FAIL" "Clippy reported issues that need attention"
     exit 1
 fi
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,17 +14,3 @@
 
 pub use harper_core::*;
 pub use harper_ui::*;
-
-pub fn clippy_test() {
-    let vec = [1, 2, 3];
-    for i in 0..vec.len() {
-        println!("{}", vec[i]);
-    }
-}
-
-pub fn test_function() {
-    let x = 1;
-    if x == 1 {
-        println!("x is 1");
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use harper_core::*;
 pub use harper_ui::*;
 
 pub fn clippy_test() {
-    let vec = vec![1, 2, 3];
+    let vec = [1, 2, 3];
     for i in 0..vec.len() {
         println!("{}", vec[i]);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,17 @@
 
 pub use harper_core::*;
 pub use harper_ui::*;
+
+pub fn clippy_test() {
+    let vec = vec![1, 2, 3];
+    for i in 0..vec.len() {
+        println!("{}", vec[i]);
+    }
+}
+
+pub fn test_function() {
+    let x = 1;
+    if x == 1 {
+        println!("x is 1");
+    }
+}


### PR DESCRIPTION
Fixed collapsible_match clippy warnings in harper-ui/src/interfaces/ui/`events.rs`. Collapsed if blocks into match guard expressions per Rust 1.95 clippy rules. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.