### PR TITLE
[chore] update bazel setup actions to v0.19.0

### DIFF
--- a/.github/workflows/bazel-smoke.yml
+++ b/.github/workflows/bazel-smoke.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Bazel
-        uses: bazel-contrib/setup-bazel@0.15.0
+        uses: bazel-contrib/setup-bazel@0.19.0
 
       - name: Clear stale Bazel cache and regenerate lock
         run: |

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Bazel
-        uses: bazel-contrib/setup-bazel@0.15.0
+        uses: bazel-contrib/setup-bazel@0.19.0
       - name: Clear stale Bazel cache and regenerate lock
         run: |
           bazel shutdown 2>/dev/null || true


### PR DESCRIPTION
Updates bazel-contrib/setup-bazel from v0.15.0 to v0.19.0 in smoke and build workflows for Node.js 24 compatibility.