### PR TITLE
[fix] ignore already locked error in lock-pr workflow

### DIFF
--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -14,6 +14,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Lock PR
-        run: gh pr lock ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+        run: gh pr lock ${{ github.event.pull_request.number }} --repo ${{ github.repository }} || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `lock-merged-prs` workflow fails when a PR is already locked, causing unnecessary CI failures.

```
gh pr lock 234 --repo harpertoken/harper
already locked
Process completed with exit code 1.
```

## Fix

Added `|| true` to ignore the "already locked" error gracefully.