### PR TITLE
[fix] ignore already locked error in post-merge-ci

### DIFF
--- a/.github/workflows/post-auto-merge-ci.yml
+++ b/.github/workflows/post-auto-merge-ci.yml
@@ -79,7 +79,7 @@ jobs:
             core.setFailed(`PR #${prNumber} was not merged within the wait window.`);
       - name: Lock merged PR
         if: steps.pr.outputs.skip != 'true'
-        run: gh pr lock ${{ steps.pr.outputs.pr_number }} --repo ${{ github.repository }}
+        run: gh pr lock ${{ steps.pr.outputs.pr_number }} --repo ${{ github.repository }} || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Apply same fix as lock-merged-prs workflow to post-auto-merge-ci workflow.