### PR TITLE
[fix] remove localhost url from test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -612,7 +612,6 @@ path = '{}'
 
 [mcp]
 enabled = false
-server_url = "http://localhost:5000"
 "#,
             db_path.display()
         );


### PR DESCRIPTION
Removed hardcoded localhost URL from integration test config to address scaling concerns. Since MCP is disabled in the test, the server_url was unused. Prevents potential debug code flags for accessing localhost in production environments. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.