### PR TITLE
[ci] macos job to bazel build workflow

### DIFF
--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -21,10 +21,49 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'harpertoken'
     steps:
+    - uses: actions/checkout@v6
+    - name: Set up Bazel
+      uses: bazel-contrib/setup-bazel@0.19.0
+    - name: Clear stale Bazel cache and regenerate lock
+      run: |
+        bazel shutdown 2>/dev/null || true
+        rm -rf /home/runner/.cache/bazel /home/runner/.cache/bazelisk /home/runner/.bazel /home/runner/.bazelrc
+        rm -rf /home/runner/.cache/bazel-external /home/runner/.bazel/external
+        rm -rf .bazelrc .bazeliskrc "$HOME"/.bazel* 2>/dev/null || true
+        rm -rf /tmp/*bazel* 2>/dev/null || true
+        rm -f cargo-bazel-lock.json
+    - name: Build with Bazel
+      run: CARGO_BAZEL_REPIN=1 bazel build :harper_bin
+    - name: Test with Bazel
+      run: bazel test //...
+    - name: Test Bazel build
+      run: bazel run :harper_bin -- --version
+
+  build-macos:
+    runs-on: macos-latest
+    if: github.repository_owner == 'harpertoken'
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Bazel
+      uses: bazel-contrib/setup-bazel@0.19.0
+    - name: Clear stale Bazel cache and regenerate lock
+      run: |
+        bazel shutdown 2>/dev/null || true
+        rm -rf /Users/runner/.cache/bazel /Users/runner/.cache/bazelisk /Users/runner/.bazel /Users/runner/.bazelrc
+        rm -rf /Users/runner/.cache/bazel-external /Users/runner/.bazel/external
+        rm -rf .bazelrc .bazeliskrc "$HOME"/.bazel* 2>/dev/null || true
+        rm -rf /tmp/*bazel* 2>/dev/null || true
+        rm -f cargo-bazel-lock.json
+    - name: Build with Bazel
+      run: CARGO_BAZEL_REPIN=1 bazel build :harper_bin
+    - name: Test with Bazel
+      run: bazel test //...
+    - name: Test Bazel build
+      run: bazel run :harper_bin -- --version
     - uses: actions/checkout@v6
     - name: Set up Bazel
       uses: bazel-contrib/setup-bazel@0.19.0


### PR DESCRIPTION
- Added a new `build-macos` job to the Bazel CI workflow to run on macOS (darwin target triple).
- Ensures Bazel builds and tests work on macOS platforms.
- Linux job renamed to `build-linux` for clarity.

## Note on PR Title
The PR title follows the conventional format enforced by the libnudget/title GitHub Action (used in fix-pr-title.yml). This action automatically formats titles to [scope] description and removes 'add' prefixes entirely from the message (e.g., `[ci] add macos job` → `[ci] macos job`). The title was updated accordingly.