### PR TITLE
[chore] enable clippy pedantic warnings, allow in validate script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ num_cpus = "1.16"
 serde_json = "1.0.140"
 
 # The profile that 'dist' will build with
+[lints.clippy]
+pedantic = "warn"
+
 [profile.dist]
 inherits = "release"
 lto = "fat"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -78,7 +78,7 @@ fi
 # 2. Clippy Linting
 echo ""
 print_status "INFO" "2. Running Clippy linter..."
-if cargo clippy --all-targets --all-features --workspace --quiet -- -D warnings 2>/dev/null; then
+if cargo clippy --all-targets --all-features --workspace --quiet -- -A clippy::pedantic -D warnings 2>/dev/null; then
     print_status "PASS" "Clippy linting passed"
 else
     print_status "FAIL" "Clippy reported issues that need attention"


### PR DESCRIPTION
Enabled Clippy's `pedantic` category as warnings in `Cargo.toml`. Modified CI validation script to allow pedantic warnings (-A clippy::pedantic) while treating other warnings as errors. This surfaces pedantic suggestions without blocking CI, enabling gradual code quality improvements. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.