### PR TITLE
[chore] fix clippy warnings and update wasip2 to 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5069,11 +5069,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -5082,7 +5082,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5633,6 +5633,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -159,6 +159,7 @@ fn test_message_validation() {
 }
 
 #[test]
+#[allow(clippy::ignored_unit_patterns)]
 fn test_concurrent_database_access() {
     use std::thread;
     use std::time::Duration;
@@ -185,7 +186,7 @@ fn test_concurrent_database_access() {
                             retries += 1;
                             thread::sleep(Duration::from_millis(50));
                         }
-                        Err(e) => panic!("Failed to save session: {:?}", e),
+                        Err(e) => panic!("Failed to save session: {e:?}"),
                     }
                 }
 
@@ -203,7 +204,7 @@ fn test_concurrent_database_access() {
                                 retries += 1;
                                 thread::sleep(Duration::from_millis(50));
                             }
-                            Err(e) => panic!("Failed to save message: {:?}", e),
+                            Err(e) => panic!("Failed to save message: {e:?}"),
                         }
                     }
                     thread::sleep(Duration::from_millis(10));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -25,11 +25,11 @@ mod performance_test;
 #[path = "integration/security_test.rs"]
 mod security_test;
 
-lazy_static::lazy_static! {
-    static ref TIMESTAMP_REGEX: Regex = Regex::new(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$").unwrap();
-}
+static TIMESTAMP_REGEX: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$").unwrap());
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn test_database_operations() {
     let temp_file = NamedTempFile::new().unwrap();
     let conn = Connection::open(temp_file.path()).unwrap();
@@ -104,11 +104,10 @@ fn test_database_operations() {
         &"a".repeat(100), // Test with long session ID
     ];
 
-    for &session_id in test_sessions.iter() {
-        // Test session creation
+    for session_id in &test_sessions {
+        let session_id: &str = session_id;
         save_session(&conn, session_id).unwrap();
 
-        // Verify session was created with correct ID
         let stored_id: String = conn
             .query_row(
                 "SELECT id FROM sessions WHERE id = ?",
@@ -252,20 +251,18 @@ fn test_database_operations() {
 }
 
 #[test]
+#[allow(clippy::items_after_statements)]
 fn test_concurrent_access() {
-    // Skip this test in CI to avoid segfaults
+    use std::sync::Arc;
+
     if std::env::var("CI").is_ok() {
         println!("Skipping concurrent access test in CI environment");
         return;
     }
 
-    use std::sync::Arc;
-
-    // Create a temporary database file
     let temp_file = NamedTempFile::new().unwrap();
     let db_path = temp_file.path().to_path_buf();
 
-    // Initialize the database
     {
         let conn = Connection::open(&db_path).unwrap();
         init_db(&conn).unwrap();
@@ -273,13 +270,11 @@ fn test_concurrent_access() {
 
     let db_path = Arc::new(db_path);
 
-    // Reduced thread count and operations to minimize segfault risk
+    let mut handles = vec![];
+
     const NUM_THREADS: usize = 2;
     const OPS_PER_THREAD: usize = 5;
 
-    let mut handles = vec![];
-
-    // Spawn worker threads
     for thread_id in 0..NUM_THREADS {
         let db_path = Arc::clone(&db_path);
 
@@ -288,24 +283,24 @@ fn test_concurrent_access() {
 
             // Simple operations without complex random access
             for op in 0..OPS_PER_THREAD {
-                let session_id = format!("session-{}-{}", thread_id, op);
+                let session_id = format!("session-{thread_id}-{op}");
 
                 // Create session
                 if let Err(e) = save_session(&conn, &session_id) {
                     if e.to_string().contains("database is locked") {
-                        println!("Warning: Failed to save session due to lock: {}", e);
+                        println!("Warning: Failed to save session due to lock: {e}");
                         continue;
                     }
-                    panic!("Unexpected error during save_session: {}", e);
+                    panic!("Unexpected error during save_session: {e}");
                 }
 
                 // Add a message
-                let content = format!("Message {} from thread {}", op, thread_id);
+                let content = format!("Message {op} from thread {thread_id}");
                 if let Err(e) = save_message(&conn, &session_id, "user", &content) {
                     if e.to_string().contains("database is locked") {
-                        println!("Warning: Failed to save message due to lock: {}", e);
+                        println!("Warning: Failed to save message due to lock: {e}");
                     } else {
-                        panic!("Unexpected error during save_message: {}", e);
+                        panic!("Unexpected error during save_message: {e}");
                     }
                 }
             }
@@ -386,7 +381,7 @@ async fn test_web_search_mock() {
         }
         Err(e) => {
             // If it fails locally, it's unexpected - fail the test
-            panic!("Web search failed unexpectedly: {:?}", e);
+            panic!("Web search failed unexpectedly: {e:?}");
         }
     }
 }
@@ -483,16 +478,16 @@ mod e2e_tests {
         let mut stmt = conn
             .prepare("SELECT id FROM sessions ORDER BY created_at DESC")
             .unwrap();
-        let sessions: Vec<String> = stmt
+        let session_ids: Vec<String> = stmt
             .query_map([], |row| row.get(0))
             .unwrap()
             .map(|r| r.unwrap())
             .collect();
 
-        assert_eq!(sessions.len(), 2, "Should retrieve both sessions");
+        assert_eq!(session_ids.len(), 2, "Should retrieve both sessions");
         // The order might vary, but both should be present
-        assert!(sessions.contains(&session1.to_string()));
-        assert!(sessions.contains(&session2.to_string()));
+        assert!(session_ids.contains(&session1.to_string()));
+        assert!(session_ids.contains(&session2.to_string()));
     }
 
     #[test]
@@ -575,6 +570,7 @@ mod e2e_tests {
 
     #[cfg(not(target_os = "windows"))]
     #[test]
+    #[allow(clippy::too_many_lines, clippy::items_after_statements)]
     fn test_binary_execution_e2e() {
         use std::fs;
         use std::process::{Command, Stdio};
@@ -712,12 +708,12 @@ enabled = false
             "
 === Running Command ==="
         );
-        println!("Command: {:?}", command);
+        println!("Command: {command:?}");
         println!("Working directory: {}", temp_dir.path().display());
         println!("Config file: {}", config_path.display());
         println!("Database path in config: {}", db_path.display());
 
-        println!("Running command: {:?}", command);
+        println!("Running command: {command:?}");
 
         // Ensure DATABASE_PATH is not set to avoid overriding config
         std::env::remove_var("DATABASE_PATH");
@@ -725,22 +721,18 @@ enabled = false
         let mut child = command.spawn().expect("Failed to start binary");
 
         // Send quit command using the constant
-        use harper_workspace::core::constants::{menu, messages};
+        use harper_core::core::constants::menu::QUIT;
+        use harper_core::core::constants::messages::GOODBYE;
 
-        let quit_command = format!(
-            "{}
-",
-            menu::QUIT
-        );
+        let quit_command = format!("{QUIT}\n");
         println!("Sending quit command: {:?}", quit_command.trim());
 
         if let Some(mut stdin) = child.stdin.take() {
             use std::io::Write;
-            // Use the QUIT constant and add newline
+
             stdin
                 .write_all(quit_command.as_bytes())
                 .expect("Failed to write to stdin");
-            // Explicitly flush the stdin to ensure the command is sent
             stdin.flush().expect("Failed to flush stdin");
         }
 
@@ -754,7 +746,7 @@ enabled = false
         ) {
             Ok(Some(status)) => {
                 // Process has finished
-                println!("Process finished with status: {}", status);
+                println!("Process finished with status: {status}");
                 child.wait_with_output().expect("Failed to wait for child")
             }
             Ok(None) => {
@@ -764,7 +756,7 @@ enabled = false
                 child.wait_with_output().expect("Failed to wait for child")
             }
             Err(e) => {
-                panic!("Error waiting for child process: {}", e);
+                panic!("Error waiting for child process: {e}");
             }
         };
 
@@ -774,33 +766,28 @@ enabled = false
 
         println!(
             "=== STDOUT ===
-{}",
-            stdout
+{stdout}"
         );
         println!(
             "=== STDERR ===
-{}",
-            stderr
+{stderr}"
         );
 
-        // Check if the process exited successfully
-        if !output.status.success() {
-            panic!("Process exited with status: {}", output.status);
-        }
+        assert!(
+            output.status.success(),
+            "Process exited with status: {}",
+            output.status
+        );
 
-        // Check for the goodbye message in the output (only for text menu mode)
-        // If TUI mode failed (indicated by TUI error in stderr), don't expect goodbye
-        if !stderr.contains("TUI error") {
-            assert!(
-                stdout.contains(messages::GOODBYE),
-                "Should print goodbye message. Expected '{}' in output.
-Full output:
-{}",
-                messages::GOODBYE,
-                stdout
-            );
-        } else {
+        if stderr.contains("TUI error") {
             println!("TUI mode failed as expected in test environment, skipping goodbye check");
+        } else {
+            assert!(
+                stdout.contains(GOODBYE),
+                "Should print goodbye message. Expected '{GOODBYE}' in output.
+Full output:
+{stdout}"
+            );
         }
     }
 

--- a/tests/integration/performance_test.rs
+++ b/tests/integration/performance_test.rs
@@ -40,12 +40,12 @@ fn setup_database(size: usize) -> (Connection, String) {
     (conn, temp_file.path().to_str().unwrap().to_string())
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::cast_sign_loss)]
 fn save_messages_benchmark(c: &mut Criterion) {
     let sizes = [1, 10, 100, 1000];
 
     for &size in &sizes {
-        let mut group = c.benchmark_group(format!("save_message_{}", size));
+        let mut group = c.benchmark_group(format!("save_message_{size}"));
 
         group.throughput(Throughput::Elements(size as u64));
 
@@ -61,13 +61,13 @@ fn save_messages_benchmark(c: &mut Criterion) {
                             &conn,
                             "bench-session",
                             if i % 2 == 0 { "user" } else { "assistant" },
-                            &format!("Message {}", i),
+                            &format!("Message {i}"),
                         )
                         .unwrap();
                     }
                 },
                 BatchSize::PerIteration,
-            )
+            );
         });
 
         group.finish();
@@ -79,7 +79,7 @@ fn load_history_benchmark(c: &mut Criterion) {
     let sizes = [1, 10, 100, 1000, 10_000];
 
     for &size in &sizes {
-        let mut group = c.benchmark_group(format!("load_history_{}", size));
+        let mut group = c.benchmark_group(format!("load_history_{size}"));
         group.sample_size(10);
 
         let (conn, _) = setup_database(size);
@@ -89,12 +89,11 @@ fn load_history_benchmark(c: &mut Criterion) {
                 let history = load_history(&conn, "bench-session").unwrap();
                 assert_eq!(history.len(), size);
                 black_box(history);
-            })
+            });
         });
 
         group.bench_function("load_paginated", |b| {
             b.iter(|| {
-                // Simulate loading in pages of 100
                 let page_size = 100;
                 let pages = size.div_ceil(page_size);
 
@@ -102,7 +101,6 @@ fn load_history_benchmark(c: &mut Criterion) {
                     let offset = page * page_size;
                     let limit = page_size.min(size - offset);
 
-                    // In a real implementation, you would modify load_history to support pagination
                     let history = load_history(&conn, "bench-session").unwrap();
                     let page_data = history
                         .into_iter()
@@ -112,7 +110,7 @@ fn load_history_benchmark(c: &mut Criterion) {
                     assert!(page_data.len() <= page_size);
                     black_box(page_data);
                 }
-            })
+            });
         });
 
         group.finish();
@@ -160,7 +158,7 @@ fn concurrent_access_benchmark(c: &mut Criterion) {
                 }
             },
             BatchSize::PerIteration,
-        )
+        );
     });
 }
 
@@ -169,7 +167,7 @@ fn large_message_benchmark(c: &mut Criterion) {
     let sizes = [1_000, 10_000, 100_000];
 
     for &size in &sizes {
-        let mut group = c.benchmark_group(format!("large_message_{}", size));
+        let mut group = c.benchmark_group(format!("large_message_{size}"));
 
         group.throughput(Throughput::Elements(1));
         group.sample_size(10);
@@ -188,7 +186,7 @@ fn large_message_benchmark(c: &mut Criterion) {
                     save_message(&conn, "bench-session", "user", &large_content).unwrap();
                 },
                 BatchSize::PerIteration,
-            )
+            );
         });
 
         group.finish();

--- a/tests/integration/security_test.rs
+++ b/tests/integration/security_test.rs
@@ -44,19 +44,18 @@ fn test_sql_injection_protection() {
             )
             .unwrap();
 
-        assert_eq!(count, 1, "Failed test case {}: {}", i, malicious_input);
+        assert_eq!(count, 1, "Failed test case {i}: {malicious_input}");
 
         // Test message content injection
         let result = save_message(
             &conn,
             malicious_input,
             "user",
-            &format!("Test message with SQL: {}", malicious_input),
+            &format!("Test message with SQL: {malicious_input}"),
         );
         assert!(
             result.is_ok(),
-            "Failed to save message with SQL injection attempt: {}",
-            malicious_input
+            "Failed to save message with SQL injection attempt: {malicious_input}"
         );
     }
 }
@@ -84,12 +83,11 @@ fn test_path_traversal_protection() {
 
     for (i, path) in test_cases.iter().enumerate() {
         // Test with path in session ID
-        let session_id = format!("session-{}-{}", i, path);
+        let session_id = format!("session-{i}-{path}");
         let save_result = save_session(&conn, &session_id);
         assert!(
             save_result.is_ok(),
-            "Should be able to save session with path-like ID: {}",
-            path
+            "Should be able to save session with path-like ID: {path}"
         );
 
         // Verify the session was created with the exact ID
@@ -100,19 +98,18 @@ fn test_path_traversal_protection() {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(count, 1, "Session with path-like ID not found: {}", path);
+        assert_eq!(count, 1, "Session with path-like ID not found: {path}");
 
         // Test with path in message content
         let message_result = save_message(
             &conn,
             &session_id,
             "user",
-            &format!("Test message with path: {}", path),
+            &format!("Test message with path: {path}"),
         );
         assert!(
             message_result.is_ok(),
-            "Should be able to save message with path-like content: {}",
-            path
+            "Should be able to save message with path-like content: {path}"
         );
 
         // Clean up
@@ -134,8 +131,7 @@ fn test_path_traversal_protection() {
                 std::fs::canonicalize(path).unwrap_or_else(|_| std::path::PathBuf::from(path));
             assert!(
                 !canonical_path.starts_with(&base_path),
-                "Path traversal vulnerability detected: {} is accessible and inside temp dir",
-                path
+                "Path traversal vulnerability detected: {path} is accessible and inside temp dir"
             );
         }
     }
@@ -177,23 +173,18 @@ fn test_xss_protection() {
         // Note: XSS protection should be handled at the application level when displaying content
         assert_eq!(
             last_message.content, *payload,
-            "Message content was modified in test case {}: {}",
-            i, payload
+            "Message content was modified in test case {i}: {payload}"
         );
 
-        // The role should be one of the allowed values
         assert!(
             ["user", "assistant", "system"].contains(&last_message.role.as_str()),
-            "Invalid role in test case {}: {}",
-            i,
+            "Invalid role in test case {i}: {}",
             last_message.role
         );
 
-        // Verify the message is in the history
         assert!(
             history.iter().any(|m| m.content == *payload),
-            "Message with payload not found in history: {}",
-            payload
+            "Message with payload not found in history: {payload}"
         );
     }
 }

--- a/tests/session_service_test.rs
+++ b/tests/session_service_test.rs
@@ -69,7 +69,7 @@ impl Output for MockOutput {
     }
 
     fn println(&self, text: &str) -> HarperResult<()> {
-        self.buffer.lock().unwrap().push(format!("{}\n", text));
+        self.buffer.lock().unwrap().push(format!("{text}\n"));
         Ok(())
     }
 


### PR DESCRIPTION
Fix clippy pedantic errors in test files (`integration.rs`, `error_handling_test.rs`, `session_service_test.rs`). Replace deprecated `lazy_static` with `std::sync::LazyLock`. Fix format strings to use inline variable syntax (`{var}` instead of `{}`). Add necessary allow attributes for unavoidable warnings. Rename variable to fix similar-names clippy warning. This is a follow-up to PR #246 which enabled pedantic warnings in CI. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.