### PR TITLE
[dev] bubblewrap in devcontainer, readme with sandbox info

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,18 @@
+# Dev Container
+
+Built on Debian Bookworm with Rust. Installs:
+
+- `libsqlite3-dev` - for rusqlite
+- `pkg-config` - build helper
+- `bubblewrap` - sandbox isolation
+
+## What It Does
+
+Provides a reproducible development environment with the exact dependencies Harper needs.
+
+## Helpful
+
+- Open in VS Code: `Cmd+Shift+P` → "Rebuild and Reopen in Container"
+- Or use GitHub Codespaces
+- Extensions auto-install (rust-analyzer, even-better-toml, vscode-json)
+- Clippy runs on save via `rust-analyzer.checkOnSave.command`

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/git:1": {}
   },
-  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y libsqlite3-dev pkg-config",
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y libsqlite3-dev pkg-config bubblewrap",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "harper-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aes",
  "arboard",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "harper-ui"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ cp .env.example .env
 cargo run -p harper-ui --bin harper
 ```
 
+Running in a sandbox (bubblewrap on Linux, sandbox-exec on macOS) isolates shell commands for safety.
+
 Pick your AI provider in the config file. If you want offline mode, set up Ollama first, then point Harper to it.
 
 When you're working on Harper itself, run `cargo fmt` to format, `cargo clippy --all-targets --all-features` to lint, and `cargo test` to test.


### PR DESCRIPTION
add bubblewrap to devcontainer postCreateCommand for sandbox support. add .devcontainer/README with helpful info. update README to mention sandbox isolation. update Cargo.lock from upstream. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.