### PR TITLE
[chore] copyright 2026 fix and skill templates

### DIFF
--- a/.agents/skills/commit.md
+++ b/.agents/skills/commit.md
@@ -1,0 +1,42 @@
+---
+name: commit
+description: Git commit workflow
+---
+
+# Git Commit Workflow
+
+See AGENTS.md for commit guidelines.
+
+## Before Committing
+- `git status` - review changes
+- `git diff` - see unstaged changes
+- `git diff --staged` - see staged changes
+
+## Stage Files
+- `git add <file>` - stage specific file
+- `git add .` - stage all changes
+- `git add -p` - stage interactively
+
+## Commit
+```bash
+git commit -m "type: description"
+```
+
+## Commit Types
+- `[feat]` - new feature
+- `[fix]` - bug fix
+- `[docs]` - documentation
+- `[chore]` - maintenance
+- `[refactor]` - code refactoring
+- `[test]` - tests
+- `[perf]` - performance
+- `[style]` - formatting
+
+## Amend Last Commit
+- `git commit --amend`
+- Only amend unpushed commits
+
+## Tips
+- Keep commits atomic
+- Write descriptive messages
+- First line: 72 chars max

--- a/.agents/skills/docs.md
+++ b/.agents/skills/docs.md
@@ -1,0 +1,23 @@
+---
+name: docs
+description: Build and serve documentation
+---
+
+# Documentation
+
+## Serve Locally
+- `mkdocs serve`
+
+## Build
+- `mkdocs build`
+
+## Deploy (on main)
+- `mkdocs gh-deploy`
+
+## Check Links
+- `mkdocs build --strict`
+
+## Key Docs
+- `docs/` - documentation files
+- `website/` - website source
+- `mkdocs.yml` - mkdocs configuration

--- a/.agents/skills/launch.md
+++ b/.agents/skills/launch.md
@@ -1,43 +1,29 @@
-<!--
-Copyright 2026 harpertoken
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-
+---
 name: launch
 description: Build and launch Harper with checks
-entrypoint: |
-  # Build and Launch Harper
+---
 
-  See AGENTS.md for full guidelines on file operations, security, and coding conventions.
+# Build and Launch Harper
 
-  ## Pre-flight Checks
-  - Run: `cargo check`
-  - Run clippy: `cargo clippy -- -D warnings`
-  - Check fmt: `cargo fmt -- --check`
-  - Run tests: `cargo test`
+See AGENTS.md for full guidelines on file operations, security, and coding conventions.
 
-  ## Build
-  - Release: `cargo build --release`
-  - Or Bazel: `bazel build //...`
+## Pre-flight Checks
+- Run: `cargo check`
+- Run clippy: `cargo clippy -- -D warnings`
+- Check fmt: `cargo fmt -- --check`
+- Run tests: `cargo test`
 
-  ## Launch
-  - Run binary with appropriate flags
+## Build
+- Release: `cargo build --release`
+- Or Bazel: `bazel build //...`
 
-  ## Core Guidelines (see AGENTS.md for details)
-  - Read only within project scope
-  - Require user consent for writes
-  - Never delete; use git operations
-  - Use Result/Option over unwrap()
-  - Prefer structs/enums over inheritance
-  - Use iterator methods (.map, .filter, .fold)
+## Launch
+- Run binary with appropriate flags
+
+## Core Guidelines (see AGENTS.md for details)
+- Read only within project scope
+- Require user consent for writes
+- Never delete; use git operations
+- Use Result/Option over unwrap()
+- Prefer structs/enums over inheritance
+- Use iterator methods (.map, .filter, .fold)

--- a/.agents/skills/lint.md
+++ b/.agents/skills/lint.md
@@ -1,0 +1,23 @@
+---
+name: lint
+description: Lint and format Harper codebase
+---
+
+# Lint and Format
+
+## Format Check
+- `cargo fmt -- --check`
+
+## Format Fix
+- `cargo fmt`
+
+## Clippy Lints
+- `cargo clippy -- -D warnings`
+
+## All Checks
+- `cargo check`
+- `cargo clippy -- -D warnings`
+- `cargo fmt -- --check`
+
+## Fix Warnings
+- `cargo clippy --fix -- -D warnings`

--- a/.agents/skills/pr.md
+++ b/.agents/skills/pr.md
@@ -1,0 +1,31 @@
+---
+name: pr
+description: Pull request workflow
+---
+
+# Pull Request Workflow
+
+See AGENTS.md for full PR guidelines.
+
+## Before Creating PR
+- `git diff` - review changes
+- `git log --oneline -5` - review commits
+- Ensure all checks pass
+
+## Create PR
+```bash
+gh pr create --title "[scope] description" --body "## Summary"
+```
+
+## PR Title Format
+- `[feat]` - new feature
+- `[fix]` - bug fix
+- `[docs]` - documentation
+- `[chore]` - maintenance
+- `[refactor]` - code refactoring
+- `[test]` - tests
+
+## After PR
+- `gh pr status` - check status
+- Address review comments
+- Squash commits if needed

--- a/.agents/skills/test.md
+++ b/.agents/skills/test.md
@@ -1,0 +1,25 @@
+---
+name: test
+description: Run tests for Harper
+---
+
+# Run Tests
+
+## Unit Tests
+- Run: `cargo test`
+
+## With Output
+- `cargo test -- --nocapture`
+
+## Specific Test
+- `cargo test <test_name>`
+
+## Integration Tests
+- `cargo test --test integration`
+- `cargo test --test integration_cli`
+
+## All Tests (including benchmarks)
+- `cargo test --all`
+
+## With Coverage
+- `cargo tarpaulin --out Html`

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [advisories]
 ignore = [
     "RUSTSEC-2025-0141", # bincode unmaintained

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [build]
 rustflags = ["-D", "warnings"]
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #:schema https://openai.com/schemas/codex/config.json
 
 # Project-scoped Codex CLI settings for this repo.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Bug Report
 description: Report a bug
 labels: ["bug"]

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Feature Request
 description: Suggest a new feature
 labels: ["enhancement"]

--- a/.github/actions/pr/action.yml
+++ b/.github/actions/pr/action.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: "PR checks"
 description: "Basic PR validation for harpertoken"
 inputs:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 version: 2
 updates:
   - package-ecosystem: cargo

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Auto Merge
 
 on:

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/cancel-runs.yml
+++ b/.github/workflows/cancel-runs.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Cancel Runs Bot
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: CodeQL
 
 on:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Dependency Review
 on: [pull_request]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Docs
 
 on:

--- a/.github/workflows/fix-pr-title.yml
+++ b/.github/workflows/fix-pr-title.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Fix PR Title
 
 on:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Label Sync
 on:
   schedule:

--- a/.github/workflows/lock-merged-prs.yml
+++ b/.github/workflows/lock-merged-prs.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Lock Merged PRs
 
 on:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Nightly
 
 on:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Release
 
 on:

--- a/.github/workflows/rust-auto-fix.yml
+++ b/.github/workflows/rust-auto-fix.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Rust Auto-Fix Bot
 on:
   issue_comment:

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Update Rust lockfiles
 
 on:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: Deploy Website
 
 on:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 queue_rules:
   - name: default
     conditions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Rust formatting configuration
 edition = "2021"
 max_width = 100

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help test build clean fmt lint doc install run dev check all
 
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/commitlint.config.js
+++ b/ci/commitlint.config.js
@@ -1,4 +1,4 @@
-// Copyright 2025 harpertoken
+// Copyright 2026 harpertoken
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/config/docker.toml
+++ b/config/docker.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Docker configuration - sandbox enabled by default
 # This file is automatically used when running in Docker
 

--- a/config/labeler.yml
+++ b/config/labeler.yml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 "area: core":
   - changed-files:
       - any-glob-to-any-file: ["src/core/**", "lib/harper-core/**"]

--- a/config/local.toml
+++ b/config/local.toml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [ advisories ]
 # Multiple dependencies are unmaintained but pose no security risk
 # This is acceptable as it's not a security vulnerability

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [workspace]
 members = ["cargo:."]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/harpertest
+++ b/harpertest
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [package]
 name = "harper-core"
 version = "0.9.0"

--- a/lib/harper-firmware/Cargo.toml
+++ b/lib/harper-firmware/Cargo.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [package]
 name = "harper-firmware"
 version = "0.1.0"

--- a/lib/harper-mcp-server/Cargo.toml
+++ b/lib/harper-mcp-server/Cargo.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [package]
 name = "harper-mcp-server"
 version = "0.1.0"

--- a/lib/harper-sandbox/Cargo.toml
+++ b/lib/harper-sandbox/Cargo.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [package]
 name = "harper-sandbox"
 version = "0.1.0"

--- a/lib/harper-ui/Cargo.toml
+++ b/lib/harper-ui/Cargo.toml
@@ -1,3 +1,16 @@
+# Copyright 2026 harpertoken
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [package]
 name = "harper-ui"
 version = "0.8.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/rewrite_msg.sh
+++ b/scripts/rewrite_msg.sh
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update copyright year to 2026 for all project files. Add missing SPDX headers to workflows and config files. Add skill templates for test, lint, pr, docs, commit. Fix `launch.md` format. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.