### PR TITLE
[fix] update comment with run id inline

### DIFF
--- a/.github/workflows/cancel-runs.yml
+++ b/.github/workflows/cancel-runs.yml
@@ -73,13 +73,30 @@ jobs:
         pr_number: ${{ github.event.pull_request.number }}
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Post comment
+    - name: Update or create comment
       uses: actions/github-script@v7
       with:
         script: |
-          await github.rest.issues.createComment({
+          const comments = await github.rest.issues.listComments({
             issue_number: context.payload.pull_request.number,
             owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'Cancelled workflow runs for this PR'
+            repo: context.repo.repo
           });
+          const existing = comments.data.find(c => c.body.startsWith('Cancelled workflow runs: #'));
+          const runId = context.runId;
+          const body = `Cancelled workflow runs: #${runId}`;
+          if (existing) {
+            await github.rest.issues.updateComment({
+              comment_id: existing.id,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+          } else {
+            await github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+          }


### PR DESCRIPTION
Update cancel-runs label trigger to update existing comment with run ID instead of creating duplicates