### PR TITLE
[chore] upgrade turul-mcp-json-rpc-server to 0.3.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "turul-mcp-json-rpc-server 0.2.1",
+ "turul-mcp-json-rpc-server",
 ]
 
 [[package]]
@@ -4868,22 +4868,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "turul-mcp-json-rpc-server 0.3.34",
+ "turul-mcp-json-rpc-server",
  "turul-mcp-protocol",
  "url",
-]
-
-[[package]]
-name = "turul-mcp-json-rpc-server"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e22c571a9f644544e13ef86b3e9ac306e648ebb54c0d5f5031465999348d1c"
-dependencies = [
- "async-trait",
- "futures",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4918,7 +4905,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "turul-mcp-json-rpc-server 0.3.34",
+ "turul-mcp-json-rpc-server",
 ]
 
 [[package]]

--- a/lib/harper-mcp-server/Cargo.toml
+++ b/lib/harper-mcp-server/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/harpertoken/harper"
 homepage = "https://github.com/harpertoken/harper"
 
 [dependencies]
-turul-mcp-json-rpc-server = "0.2.1"
+turul-mcp-json-rpc-server = "0.3.34"
 tokio = { version = "^1.48", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"


### PR DESCRIPTION
Upgrade `turul-mcp-json-rpc-server` from `0.2.1` to `0.3.34` in harper-mcp-server. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.