### PR TITLE
[fix] use result type in tests instead of unwrap/expect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,9 +2452,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/lib/harper-core/src/lib.rs
+++ b/lib/harper-core/src/lib.rs
@@ -54,11 +54,24 @@ pub use crate::runtime::scheduler::TaskScheduler;
 #[cfg(test)]
 mod tests {
     use super::*;
-    // Use full paths in tests to avoid conflicts
-    use crate::agent::chat::ChatService;
-    use crate::core::error::HarperError;
-    // use crate::interfaces::ui::events::save_image_to_temp;
-    // use ::image::open as image_open;
+    use rusqlite::Connection;
+    use tempfile::NamedTempFile;
+
+    fn setup_test_db() -> Result<(NamedTempFile, Connection), Box<dyn std::error::Error>> {
+        let temp_file = NamedTempFile::new()?;
+        let conn = Connection::open(temp_file.path())?;
+        init_db(&conn)?;
+        Ok((temp_file, conn))
+    }
+
+    fn default_api_config() -> ApiConfig {
+        ApiConfig {
+            provider: ApiProvider::OpenAI,
+            api_key: "test-key".to_string(),
+            base_url: "https://api.openai.com/v1/chat/completions".to_string(),
+            model_name: "gpt-4".to_string(),
+        }
+    }
 
     #[test]
     fn test_api_provider_variants() {
@@ -130,219 +143,145 @@ mod tests {
         assert_eq!(format!("{}", db_error), "Database error: test db error");
     }
 
-    // Config validation tests are disabled due to import conflicts in test scope
-    // These tests would validate configuration parsing and validation logic
-
     #[tokio::test]
-    async fn test_chat_service_build_system_prompt() {
-        use rusqlite::Connection;
-        use tempfile::NamedTempFile;
-
-        let temp_file = NamedTempFile::new().expect("Failed to create temp file for test");
-        let conn = Connection::open(temp_file.path()).expect("Failed to open test database");
-        init_db(&conn).expect("Failed to initialize test database");
-
-        let config = ApiConfig {
-            provider: ApiProvider::OpenAI,
-            api_key: "test-key".to_string(),
-            base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-            model_name: "gpt-4".to_string(),
-        };
-
+    async fn test_chat_service_build_system_prompt() -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp, conn) = setup_test_db()?;
+        let config = default_api_config();
         let chat_service = ChatService::new_test(&conn, &config);
 
-        // Test without web search
         let prompt = chat_service.build_system_prompt(false).await;
         assert!(prompt.contains("gpt-4"));
-        assert!(prompt.contains("run_command")); // Tools are always available now
+        assert!(prompt.contains("run_command"));
         assert!(!prompt.contains("SEARCH:"));
 
-        // Test with web search
         let prompt = chat_service.build_system_prompt(true).await;
         assert!(prompt.contains("gpt-4"));
         assert!(prompt.contains("run_command"));
         assert!(prompt.contains("SEARCH:"));
+        Ok(())
     }
 
     #[test]
-    fn test_preprocess_file_references() {
-        use rusqlite::Connection;
-        use tempfile::NamedTempFile;
-
-        let temp_file = NamedTempFile::new().expect("Failed to create temp file for test");
-        let conn = Connection::open(temp_file.path()).expect("Failed to open test database");
-        init_db(&conn).expect("Failed to initialize test database");
-
-        let config = ApiConfig {
-            provider: ApiProvider::OpenAI,
-            api_key: "test-key".to_string(),
-            base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-            model_name: "gpt-4".to_string(),
-        };
-
+    fn test_preprocess_file_references() -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp, conn) = setup_test_db()?;
+        let config = default_api_config();
         let chat_service = ChatService::new_test(&conn, &config);
 
-        // Test basic file reference
-        let result = chat_service.preprocess_file_references("Check this file @src/main.rs");
-        assert_eq!(result, "Check this file [READ_FILE src/main.rs]");
-
-        // Test file reference at start
-        let result = chat_service.preprocess_file_references("@Cargo.toml please");
-        assert_eq!(result, "[READ_FILE Cargo.toml] please");
-
-        // Test multiple @ symbols (should process all file references)
-        let result = chat_service.preprocess_file_references("Look at @file1.txt and @file2.txt");
         assert_eq!(
-            result,
+            chat_service.preprocess_file_references("Check this file @src/main.rs"),
+            "Check this file [READ_FILE src/main.rs]"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("@Cargo.toml please"),
+            "[READ_FILE Cargo.toml] please"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("Look at @file1.txt and @file2.txt"),
             "Look at [READ_FILE file1.txt] and [READ_FILE file2.txt]"
         );
-
-        // Test no @ symbol
-        let result = chat_service.preprocess_file_references("Just a normal message");
-        assert_eq!(result, "Just a normal message");
-
-        // Test @ followed by nothing
-        let result = chat_service.preprocess_file_references("Message with @");
-        assert_eq!(result, "Message with @");
-
-        // Test @ followed by command-like syntax (should skip)
-        let result = chat_service.preprocess_file_references("Use @/help command");
-        assert_eq!(result, "Use @/help command");
-
-        // Test multiple file references with mixed valid/invalid
-        let result = chat_service.preprocess_file_references("@file1.txt @/invalid @file2.txt");
         assert_eq!(
-            result,
+            chat_service.preprocess_file_references("Just a normal message"),
+            "Just a normal message"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("Message with @"),
+            "Message with @"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("Use @/help command"),
+            "Use @/help command"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("@file1.txt @/invalid @file2.txt"),
             "[READ_FILE file1.txt] @/invalid [READ_FILE file2.txt]"
         );
-
-        // Test file references with spaces in names (should work with spaces)
-        let result = chat_service.preprocess_file_references("Check @src/main.rs and @README.md");
         assert_eq!(
-            result,
+            chat_service.preprocess_file_references("Check @src/main.rs and @README.md"),
             "Check [READ_FILE src/main.rs] and [READ_FILE README.md]"
         );
-
-        // Test empty file reference (should skip)
-        let result = chat_service.preprocess_file_references("Check @ and continue");
-        assert_eq!(result, "Check @ and continue");
-
-        // Test @ followed by space (should skip)
-        let result = chat_service.preprocess_file_references("Check @ file.txt");
-        assert_eq!(result, "Check @ file.txt");
-
-        // Test file path containing @ symbol (should treat as single path)
-        let result = chat_service.preprocess_file_references("@file1.txt@file2.txt");
-        assert_eq!(result, "[READ_FILE file1.txt@file2.txt]");
-
-        // Test @ at end of string
-        let result = chat_service.preprocess_file_references("Check this @");
-        assert_eq!(result, "Check this @");
-
-        // Test multiple @ with invalid ones mixed in
-        let result = chat_service.preprocess_file_references("@valid.txt @ @invalid/ @another.txt");
         assert_eq!(
-            result,
+            chat_service.preprocess_file_references("Check @ and continue"),
+            "Check @ and continue"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("Check @ file.txt"),
+            "Check @ file.txt"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("@file1.txt@file2.txt"),
+            "[READ_FILE file1.txt@file2.txt]"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("Check this @"),
+            "Check this @"
+        );
+        assert_eq!(
+            chat_service.preprocess_file_references("@valid.txt @ @invalid/ @another.txt"),
             "[READ_FILE valid.txt] @ [READ_FILE invalid/] [READ_FILE another.txt]"
         );
+        Ok(())
     }
 
     #[test]
-    fn test_remove_todo_by_index() {
-        use rusqlite::Connection;
-        use tempfile::NamedTempFile;
+    fn test_remove_todo_by_index() -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp, conn) = setup_test_db()?;
 
-        let temp_file = NamedTempFile::new().expect("Failed to create temp file for test");
-        let conn = Connection::open(temp_file.path()).expect("Failed to open test database");
-        init_db(&conn).expect("Failed to initialize test database");
+        crate::memory::storage::save_todo(&conn, "First todo")?;
+        crate::memory::storage::save_todo(&conn, "Second todo")?;
+        crate::memory::storage::save_todo(&conn, "Third todo")?;
 
-        // Add some todos
-        crate::memory::storage::save_todo(&conn, "First todo").unwrap();
-        crate::memory::storage::save_todo(&conn, "Second todo").unwrap();
-        crate::memory::storage::save_todo(&conn, "Third todo").unwrap();
-
-        // Test removing middle todo (index 2)
-        let result = crate::tools::todo::manage_todo(&conn, "[TODO remove 2]").unwrap();
+        let result = crate::tools::todo::manage_todo(&conn, "[TODO remove 2]")?;
         assert_eq!(result, "Removed todo: Second todo");
 
-        // Verify remaining todos
-        let todos = crate::memory::storage::load_todos(&conn).unwrap();
+        let todos = crate::memory::storage::load_todos(&conn)?;
         assert_eq!(todos.len(), 2);
         assert_eq!(todos[0].1, "First todo");
         assert_eq!(todos[1].1, "Third todo");
 
-        // Test removing first todo (index 1)
-        let result = crate::tools::todo::manage_todo(&conn, "[TODO remove 1]").unwrap();
+        let result = crate::tools::todo::manage_todo(&conn, "[TODO remove 1]")?;
         assert_eq!(result, "Removed todo: First todo");
 
-        // Test removing last todo (index 1 after removal)
-        let result = crate::tools::todo::manage_todo(&conn, "[TODO remove 1]").unwrap();
+        let result = crate::tools::todo::manage_todo(&conn, "[TODO remove 1]")?;
         assert_eq!(result, "Removed todo: Third todo");
 
-        // Verify no todos left
-        let todos = crate::memory::storage::load_todos(&conn).unwrap();
+        let todos = crate::memory::storage::load_todos(&conn)?;
         assert_eq!(todos.len(), 0);
 
-        // Test invalid index (too high)
         let result = crate::tools::todo::manage_todo(&conn, "[TODO remove 1]");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Invalid todo index: 1"));
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Invalid todo index: 1"));
 
-        // Test invalid index (zero)
         let result = crate::tools::todo::manage_todo(&conn, "[TODO remove 0]");
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("1-based index expected"));
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("1-based index expected"));
+        Ok(())
     }
 
     #[test]
-    fn test_clear_todos_returns_count() {
-        use rusqlite::Connection;
-        use tempfile::NamedTempFile;
+    fn test_clear_todos_returns_count() -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp, conn) = setup_test_db()?;
 
-        let temp_file = NamedTempFile::new().expect("Failed to create temp file for test");
-        let conn = Connection::open(temp_file.path()).expect("Failed to open test database");
-        init_db(&conn).expect("Failed to initialize test database");
+        crate::memory::storage::save_todo(&conn, "Test todo 1")?;
+        crate::memory::storage::save_todo(&conn, "Test todo 2")?;
+        crate::memory::storage::save_todo(&conn, "Test todo 3")?;
 
-        // Add some todos
-        crate::memory::storage::save_todo(&conn, "Test todo 1").unwrap();
-        crate::memory::storage::save_todo(&conn, "Test todo 2").unwrap();
-        crate::memory::storage::save_todo(&conn, "Test todo 3").unwrap();
-
-        // Verify todos were added
-        let todos = crate::memory::storage::load_todos(&conn).unwrap();
+        let todos = crate::memory::storage::load_todos(&conn)?;
         assert_eq!(todos.len(), 3);
 
-        // Clear todos and check return count
-        let cleared_count = crate::memory::storage::clear_todos(&conn).unwrap();
+        let cleared_count = crate::memory::storage::clear_todos(&conn)?;
         assert_eq!(cleared_count, 3);
 
-        // Verify todos were cleared
-        let todos_after = crate::memory::storage::load_todos(&conn).unwrap();
+        let todos_after = crate::memory::storage::load_todos(&conn)?;
         assert_eq!(todos_after.len(), 0);
+        Ok(())
     }
 
     #[test]
-    fn test_chat_service_should_exit() {
-        use rusqlite::Connection;
-        use tempfile::NamedTempFile;
-
-        let temp_file = NamedTempFile::new().expect("Failed to create temp file for test");
-        let conn = Connection::open(temp_file.path()).expect("Failed to open test database");
-        init_db(&conn).expect("Failed to initialize test database");
-
-        let config = ApiConfig {
-            provider: ApiProvider::OpenAI,
-            api_key: "test-key".to_string(),
-            base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-            model_name: "gpt-4".to_string(),
-        };
-
+    fn test_chat_service_should_exit() -> Result<(), Box<dyn std::error::Error>> {
+        let (_temp, conn) = setup_test_db()?;
+        let config = default_api_config();
         let chat_service = ChatService::new_test(&conn, &config);
 
         assert!(chat_service.should_exit("exit"));
@@ -351,5 +290,6 @@ mod tests {
         assert!(chat_service.should_exit(""));
         assert!(!chat_service.should_exit("hello"));
         assert!(!chat_service.should_exit("how are you?"));
+        Ok(())
     }
 }


### PR DESCRIPTION
Replace `unwrap()`/`expect()` with `?` operator in tests. Return `Result` from tests for graceful error handling. Add test helper functions (setup_test_db, default_api_config). Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.