### PR TITLE
[refactor] standardize error handling across codebase

### DIFF
--- a/lib/harper-core/src/agent/chat.rs
+++ b/lib/harper-core/src/agent/chat.rs
@@ -512,7 +512,7 @@ impl<'a> ChatService<'a> {
             "clear" => CommandAction::Clear,
             "audit" => match parse_audit_params(args) {
                 Ok(params) => CommandAction::Audit(params),
-                Err(err) => CommandAction::Unknown(err),
+                Err(err) => CommandAction::Unknown(err.to_string()),
             },
             cmd => {
                 if let Some(desc) = self.custom_commands.get(cmd) {
@@ -1262,7 +1262,7 @@ impl<'a> ChatService<'a> {
     }
 }
 
-fn parse_audit_params(args: Option<&str>) -> Result<AuditParams, String> {
+fn parse_audit_params(args: Option<&str>) -> HarperResult<AuditParams> {
     let mut params = AuditParams::default();
 
     let Some(arg_text) = args.filter(|a| !a.is_empty()) else {
@@ -1272,13 +1272,20 @@ fn parse_audit_params(args: Option<&str>) -> Result<AuditParams, String> {
     for token in arg_text.split_whitespace() {
         if token.chars().all(|c| c.is_ascii_digit()) {
             if params.limit.is_some() {
-                return Err("Audit limit specified multiple times.".to_string());
+                return Err(HarperError::Api(
+                    "Audit limit specified multiple times.".to_string(),
+                ));
             }
-            let parsed = token
-                .parse::<usize>()
-                .map_err(|_| format!("Invalid limit '{}'. Use a positive integer.", token))?;
+            let parsed = token.parse::<usize>().map_err(|_| {
+                HarperError::Api(format!(
+                    "Invalid limit '{}'. Use a positive integer.",
+                    token
+                ))
+            })?;
             if parsed == 0 {
-                return Err("Audit limit must be greater than zero.".to_string());
+                return Err(HarperError::Api(
+                    "Audit limit must be greater than zero.".to_string(),
+                ));
             }
             params.limit = Some(parsed);
             continue;
@@ -1286,10 +1293,14 @@ fn parse_audit_params(args: Option<&str>) -> Result<AuditParams, String> {
 
         if let Some(value) = token.strip_prefix("status=") {
             if params.status.is_some() {
-                return Err("Status filter specified multiple times.".to_string());
+                return Err(HarperError::Api(
+                    "Status filter specified multiple times.".to_string(),
+                ));
             }
             if value.is_empty() {
-                return Err("Status filter cannot be empty.".to_string());
+                return Err(HarperError::Api(
+                    "Status filter cannot be empty.".to_string(),
+                ));
             }
             params.status = Some(value.to_lowercase());
             continue;
@@ -1297,16 +1308,18 @@ fn parse_audit_params(args: Option<&str>) -> Result<AuditParams, String> {
 
         if let Some(value) = token.strip_prefix("approval=") {
             if params.approval.is_some() {
-                return Err("Approval filter specified multiple times.".to_string());
+                return Err(HarperError::Api(
+                    "Approval filter specified multiple times.".to_string(),
+                ));
             }
             params.approval = Some(match value.to_lowercase().as_str() {
                 "approved" => AuditApprovalFilter::Approved,
                 "rejected" => AuditApprovalFilter::Rejected,
                 "auto" => AuditApprovalFilter::Auto,
                 _ => {
-                    return Err(
-                        "Approval filter must be one of: approved, rejected, auto.".to_string()
-                    )
+                    return Err(HarperError::Api(
+                        "Approval filter must be one of: approved, rejected, auto.".to_string(),
+                    ))
                 }
             });
             continue;
@@ -1318,7 +1331,9 @@ fn parse_audit_params(args: Option<&str>) -> Result<AuditParams, String> {
             "failed" | "succeeded" | "error" | "cancelled" | "blocked"
         ) {
             if params.status.is_some() {
-                return Err("Status filter specified multiple times.".to_string());
+                return Err(HarperError::Api(
+                    "Status filter specified multiple times.".to_string(),
+                ));
             }
             params.status = Some(lower);
             continue;
@@ -1326,7 +1341,9 @@ fn parse_audit_params(args: Option<&str>) -> Result<AuditParams, String> {
 
         if matches!(lower.as_str(), "approved" | "rejected" | "auto") {
             if params.approval.is_some() {
-                return Err("Approval filter specified multiple times.".to_string());
+                return Err(HarperError::Api(
+                    "Approval filter specified multiple times.".to_string(),
+                ));
             }
             params.approval = Some(match lower.as_str() {
                 "approved" => AuditApprovalFilter::Approved,
@@ -1337,10 +1354,10 @@ fn parse_audit_params(args: Option<&str>) -> Result<AuditParams, String> {
             continue;
         }
 
-        return Err(format!(
+        return Err(HarperError::Api(format!(
             "Unknown audit argument '{}'. Use /audit [limit] [status=...] [approval=approved|rejected|auto].",
             token
-        ));
+        )));
     }
 
     Ok(params)
@@ -1387,7 +1404,7 @@ mod tests {
     #[test]
     fn parse_audit_errors_on_unknown_token() {
         let err = parse_audit_params(Some("foo=bar")).expect_err("should fail");
-        assert!(err.contains("Unknown audit argument"));
+        assert!(err.to_string().contains("Unknown audit argument"));
     }
 
     #[test]
@@ -1424,6 +1441,8 @@ mod tests {
     #[test]
     fn parse_audit_duplicate_status_errors() {
         let err = parse_audit_params(Some("status=failed succeeded")).expect_err("should fail");
-        assert!(err.contains("Status filter specified multiple times"));
+        assert!(err
+            .to_string()
+            .contains("Status filter specified multiple times"));
     }
 }

--- a/lib/harper-core/src/core/error.rs
+++ b/lib/harper-core/src/core/error.rs
@@ -13,58 +13,48 @@
 // limitations under the License.
 
 use colored::Colorize;
-use std::fmt;
 
 /// Custom error type for Harper application
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum HarperError {
     /// Configuration related errors
+    #[error("Configuration error: {0}")]
     Config(String),
     /// Database related errors
+    #[error("Database error: {0}")]
     Database(String),
     /// API related errors
+    #[error("API error: {0}")]
     Api(String),
     /// MCP related errors
     #[allow(dead_code)]
+    #[error("MCP error: {0}")]
     Mcp(String),
     /// Cryptography related errors
+    #[error("Cryptography error: {0}")]
     Crypto(String),
     /// I/O related errors
+    #[error("I/O error: {0}")]
     Io(String),
     /// File operation errors
+    #[error("File operation error: {0}")]
     File(String),
     /// Command execution errors
+    #[error("Command execution error: {0}")]
     Command(String),
     /// Web search errors
     #[allow(dead_code)]
+    #[error("Web search error: {0}")]
     WebSearch(String),
+    /// Firmware errors
+    #[error("Firmware error: {0}")]
+    Firmware(#[from] harper_firmware::FirmwareError),
+    /// Sandbox errors
+    #[error("Sandbox error: {0}")]
+    Sandbox(#[from] harper_sandbox::SandboxError),
 }
-
-impl fmt::Display for HarperError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            HarperError::Config(msg) => write!(f, "Configuration error: {}", msg),
-            HarperError::Database(msg) => write!(f, "Database error: {}", msg),
-            HarperError::Api(msg) => write!(f, "API error: {}", msg),
-            HarperError::Mcp(msg) => write!(f, "MCP error: {}", msg),
-            HarperError::Crypto(msg) => write!(f, "Cryptography error: {}", msg),
-            HarperError::Io(msg) => write!(f, "I/O error: {}", msg),
-            HarperError::File(msg) => write!(f, "File operation error: {}", msg),
-            HarperError::Command(msg) => write!(f, "Command execution error: {}", msg),
-            HarperError::WebSearch(msg) => write!(f, "Web search error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for HarperError {}
 
 impl HarperError {
-    /// Get formatted error message for display
-    #[deprecated(note = "Please use `to_string()` instead")]
-    pub fn display_message(&self) -> String {
-        self.to_string()
-    }
-
     /// Get colored error message for CLI
     pub fn cli_message(&self) -> colored::ColoredString {
         self.to_string().red()

--- a/lib/harper-core/src/server/mod.rs
+++ b/lib/harper-core/src/server/mod.rs
@@ -63,8 +63,11 @@ pub async fn health() -> Json<HealthResponse> {
 }
 
 pub async fn list_sessions(State(state): State<Arc<ServerState>>) -> Json<Vec<SessionListItem>> {
-    let conn = state.conn.lock().unwrap();
-    let mut stmt = conn.prepare("SELECT id, created_at, updated_at, title FROM sessions ORDER BY updated_at DESC LIMIT 50").unwrap();
+    let conn = state
+        .conn
+        .lock()
+        .expect("Failed to lock database connection");
+    let mut stmt = conn.prepare("SELECT id, created_at, updated_at, title FROM sessions ORDER BY updated_at DESC LIMIT 50").expect("Failed to prepare SQL statement");
 
     let sessions: Vec<SessionListItem> = stmt
         .query_map([], |row| {
@@ -75,7 +78,7 @@ pub async fn list_sessions(State(state): State<Arc<ServerState>>) -> Json<Vec<Se
                 title: row.get(3)?,
             })
         })
-        .unwrap()
+        .expect("Failed to execute query")
         .filter_map(|r| r.ok())
         .collect();
 
@@ -86,7 +89,10 @@ pub async fn get_session(
     State(state): State<Arc<ServerState>>,
     Path(session_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    let conn = state.conn.lock().unwrap();
+    let conn = state
+        .conn
+        .lock()
+        .expect("Failed to lock database connection");
 
     let mut stmt = conn
         .prepare("SELECT messages FROM sessions WHERE id = ?")
@@ -110,7 +116,10 @@ pub async fn delete_session(
     State(state): State<Arc<ServerState>>,
     Path(session_id): Path<String>,
 ) -> StatusCode {
-    let conn = state.conn.lock().unwrap();
+    let conn = state
+        .conn
+        .lock()
+        .expect("Failed to lock database connection");
 
     match conn.execute("DELETE FROM sessions WHERE id = ?", [&session_id]) {
         Ok(_) => StatusCode::NO_CONTENT,

--- a/lib/harper-mcp-server/src/main.rs
+++ b/lib/harper-mcp-server/src/main.rs
@@ -39,7 +39,7 @@ impl RateLimiter {
         let now = Instant::now();
         let window = Duration::from_secs(RATE_LIMIT_WINDOW_SECS);
 
-        let mut requests = self.requests.lock().unwrap();
+        let mut requests = self.requests.lock().expect("Failed to lock rate limiter");
 
         // Clean up expired entries
         for v in requests.values_mut() {

--- a/lib/harper-ui/src/auth.rs
+++ b/lib/harper-ui/src/auth.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use harper_core::{HarperError, HarperResult};
 use keyring::Entry;
 use std::io::{self, Write};
 
@@ -73,8 +74,8 @@ pub fn handle_auth_command(args: &[String]) -> Option<i32> {
 
     match subcommand {
         "login" => {
-            if let Err(message) = login(provider) {
-                eprintln!("Auth login failed: {}", message);
+            if let Err(err) = login(provider) {
+                eprintln!("Auth login failed: {}", err);
                 return Some(1);
             }
             println!(
@@ -84,8 +85,8 @@ pub fn handle_auth_command(args: &[String]) -> Option<i32> {
             Some(0)
         }
         "logout" => {
-            if let Err(message) = logout(provider) {
-                eprintln!("Auth logout failed: {}", message);
+            if let Err(err) = logout(provider) {
+                eprintln!("Auth logout failed: {}", err);
                 return Some(1);
             }
             println!(
@@ -116,31 +117,31 @@ pub fn is_placeholder_key(value: &str) -> bool {
     trimmed == "your_api_key_here" || trimmed == "your_gemini_api_key_here"
 }
 
-fn login(provider: Provider) -> Result<(), String> {
+fn login(provider: Provider) -> HarperResult<()> {
     let api_key = prompt_for_key(provider)?;
     if api_key.trim().is_empty() {
-        return Err("API key cannot be empty.".to_string());
+        return Err(HarperError::Api("API key cannot be empty.".to_string()));
     }
 
     let entry = Entry::new(KEYRING_SERVICE, provider.account_name())
-        .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
+        .map_err(|e| HarperError::Crypto(format!("Failed to open keychain entry: {}", e)))?;
     entry
         .set_password(api_key.trim())
-        .map_err(|e| format!("Failed to store key: {}", e))?;
+        .map_err(|e| HarperError::Crypto(format!("Failed to store key: {}", e)))?;
 
     Ok(())
 }
 
-fn logout(provider: Provider) -> Result<(), String> {
+fn logout(provider: Provider) -> HarperResult<()> {
     let entry = Entry::new(KEYRING_SERVICE, provider.account_name())
-        .map_err(|e| format!("Failed to open keychain entry: {}", e))?;
+        .map_err(|e| HarperError::Crypto(format!("Failed to open keychain entry: {}", e)))?;
     entry
         .delete_password()
-        .map_err(|e| format!("Failed to remove key: {}", e))?;
+        .map_err(|e| HarperError::Crypto(format!("Failed to remove key: {}", e)))?;
     Ok(())
 }
 
-fn prompt_for_key(provider: Provider) -> Result<String, String> {
+fn prompt_for_key(provider: Provider) -> HarperResult<String> {
     println!(
         "Enter {} API key (input will be visible):",
         provider.display_name()
@@ -148,16 +149,16 @@ fn prompt_for_key(provider: Provider) -> Result<String, String> {
     print!("> ");
     io::stdout()
         .flush()
-        .map_err(|e| format!("Failed to flush stdout: {}", e))?;
+        .map_err(|e| HarperError::Io(format!("Failed to flush stdout: {}", e)))?;
 
     let mut input = String::new();
     io::stdin()
         .read_line(&mut input)
-        .map_err(|e| format!("Failed to read input: {}", e))?;
+        .map_err(|e| HarperError::Io(format!("Failed to read input: {}", e)))?;
     Ok(input)
 }
 
-fn parse_provider(args: &[String]) -> Result<Provider, String> {
+fn parse_provider(args: &[String]) -> HarperResult<Provider> {
     let mut provider_value: Option<String> = None;
 
     let mut iter = args.iter().skip(3);
@@ -173,14 +174,14 @@ fn parse_provider(args: &[String]) -> Result<Provider, String> {
         }
     }
 
-    let provider_value =
-        provider_value.ok_or_else(|| "Missing provider. Use --provider <name>.".to_string())?;
+    let provider_value = provider_value
+        .ok_or_else(|| HarperError::Api("Missing provider. Use --provider <name>.".to_string()))?;
 
     Provider::from_str(&provider_value).ok_or_else(|| {
-        format!(
+        HarperError::Api(format!(
             "Unknown provider '{}'. Use OpenAI, Sambanova, or Gemini.",
             provider_value
-        )
+        ))
     })
 }
 

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -117,7 +117,12 @@ pub fn handle_event(
                 match key.code {
                     KeyCode::Char('y') | KeyCode::Char('Y') => {
                         let command = approval.command.clone();
-                        if let Some(tx) = approval.tx.lock().unwrap().take() {
+                        if let Some(tx) = approval
+                            .tx
+                            .lock()
+                            .expect("Failed to lock approval channel")
+                            .take()
+                        {
                             let _ = tx.send(true);
                         }
                         app.pending_approval = None;
@@ -126,7 +131,12 @@ pub fn handle_event(
                     }
                     KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                         let command = approval.command.clone();
-                        if let Some(tx) = approval.tx.lock().unwrap().take() {
+                        if let Some(tx) = approval
+                            .tx
+                            .lock()
+                            .expect("Failed to lock approval channel")
+                            .take()
+                        {
                             let _ = tx.send(false);
                         }
                         app.pending_approval = None;


### PR DESCRIPTION
Convert HarperError to use thiserror for consistency with other error types. Replace raw Result<T, String> returns with HarperResult<T> in auth and chat modules. Replace unwrap() calls in production code with expect() for better error messages. Unify error types by adding Firmware and Sandbox variants to HarperError. Update tests to work with typed errors. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.