### PR TITLE
[chore] bump dependencies and update lockfiles

### DIFF
--- a/.agents/skills/localfix.md
+++ b/.agents/skills/localfix.md
@@ -1,0 +1,34 @@
+---
+name: localfix
+description: Fix local Bazel and Cargo-Bazel issues by cleaning caches and repinning dependencies
+---
+
+# Local Fix Skill
+
+This skill provides commands to fix local Bazel and Cargo-Bazel issues by cleaning caches and repinning dependencies.
+
+## Usage
+
+Run the following commands to fix common local build issues:
+
+```bash
+bazel shutdown
+rm -rf ~/.cache/bazel ~/.bazel
+rm -f cargo-bazel-lock.json
+CARGO_BAZEL_REPIN=true bazel build :harper_bin
+```
+
+## Description
+
+- `bazel shutdown`: Shuts down the Bazel server
+- `rm -rf ~/.cache/bazel ~/.bazel`: Removes Bazel cache directories
+- `rm -f cargo-bazel-lock.json`: Removes the Cargo-Bazel lock file
+- `CARGO_BAZEL_REPIN=true bazel build :harper_bin`: Repins Cargo dependencies and builds the main binary
+
+## Important Notes
+
+- **Time Warning**: Initial dependency repinning takes 10-15 minutes (recompiles ~200 Rust crates)
+- **Subsequent Builds**: Run `bazel build :harper_bin` (no CARGO_BAZEL_REPIN) for fast ~30-60 second builds
+- **Expected Behavior**: Build may show compilation progress for several minutes before completing
+
+This sequence clears corrupted caches and forces dependency repinning, resolving issues with stale or inconsistent build artifacts.

--- a/.github/workflows/bazel-smoke.yml
+++ b/.github/workflows/bazel-smoke.yml
@@ -27,18 +27,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'harpertoken'
     steps:
-       - uses: actions/checkout@v6
-       - name: Set up Bazel
-         uses: bazel-contrib/setup-bazel@0.19.0
-       - name: Clear stale Bazel cache and regenerate lock
-         run: |
-           bazel shutdown 2>/dev/null || true
-           rm -rf /home/runner/.cache/bazel /home/runner/.cache/bazelisk /home/runner/.bazel /home/runner/.bazelrc
-           rm -rf /home/runner/.cache/bazel-external /home/runner/.bazel/external
-           rm -rf .bazelrc .bazeliskrc "$HOME"/.bazel* 2>/dev/null || true
-           rm -rf /tmp/*bazel* 2>/dev/null || true
-           rm -f cargo-bazel-lock.json
-       - name: Fetch external dependencies
-         run: CARGO_BAZEL_REPIN=1 bazel fetch //...
-       - name: Bazel test smoke suite
-         run: bazel test //... --build_tests_only --repo_env=CARGO_BAZEL_REPIN=1 || echo "No test targets found, smoke test passed"
+      - uses: actions/checkout@v6
+      - name: Set up Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+      - name: Clear stale Bazel cache and regenerate lock
+        run: |
+          bazel shutdown 2>/dev/null || true
+          rm -rf /home/runner/.cache/bazel /home/runner/.cache/bazelisk /home/runner/.bazel /home/runner/.bazelrc
+          rm -rf /home/runner/.cache/bazel-external /home/runner/.bazel/external
+          rm -rf .bazelrc .bazeliskrc "$HOME"/.bazel* 2>/dev/null || true
+          rm -rf /tmp/*bazel* 2>/dev/null || true
+          rm -f cargo-bazel-lock.json
+      - name: Fetch external dependencies
+        run: CARGO_BAZEL_REPIN=true bazel fetch //...
+      - name: Bazel test smoke suite
+        run: bazel test //... --build_tests_only --repo_env=CARGO_BAZEL_REPIN=true || echo "No test targets found, smoke test passed"

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -37,7 +37,7 @@ jobs:
         rm -rf /tmp/*bazel* 2>/dev/null || true
         rm -f cargo-bazel-lock.json
     - name: Build with Bazel
-      run: CARGO_BAZEL_REPIN=1 bazel build :harper_bin
+      run: CARGO_BAZEL_REPIN=true bazel build :harper_bin
     - name: Test with Bazel
       run: bazel test //...
     - name: Test Bazel build
@@ -59,7 +59,7 @@ jobs:
         rm -rf /tmp/*bazel* 2>/dev/null || true
         rm -f cargo-bazel-lock.json
     - name: Build with Bazel
-      run: CARGO_BAZEL_REPIN=1 bazel build :harper_bin
+      run: CARGO_BAZEL_REPIN=true bazel build :harper_bin
     - name: Test with Bazel
       run: bazel test //...
     - name: Test Bazel build

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -49,7 +49,7 @@ jobs:
           set -euo pipefail
           bazel shutdown
           rm -f cargo-bazel-lock.json
-          CARGO_BAZEL_REPIN=1 bazel build :harper_bin 2>/dev/null || true
+          CARGO_BAZEL_REPIN=true bazel build :harper_bin 2>/dev/null || true
           bazel shutdown
 
       - name: Create PR

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -131,8 +131,8 @@
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -195,7 +195,7 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
+        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -252,7 +252,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "efee991c65601788143998cd4fee23ba8115a3ab40bfd988f284c582ae49f595",
+  "checksum": "0db460eeb11ff7349bfe25c8e84e570140e12a82bde1424fb51ebcf29ae2718c",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -334,7 +334,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -966,7 +966,7 @@
           "selects": {
             "cfg(any())": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -3489,7 +3489,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -4706,7 +4706,7 @@
               "target": "toml"
             },
             {
-              "id": "winnow 1.0.1",
+              "id": "winnow 1.0.2",
               "target": "winnow"
             },
             {
@@ -4976,7 +4976,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -5035,7 +5035,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -5131,25 +5131,25 @@
           "selects": {
             "aarch64-linux-android": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -5199,25 +5199,25 @@
           "selects": {
             "cfg(all(target_arch = \"aarch64\", target_os = \"android\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"aarch64\", target_vendor = \"apple\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(all(target_arch = \"loongarch64\", target_os = \"linux\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -6012,7 +6012,7 @@
               "target": "generic_array"
             },
             {
-              "id": "typenum 1.19.0",
+              "id": "typenum 1.20.0",
               "target": "typenum"
             }
           ],
@@ -6296,6 +6296,69 @@
         },
         "edition": "2021",
         "version": "0.23.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
+    },
+    "dashmap 5.5.3": {
+      "name": "dashmap",
+      "version": "5.5.3",
+      "package_url": "https://github.com/xacrimon/dashmap",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/dashmap/5.5.3/download",
+          "sha256": "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "dashmap",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "dashmap",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.4",
+              "target": "cfg_if"
+            },
+            {
+              "id": "hashbrown 0.14.5",
+              "target": "hashbrown"
+            },
+            {
+              "id": "lock_api 0.4.14",
+              "target": "lock_api"
+            },
+            {
+              "id": "once_cell 1.21.4",
+              "target": "once_cell"
+            },
+            {
+              "id": "parking_lot_core 0.9.12",
+              "target": "parking_lot_core"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "5.5.3"
       },
       "license": "MIT",
       "license_ids": [
@@ -6802,7 +6865,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -7620,19 +7683,19 @@
           "selects": {
             "cfg(target_os = \"hermit\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"wasi\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -8511,7 +8574,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -9780,7 +9843,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "typenum 1.19.0",
+              "id": "typenum 1.20.0",
               "target": "typenum"
             }
           ],
@@ -9929,7 +9992,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -10000,7 +10063,7 @@
           "selects": {
             "cfg(all(any(target_os = \"linux\", target_os = \"android\"), not(any(all(target_os = \"linux\", target_env = \"\"), getrandom_backend = \"custom\", getrandom_backend = \"linux_raw\", getrandom_backend = \"rdrand\", getrandom_backend = \"rndr\"))))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -10018,43 +10081,43 @@
             ],
             "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"hurd\", target_os = \"illumos\", target_os = \"cygwin\", all(target_os = \"horizon\", target_arch = \"arm\")))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"haiku\", target_os = \"redox\", target_os = \"nto\", target_os = \"aix\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"ios\", target_os = \"visionos\", target_os = \"watchos\", target_os = \"tvos\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"macos\", target_os = \"openbsd\", target_os = \"vita\", target_os = \"emscripten\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"netbsd\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"solaris\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"vxworks\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -10147,7 +10210,7 @@
           "selects": {
             "cfg(all(any(target_os = \"linux\", target_os = \"android\"), not(any(all(target_os = \"linux\", target_env = \"\"), getrandom_backend = \"custom\", getrandom_backend = \"linux_raw\", getrandom_backend = \"rdrand\", getrandom_backend = \"rndr\"))))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -10171,43 +10234,43 @@
             ],
             "cfg(any(target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"hurd\", target_os = \"illumos\", target_os = \"cygwin\", all(target_os = \"horizon\", target_arch = \"arm\")))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"haiku\", target_os = \"redox\", target_os = \"nto\", target_os = \"aix\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"ios\", target_os = \"visionos\", target_os = \"watchos\", target_os = \"tvos\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(any(target_os = \"macos\", target_os = \"openbsd\", target_os = \"vita\", target_os = \"emscripten\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"netbsd\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"solaris\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(target_os = \"vxworks\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -10449,9 +10512,9 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "harper-core 0.8.0": {
+    "harper-core 0.9.0": {
       "name": "harper-core",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "package_url": "https://github.com/harpertoken/harper",
       "repository": null,
       "targets": [
@@ -10488,6 +10551,10 @@
             {
               "id": "arboard 3.6.1",
               "target": "arboard"
+            },
+            {
+              "id": "axum 0.8.9",
+              "target": "axum"
             },
             {
               "id": "base64 0.22.1",
@@ -10562,6 +10629,10 @@
               "target": "image"
             },
             {
+              "id": "log 0.4.29",
+              "target": "log"
+            },
+            {
               "id": "reqwest 0.12.28",
               "target": "reqwest"
             },
@@ -10606,7 +10677,7 @@
               "target": "tower"
             },
             {
-              "id": "turul-mcp-client 0.3.32",
+              "id": "turul-mcp-client 0.3.34",
               "target": "turul_mcp_client"
             },
             {
@@ -10655,7 +10726,7 @@
           ],
           "selects": {}
         },
-        "version": "0.8.0"
+        "version": "0.9.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -10756,6 +10827,14 @@
               "target": "chrono"
             },
             {
+              "id": "dashmap 5.5.3",
+              "target": "dashmap"
+            },
+            {
+              "id": "lazy_static 1.5.0",
+              "target": "lazy_static"
+            },
+            {
               "id": "serde 1.0.228",
               "target": "serde"
             },
@@ -10772,7 +10851,7 @@
               "target": "tracing"
             },
             {
-              "id": "turul-mcp-json-rpc-server 0.2.1",
+              "id": "turul-mcp-json-rpc-server 0.3.34",
               "target": "turul_mcp_json_rpc_server"
             }
           ],
@@ -10860,9 +10939,9 @@
       ],
       "license_file": null
     },
-    "harper-ui 0.7.1": {
+    "harper-ui 0.8.0": {
       "name": "harper-ui",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "package_url": "https://github.com/harpertoken/harper",
       "repository": null,
       "targets": [
@@ -10931,7 +11010,7 @@
               "target": "tokio"
             },
             {
-              "id": "turul-mcp-client 0.3.32",
+              "id": "turul-mcp-client 0.3.34",
               "target": "turul_mcp_client"
             },
             {
@@ -10951,7 +11030,7 @@
           ],
           "selects": {}
         },
-        "version": "0.7.1"
+        "version": "0.8.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -12150,7 +12229,7 @@
               "target": "hyper_util"
             },
             {
-              "id": "rustls 0.23.38",
+              "id": "rustls 0.23.39",
               "target": "rustls"
             },
             {
@@ -12380,7 +12459,7 @@
                 "target": "ipnet"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -12418,7 +12497,7 @@
                 "target": "ipnet"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -12452,7 +12531,7 @@
                 "target": "ipnet"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -12490,7 +12569,7 @@
                 "target": "ipnet"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -12524,7 +12603,7 @@
                 "target": "ipnet"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -14122,7 +14201,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -14276,7 +14355,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -14488,7 +14567,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -14975,14 +15054,14 @@
       ],
       "license_file": "LICENSE-BSD-3-Clause"
     },
-    "libc 0.2.185": {
+    "libc 0.2.186": {
       "name": "libc",
-      "version": "0.2.185",
+      "version": "0.2.186",
       "package_url": "https://github.com/rust-lang/libc",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/libc/0.2.185/download",
-          "sha256": "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+          "url": "https://static.crates.io/crates/libc/0.2.186/download",
+          "sha256": "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
         }
       },
       "targets": [
@@ -15039,14 +15118,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.2.185"
+        "version": "0.2.186"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -15419,7 +15498,7 @@
               "target": "bitflags"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -16469,7 +16548,7 @@
             ],
             "cfg(any(unix, target_os = \"hermit\", target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -16640,7 +16719,7 @@
                 "target": "log"
               },
               {
-                "id": "openssl 0.10.77",
+                "id": "openssl 0.10.78",
                 "target": "openssl"
               },
               {
@@ -16648,7 +16727,7 @@
                 "target": "openssl_probe"
               },
               {
-                "id": "openssl-sys 0.9.113",
+                "id": "openssl-sys 0.9.114",
                 "target": "openssl_sys"
               }
             ],
@@ -16666,7 +16745,7 @@
             ],
             "cfg(target_vendor = \"apple\")": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -16698,7 +16777,7 @@
           "selects": {
             "cfg(not(any(target_os = \"windows\", target_vendor = \"apple\")))": [
               {
-                "id": "openssl-sys 0.9.113",
+                "id": "openssl-sys 0.9.114",
                 "target": "openssl_sys"
               }
             ]
@@ -16847,7 +16926,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -16918,7 +16997,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -17020,7 +17099,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -17890,7 +17969,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -17946,7 +18025,7 @@
           "selects": {
             "cfg(any(target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -18531,7 +18610,7 @@
           "selects": {
             "cfg(windows)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -18668,14 +18747,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "openssl 0.10.77": {
+    "openssl 0.10.78": {
       "name": "openssl",
-      "version": "0.10.77",
+      "version": "0.10.78",
       "package_url": "https://github.com/rust-openssl/rust-openssl",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/openssl/0.10.77/download",
-          "sha256": "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+          "url": "https://static.crates.io/crates/openssl/0.10.78/download",
+          "sha256": "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
         }
       },
       "targets": [
@@ -18730,7 +18809,7 @@
               "target": "foreign_types"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -18738,11 +18817,11 @@
               "target": "once_cell"
             },
             {
-              "id": "openssl 0.10.77",
+              "id": "openssl 0.10.78",
               "target": "build_script_build"
             },
             {
-              "id": "openssl-sys 0.9.113",
+              "id": "openssl-sys 0.9.114",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -18759,7 +18838,7 @@
           ],
           "selects": {}
         },
-        "version": "0.10.77"
+        "version": "0.10.78"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -18774,7 +18853,7 @@
         "link_deps": {
           "common": [
             {
-              "id": "openssl-sys 0.9.113",
+              "id": "openssl-sys 0.9.114",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -18883,14 +18962,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "openssl-sys 0.9.113": {
+    "openssl-sys 0.9.114": {
       "name": "openssl-sys",
-      "version": "0.9.113",
+      "version": "0.9.114",
       "package_url": "https://github.com/rust-openssl/rust-openssl",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/openssl-sys/0.9.113/download",
-          "sha256": "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+          "url": "https://static.crates.io/crates/openssl-sys/0.9.114/download",
+          "sha256": "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
         }
       },
       "targets": [
@@ -18927,18 +19006,18 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
-              "id": "openssl-sys 0.9.113",
+              "id": "openssl-sys 0.9.114",
               "target": "build_script_main"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.9.113"
+        "version": "0.9.114"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -19332,7 +19411,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -20565,7 +20644,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -21876,7 +21955,7 @@
           "selects": {
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -21886,7 +21965,7 @@
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -21896,7 +21975,7 @@
             ],
             "x86_64-unknown-nixos-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -22841,7 +22920,7 @@
               "target": "itertools"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -24127,13 +24206,13 @@
             ],
             "cfg(all(all(target_arch = \"aarch64\", target_endian = \"little\"), target_vendor = \"apple\", any(target_os = \"ios\", target_os = \"macos\", target_os = \"tvos\", target_os = \"visionos\", target_os = \"watchos\")))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
             "cfg(all(any(all(target_arch = \"aarch64\", target_endian = \"little\"), all(target_arch = \"arm\", target_endian = \"little\")), any(target_os = \"android\", target_os = \"linux\")))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -24513,7 +24592,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -24623,7 +24702,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -24756,7 +24835,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -24779,7 +24858,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -24801,7 +24880,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -24828,14 +24907,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustls 0.23.38": {
+    "rustls 0.23.39": {
       "name": "rustls",
-      "version": "0.23.38",
+      "version": "0.23.39",
       "package_url": "https://github.com/rustls/rustls",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls/0.23.38/download",
-          "sha256": "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+          "url": "https://static.crates.io/crates/rustls/0.23.39/download",
+          "sha256": "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
         }
       },
       "targets": [
@@ -24876,7 +24955,7 @@
               "target": "once_cell"
             },
             {
-              "id": "rustls 0.23.38",
+              "id": "rustls 0.23.39",
               "target": "build_script_build"
             },
             {
@@ -24885,7 +24964,7 @@
               "alias": "pki_types"
             },
             {
-              "id": "rustls-webpki 0.103.12",
+              "id": "rustls-webpki 0.103.13",
               "target": "webpki"
             },
             {
@@ -24900,7 +24979,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.23.38"
+        "version": "0.23.39"
       },
       "build_script_attrs": {
         "compile_data_glob": [
@@ -24977,14 +25056,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rustls-webpki 0.103.12": {
+    "rustls-webpki 0.103.13": {
       "name": "rustls-webpki",
-      "version": "0.103.12",
+      "version": "0.103.13",
       "package_url": "https://github.com/rustls/webpki",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/rustls-webpki/0.103.12/download",
-          "sha256": "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+          "url": "https://static.crates.io/crates/rustls-webpki/0.103.13/download",
+          "sha256": "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
         }
       },
       "targets": [
@@ -25021,7 +25100,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.103.12"
+        "version": "0.103.13"
       },
       "license": "ISC",
       "license_ids": [
@@ -25160,7 +25239,7 @@
               "target": "home"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -25540,7 +25619,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -25613,7 +25692,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -25680,7 +25759,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -26624,7 +26703,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -26698,7 +26777,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -26759,7 +26838,7 @@
               "target": "errno"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -27045,7 +27124,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -27121,7 +27200,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -27925,7 +28004,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -28187,7 +28266,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             }
           ],
@@ -28308,7 +28387,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -28852,7 +28931,7 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -28862,7 +28941,7 @@
             ],
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -28872,7 +28951,7 @@
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -28882,7 +28961,7 @@
             ],
             "x86_64-unknown-nixos-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -29268,7 +29347,7 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -29282,7 +29361,7 @@
             ],
             "aarch64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -29296,7 +29375,7 @@
             ],
             "wasm32-wasip1": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -29312,7 +29391,7 @@
             ],
             "x86_64-unknown-linux-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -29326,7 +29405,7 @@
             ],
             "x86_64-unknown-nixos-gnu": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               },
               {
@@ -29496,7 +29575,7 @@
         "deps": {
           "common": [
             {
-              "id": "rustls 0.23.38",
+              "id": "rustls 0.23.39",
               "target": "rustls"
             },
             {
@@ -29669,7 +29748,7 @@
               "target": "toml_parser"
             },
             {
-              "id": "winnow 1.0.1",
+              "id": "winnow 1.0.2",
               "target": "winnow"
             }
           ],
@@ -29879,7 +29958,7 @@
         "deps": {
           "common": [
             {
-              "id": "winnow 1.0.1",
+              "id": "winnow 1.0.2",
               "target": "winnow"
             }
           ],
@@ -30394,14 +30473,14 @@
       ],
       "license_file": "LICENSE"
     },
-    "turul-mcp-client 0.3.32": {
+    "turul-mcp-client 0.3.34": {
       "name": "turul-mcp-client",
-      "version": "0.3.32",
+      "version": "0.3.34",
       "package_url": "https://github.com/aussierobots/turul-mcp-framework",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/turul-mcp-client/0.3.32/download",
-          "sha256": "d3355c07b9813ac559e180a27f0eb62c7816294d59e9b5429e3478dd82ca8602"
+          "url": "https://static.crates.io/crates/turul-mcp-client/0.3.34/download",
+          "sha256": "4ef6ce2e09ae9e864fd1d85538560275dfcaa77e0c503b241e6681fe55c4e55d"
         }
       },
       "targets": [
@@ -30483,11 +30562,11 @@
               "target": "tracing"
             },
             {
-              "id": "turul-mcp-json-rpc-server 0.3.32",
+              "id": "turul-mcp-json-rpc-server 0.3.34",
               "target": "turul_mcp_json_rpc_server"
             },
             {
-              "id": "turul-mcp-protocol 0.3.32",
+              "id": "turul-mcp-protocol 0.3.34",
               "target": "turul_mcp_protocol"
             },
             {
@@ -30507,7 +30586,7 @@
           ],
           "selects": {}
         },
-        "version": "0.3.32"
+        "version": "0.3.34"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -30516,14 +30595,14 @@
       ],
       "license_file": null
     },
-    "turul-mcp-json-rpc-server 0.2.1": {
+    "turul-mcp-json-rpc-server 0.3.34": {
       "name": "turul-mcp-json-rpc-server",
-      "version": "0.2.1",
+      "version": "0.3.34",
       "package_url": "https://github.com/aussierobots/turul-mcp-framework",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/turul-mcp-json-rpc-server/0.2.1/download",
-          "sha256": "83e22c571a9f644544e13ef86b3e9ac306e648ebb54c0d5f5031465999348d1c"
+          "url": "https://static.crates.io/crates/turul-mcp-json-rpc-server/0.3.34/download",
+          "sha256": "742eed33c92e61dc0bf5bd3a785fa8389c3bc6a02bbbb9cfaa2715e00bacaa3e"
         }
       },
       "targets": [
@@ -30585,7 +30664,7 @@
           ],
           "selects": {}
         },
-        "version": "0.2.1"
+        "version": "0.3.34"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -30594,92 +30673,14 @@
       ],
       "license_file": null
     },
-    "turul-mcp-json-rpc-server 0.3.32": {
-      "name": "turul-mcp-json-rpc-server",
-      "version": "0.3.32",
-      "package_url": "https://github.com/aussierobots/turul-mcp-framework",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/turul-mcp-json-rpc-server/0.3.32/download",
-          "sha256": "e863475f17a669803a4566d1b858e2f6408c138a55f1a1b06423f4af8b4bd8db"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "turul_mcp_json_rpc_server",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "turul_mcp_json_rpc_server",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "async",
-            "async-trait",
-            "default",
-            "futures"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "futures 0.3.32",
-              "target": "futures"
-            },
-            {
-              "id": "serde 1.0.228",
-              "target": "serde"
-            },
-            {
-              "id": "serde_json 1.0.149",
-              "target": "serde_json"
-            },
-            {
-              "id": "thiserror 2.0.18",
-              "target": "thiserror"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2024",
-        "proc_macro_deps": {
-          "common": [
-            {
-              "id": "async-trait 0.1.89",
-              "target": "async_trait"
-            }
-          ],
-          "selects": {}
-        },
-        "version": "0.3.32"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": null
-    },
-    "turul-mcp-protocol 0.3.32": {
+    "turul-mcp-protocol 0.3.34": {
       "name": "turul-mcp-protocol",
-      "version": "0.3.32",
+      "version": "0.3.34",
       "package_url": "https://github.com/aussierobots/turul-mcp-framework",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/turul-mcp-protocol/0.3.32/download",
-          "sha256": "4bc3d41e9c49c7d969115295325b3b07611e1e2861ffc3649cca980be2975e75"
+          "url": "https://static.crates.io/crates/turul-mcp-protocol/0.3.34/download",
+          "sha256": "2b65790890299c32a42cb5685e43ff1a2c2bd9579de8cb0947d3224b1d42d3ab"
         }
       },
       "targets": [
@@ -30710,14 +30711,14 @@
         "deps": {
           "common": [
             {
-              "id": "turul-mcp-protocol-2025-11-25 0.3.32",
+              "id": "turul-mcp-protocol-2025-11-25 0.3.34",
               "target": "turul_mcp_protocol_2025_11_25"
             }
           ],
           "selects": {}
         },
         "edition": "2024",
-        "version": "0.3.32"
+        "version": "0.3.34"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -30726,14 +30727,14 @@
       ],
       "license_file": null
     },
-    "turul-mcp-protocol-2025-11-25 0.3.32": {
+    "turul-mcp-protocol-2025-11-25 0.3.34": {
       "name": "turul-mcp-protocol-2025-11-25",
-      "version": "0.3.32",
+      "version": "0.3.34",
       "package_url": "https://github.com/aussierobots/turul-mcp-framework",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/turul-mcp-protocol-2025-11-25/0.3.32/download",
-          "sha256": "2586edbf9d48ea3c05e475ac32da4306986d98248959b451fd488a8bbcc181e7"
+          "url": "https://static.crates.io/crates/turul-mcp-protocol-2025-11-25/0.3.34/download",
+          "sha256": "ba4b9d327b1ba3ae38bd08be60faac9bc3b5b00b0eb7f23d27856ab74d30817b"
         }
       },
       "targets": [
@@ -30776,7 +30777,7 @@
               "target": "thiserror"
             },
             {
-              "id": "turul-mcp-json-rpc-server 0.3.32",
+              "id": "turul-mcp-json-rpc-server 0.3.34",
               "target": "turul_mcp_json_rpc_server"
             }
           ],
@@ -30792,7 +30793,7 @@
           ],
           "selects": {}
         },
-        "version": "0.3.32"
+        "version": "0.3.34"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -30872,14 +30873,14 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "typenum 1.19.0": {
+    "typenum 1.20.0": {
       "name": "typenum",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "package_url": "https://github.com/paholg/typenum",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/typenum/1.19.0/download",
-          "sha256": "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+          "url": "https://static.crates.io/crates/typenum/1.20.0/download",
+          "sha256": "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
         }
       },
       "targets": [
@@ -30894,18 +30895,6 @@
               ]
             }
           }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
         }
       ],
       "library_target_name": "typenum",
@@ -30913,28 +30902,8 @@
         "compile_data_glob": [
           "**"
         ],
-        "deps": {
-          "common": [
-            {
-              "id": "typenum 1.19.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2018",
-        "version": "1.19.0"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ]
+        "version": "1.20.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -31807,7 +31776,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ]
@@ -36201,14 +36170,14 @@
       ],
       "license_file": "LICENSE-MIT"
     },
-    "winnow 1.0.1": {
+    "winnow 1.0.2": {
       "name": "winnow",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "package_url": "https://github.com/winnow-rs/winnow",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/winnow/1.0.1/download",
-          "sha256": "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+          "url": "https://static.crates.io/crates/winnow/1.0.2/download",
+          "sha256": "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
         }
       },
       "targets": [
@@ -36242,7 +36211,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.1"
+        "version": "1.0.2"
       },
       "license": "MIT",
       "license_ids": [
@@ -37032,7 +37001,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.185",
+                "id": "libc 0.2.186",
                 "target": "libc"
               }
             ],
@@ -38417,7 +38386,7 @@
               "target": "enumflags2"
             },
             {
-              "id": "libc 0.2.185",
+              "id": "libc 0.2.186",
               "target": "libc"
             },
             {
@@ -38570,11 +38539,11 @@
   },
   "binary_crates": [],
   "workspace_members": {
-    "harper-core 0.8.0": "lib/harper-core",
+    "harper-core 0.9.0": "lib/harper-core",
     "harper-firmware 0.1.0": "lib/harper-firmware",
     "harper-mcp-server 0.1.0": "lib/harper-mcp-server",
     "harper-sandbox 0.1.0": "lib/harper-sandbox",
-    "harper-ui 0.7.1": "lib/harper-ui",
+    "harper-ui 0.8.0": "lib/harper-ui",
     "harper-workspace 0.7.0": ""
   },
   "conditions": {
@@ -38819,6 +38788,7 @@
     "config 0.15.22",
     "crossterm 0.29.0",
     "ctr 0.9.2",
+    "dashmap 5.5.3",
     "dirs 6.0.0",
     "dotenvy 0.15.7",
     "getrandom 0.4.2",
@@ -38831,6 +38801,7 @@
     "hyper 1.9.0",
     "image 0.25.10",
     "keyring 2.3.3",
+    "lazy_static 1.5.0",
     "log 0.4.29",
     "ratatui 0.30.0",
     "reqwest 0.12.28",
@@ -38847,8 +38818,8 @@
     "tokio 1.52.1",
     "tower 0.5.3",
     "tracing 0.1.44",
-    "turul-mcp-client 0.3.32",
-    "turul-mcp-json-rpc-server 0.2.1",
+    "turul-mcp-client 0.3.34",
+    "turul-mcp-json-rpc-server 0.3.34",
     "urlencoding 2.1.3",
     "uuid 1.23.1",
     "windows-sys 0.61.2",
@@ -38857,7 +38828,6 @@
   "direct_dev_deps": [
     "assert_cmd 2.2.1",
     "criterion 0.5.1",
-    "lazy_static 1.5.0",
     "num_cpus 1.17.0",
     "predicates 3.1.4",
     "rand 0.10.1",

--- a/lib/harper-core/BUILD
+++ b/lib/harper-core/BUILD
@@ -4,7 +4,12 @@ load("@crates//:defs.bzl", "all_crate_deps")
 rust_library(
     name = "harper_core",
     srcs = glob(["src/**/*.rs"]),
-    deps = all_crate_deps(normal = True),
+    deps = all_crate_deps(normal = True) + [
+        "//lib/harper-firmware:harper_firmware",
+        "//lib/harper-sandbox:harper_sandbox",
+        "@crates//:axum",
+        "@crates//:log",
+    ],
     proc_macro_deps = ["@crates//:async-trait"],
     rustc_env = {
         "HARPER_VERSION": "0.7.1",
@@ -15,7 +20,12 @@ rust_library(
 rust_test(
     name = "harper_core_test",
     crate = ":harper_core",
-    deps = all_crate_deps(normal_dev = True),
+    deps = all_crate_deps(normal_dev = True) + [
+        "//lib/harper-firmware:harper_firmware",
+        "//lib/harper-sandbox:harper_sandbox",
+        "@crates//:axum",
+        "@crates//:log",
+    ],
     proc_macro_deps = ["@crates//:async-trait"],
     rustc_env = {
         "HARPER_VERSION": "0.7.1",

--- a/lib/harper-mcp-server/BUILD
+++ b/lib/harper-mcp-server/BUILD
@@ -6,6 +6,8 @@ exports_files(glob(["src/**/*.rs"]))
 rust_binary(
     name = "harper_mcp_server",
     srcs = glob(["src/**/*.rs"]),
-    deps = all_crate_deps(normal = True),
+    deps = all_crate_deps(normal = True) + [
+        "@crates//:lazy_static",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/lib/harper-mcp-server/Cargo.toml
+++ b/lib/harper-mcp-server/Cargo.toml
@@ -30,5 +30,5 @@ serde_json = "1.0.140"
 axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
-lazy_static = "1.4"
+lazy_static = "1.5"
 dashmap = "5.5"

--- a/lib/harper-mcp-server/src/main.rs
+++ b/lib/harper-mcp-server/src/main.rs
@@ -276,3 +276,202 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     axum::serve(listener, app).await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_rate_limiter_new() {
+        let limiter = RateLimiter::new();
+        // Should allow requests initially
+        assert!(limiter.check("127.0.0.1"));
+    }
+
+    #[test]
+    fn test_rate_limiter_under_limit() {
+        let limiter = RateLimiter::new();
+        let ip = "127.0.0.1";
+
+        // Should allow up to RATE_LIMIT_REQUESTS
+        for _ in 0..RATE_LIMIT_REQUESTS {
+            assert!(limiter.check(ip), "Should allow request under limit");
+        }
+    }
+
+    #[test]
+    fn test_rate_limiter_over_limit() {
+        let limiter = RateLimiter::new();
+        let ip = "127.0.0.1";
+
+        // Fill up the limit
+        for _ in 0..RATE_LIMIT_REQUESTS {
+            assert!(limiter.check(ip));
+        }
+
+        // This should be blocked
+        assert!(!limiter.check(ip), "Should block request over limit");
+    }
+
+    #[test]
+    fn test_rate_limiter_cleanup() {
+        let limiter = RateLimiter::new();
+        let ip = "127.0.0.1";
+
+        // Fill up the limit
+        for _ in 0..RATE_LIMIT_REQUESTS {
+            assert!(limiter.check(ip));
+        }
+        assert!(!limiter.check(ip));
+
+        // Wait for the window to expire (simulate time passing)
+        thread::sleep(Duration::from_secs(RATE_LIMIT_WINDOW_SECS + 1));
+
+        // Should allow again after cleanup
+        assert!(limiter.check(ip), "Should allow after window expires");
+    }
+
+    #[test]
+    fn test_rate_limiter_different_ips() {
+        let limiter = RateLimiter::new();
+
+        // Fill up for one IP
+        for _ in 0..RATE_LIMIT_REQUESTS {
+            assert!(limiter.check("127.0.0.1"));
+        }
+        assert!(!limiter.check("127.0.0.1"));
+
+        // Different IP should still work
+        assert!(limiter.check("127.0.0.2"));
+    }
+
+    #[test]
+    fn test_error_response() {
+        let response = error_response(Some(json!(1)), -32600, "Test error", None);
+        assert_eq!(response.jsonrpc, "2.0");
+        assert_eq!(response.id, Some(json!(1)));
+        assert!(response.result.is_none());
+        assert!(response.error.is_some());
+
+        let error = response.error.unwrap();
+        assert_eq!(error.code, -32600);
+        assert_eq!(error.message, "Test error");
+        assert!(error.data.is_none());
+    }
+
+    #[test]
+    fn test_handle_initialize_valid() {
+        let params = json!({
+            "protocolVersion": PROTOCOL_VERSION
+        });
+        let response = handle_initialize(json!(1), Some(&params));
+
+        assert_eq!(response.jsonrpc, "2.0");
+        assert_eq!(response.id, Some(json!(1)));
+        assert!(response.error.is_none());
+        assert!(response.result.is_some());
+
+        let result = response.result.unwrap();
+        assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
+        assert!(result.get("capabilities").is_some());
+        assert!(result.get("serverInfo").is_some());
+    }
+
+    #[test]
+    fn test_handle_initialize_invalid_protocol() {
+        let params = json!({
+            "protocolVersion": "invalid"
+        });
+        let response = handle_initialize(json!(1), Some(&params));
+
+        assert!(response.error.is_some());
+        assert_eq!(response.error.unwrap().code, -32602);
+    }
+
+    #[test]
+    fn test_handle_initialize_no_params() {
+        let response = handle_initialize(json!(1), None);
+
+        assert!(response.error.is_some());
+        assert_eq!(response.error.unwrap().code, -32601);
+    }
+
+    #[test]
+    fn test_handle_tools_list() {
+        let response = handle_tools_list(json!(1));
+
+        assert_eq!(response.jsonrpc, "2.0");
+        assert_eq!(response.id, Some(json!(1)));
+        assert!(response.error.is_none());
+        assert!(response.result.is_some());
+
+        let result = response.result.unwrap();
+        let tools = result["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["name"], "echo");
+        assert_eq!(tools[1]["name"], "get_time");
+    }
+
+    #[test]
+    fn test_handle_tools_call_echo() {
+        let params = json!({
+            "name": "echo",
+            "arguments": {
+                "message": "Hello, World!"
+            }
+        });
+        let response = handle_tools_call(json!(1), Some(&params));
+
+        assert!(response.error.is_none());
+        assert!(response.result.is_some());
+
+        let result = response.result.unwrap();
+        let content = &result["content"][0];
+        assert_eq!(content["type"], "text");
+        assert_eq!(content["text"], "Hello, World!");
+    }
+
+    #[test]
+    fn test_handle_tools_call_get_time() {
+        let params = json!({
+            "name": "get_time",
+            "arguments": {}
+        });
+        let response = handle_tools_call(json!(1), Some(&params));
+
+        assert!(response.error.is_none());
+        assert!(response.result.is_some());
+
+        let result = response.result.unwrap();
+        let content = &result["content"][0];
+        assert_eq!(content["type"], "text");
+        // Should be a valid RFC3339 timestamp
+        assert!(content["text"].as_str().unwrap().contains('T'));
+    }
+
+    #[test]
+    fn test_handle_tools_call_invalid_tool() {
+        let params = json!({
+            "name": "invalid_tool",
+            "arguments": {}
+        });
+        let response = handle_tools_call(json!(1), Some(&params));
+
+        assert!(response.error.is_some());
+        assert_eq!(response.error.unwrap().code, -32601);
+    }
+
+    #[test]
+    fn test_handle_tools_call_missing_args() {
+        let params = json!({
+            "name": "echo"
+        });
+        let response = handle_tools_call(json!(1), Some(&params));
+
+        assert!(response.error.is_some());
+        assert_eq!(response.error.unwrap().code, -32602);
+    }
+}

--- a/lib/harper-sandbox/src/lib.rs
+++ b/lib/harper-sandbox/src/lib.rs
@@ -268,18 +268,16 @@ impl Sandbox {
 
     pub fn is_command_allowed(&self, command: &str) -> bool {
         if let Some(allowed) = &self.config.allowed_commands {
-            if !allowed.is_empty() {
-                return allowed.iter().any(|c| command.contains(c));
+            if !allowed.is_empty() && allowed.iter().any(|c| command.contains(c)) {
+                return true;
             }
         }
         if let Some(blocked) = &self.config.blocked_commands {
-            for b in blocked {
-                if command.contains(b) {
-                    return false;
-                }
+            if blocked.iter().any(|b| command.contains(b)) {
+                return false;
             }
         }
-        true
+        self.config.allowed_commands.is_none()
     }
 }
 
@@ -288,7 +286,7 @@ fn bpush(args: &mut Vec<String>, flag: &str, val: impl Into<String>) {
     args.push(flag.to_string());
     args.push(val.into());
 }
-
+// }
 #[allow(dead_code)]
 mod config {
     pub use super::SandboxConfig;
@@ -343,6 +341,8 @@ mod tests {
         let config = SandboxConfig::default();
         assert!(!config.enabled);
         assert!(config.readonly_home);
+        assert!(!config.network_access);
+        assert_eq!(config.max_execution_time_secs, Some(30));
     }
 
     #[test]
@@ -350,5 +350,75 @@ mod tests {
         std::env::set_var("HARPER_SANDBOX_ENABLED", "true");
         let config = config::from_env();
         assert!(config.enabled);
+        std::env::remove_var("HARPER_SANDBOX_ENABLED");
+    }
+
+    #[test]
+    fn test_sandbox_new() {
+        let config = SandboxConfig::default();
+        let sandbox = Sandbox::new(config);
+        // Backend detection depends on platform, but new() should work
+        assert!(matches!(
+            sandbox.backend,
+            SandboxBackend::Bubblewrap | SandboxBackend::SandboxExec | SandboxBackend::None
+        ));
+    }
+
+    #[test]
+    fn test_backend_name() {
+        let config = SandboxConfig::default();
+        let sandbox = Sandbox::new(config);
+
+        let name = sandbox.backend_name();
+        match sandbox.backend {
+            SandboxBackend::Bubblewrap => assert_eq!(name, "bubblewrap (bwrap)"),
+            SandboxBackend::SandboxExec => assert_eq!(name, "sandbox-exec (macOS)"),
+            SandboxBackend::None => assert_eq!(name, "none"),
+        }
+    }
+
+    #[test]
+    fn test_is_available() {
+        let config = SandboxConfig::default();
+        let sandbox = Sandbox::new(config);
+        // Availability depends on backend detection
+        let available = sandbox.is_available();
+        assert_eq!(available, sandbox.backend != SandboxBackend::None);
+    }
+
+    #[test]
+    fn test_is_command_allowed_no_restrictions() {
+        let config = SandboxConfig::default();
+        let sandbox = Sandbox::new(config);
+
+        assert!(sandbox.is_command_allowed("ls"));
+        assert!(sandbox.is_command_allowed("echo hello"));
+        assert!(sandbox.is_command_allowed("rm -rf /"));
+    }
+
+    #[test]
+    fn test_is_command_allowed_with_blocked() {
+        let config = SandboxConfig {
+            blocked_commands: Some(vec!["rm".to_string(), "sudo".to_string()]),
+            ..Default::default()
+        };
+        let sandbox = Sandbox::new(config);
+
+        assert!(sandbox.is_command_allowed("ls"));
+        assert!(!sandbox.is_command_allowed("rm -rf /"));
+        assert!(!sandbox.is_command_allowed("sudo apt update"));
+    }
+
+    #[test]
+    fn test_is_command_allowed_with_allowed() {
+        let config = SandboxConfig {
+            allowed_commands: Some(vec!["ls".to_string(), "cat".to_string()]),
+            ..Default::default()
+        };
+        let sandbox = Sandbox::new(config);
+
+        assert!(sandbox.is_command_allowed("ls"));
+        assert!(sandbox.is_command_allowed("cat file.txt"));
+        assert!(!sandbox.is_command_allowed("rm -rf /"));
     }
 }


### PR DESCRIPTION
Bump dependency versions and * comprehensive test coverage

Bump `libc` to `0.2.186`, `rustls` to `0.23.39`, `rustls-webpki` to `0.103.13`, `openssl` to `0.10.78`, `openssl-sys` to `0.9.114`, `typenum` to `1.20.0`, `winnow` to `1.0.2`, `turul-mcp-client/json-rpc-server/protocol` to `0.3.34`, and `rules_java` to `9.1.0`. Add `dashmap` `5.5.3` as a direct dependency and promote `lazy_static` from dev-only to a normal dependency of `harper-mcp-server`. Bump `harper-core` to `0.9.0` and `harper-ui` to `0.8.0`. Standardize `CARGO_BAZEL_REPIN=true` across all CI workflows (replacing `=1`). Add a `.agents/skills/localfix.md` skill documenting the cache-clearing and repin workflow for local build issues.

Add 14 unit tests to `harper-mcp-server` covering rate limiting (new, under-limit, over-limit, window expiry, per-IP isolation), JSON-RPC error response construction, initialize handling (valid, invalid protocol version, missing params), `tools/list`, and `tools/call` (echo, get_time, unknown tool, missing arguments).

Add 8 unit tests to `harper-sandbox` covering `SandboxConfig` default field assertions, environment-variable config loading with proper cleanup, `Sandbox::new` backend detection, `backend_name`, `is_available`, and `is_command_allowed` with no restrictions, blocked-command lists, and allowed-command lists. Fix `is_command_allowed` logic so that an empty `allowed_commands` list correctly denies unlisted commands rather than falling through to allow-all.

- All existing tests continue to pass.
- New tests provide comprehensive coverage for previously sparse modules.
- Total test count increased significantly.
- CI checks pass (compilation, linting, testing).