### PR TITLE
[chore] sync versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "harper-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes",
  "arboard",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "harper-ui"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arboard",
  "async-trait",


### PR DESCRIPTION
Update Cargo.lock to reflect harper-core 0.9.1 and harper-ui 0.8.1. - Cargo.lock regenerated from cargo update.