### PR TITLE
[docs] include rustdoc comments across core modules

### DIFF
--- a/lib/harper-core/src/server/mod.rs
+++ b/lib/harper-core/src/server/mod.rs
@@ -140,6 +140,13 @@ pub async fn chat(
     })
 }
 
+/// Creates the Axum router with all API routes configured
+///
+/// # Arguments
+/// * `conn` - Database connection wrapped in Arc<Mutex<>>
+///
+/// # Returns
+/// Configured Axum Router with health and session endpoints
 pub fn create_router(conn: Arc<Mutex<Connection>>) -> Router {
     let state = Arc::new(ServerState { conn });
 

--- a/lib/harper-core/src/tools/git.rs
+++ b/lib/harper-core/src/tools/git.rs
@@ -47,7 +47,22 @@ fn process_git_status_output(output: std::process::Output) -> String {
     }
 }
 
-/// Get git status
+/// Get the current git repository status
+///
+/// Returns the output of `git status --porcelain` which shows
+/// staged, unstaged, and untracked files in a machine-readable format.
+///
+/// # Returns
+/// A string containing the git status output
+///
+/// # Errors
+/// Returns `HarperError::Command` if the git command fails
+///
+/// # Example
+/// ```
+/// let status = harper_core::tools::git::git_status()?;
+/// println!("Git status: {}", status);
+/// ```
 pub fn git_status() -> crate::core::error::HarperResult<String> {
     let output = std::process::Command::new("git")
         .arg("status")
@@ -70,7 +85,26 @@ pub async fn git_status_async() -> crate::core::error::HarperResult<String> {
     Ok(process_git_status_output(output))
 }
 
-/// Show git diff
+/// Get the current git diff
+///
+/// Returns the output of `git diff` showing unstaged changes
+/// between the working directory and the index.
+///
+/// # Returns
+/// A string containing the git diff output
+///
+/// # Errors
+/// Returns `HarperError::Command` if the git command fails
+///
+/// # Example
+/// ```
+/// let diff = harper_core::tools::git::git_diff()?;
+/// if diff.is_empty() {
+///     println!("No unstaged changes");
+/// } else {
+///     println!("Unstaged changes:\n{}", diff);
+/// }
+/// ```
 pub fn git_diff() -> crate::core::error::HarperResult<String> {
     let output = std::process::Command::new("git")
         .arg("diff")

--- a/lib/harper-core/src/tools/todo.rs
+++ b/lib/harper-core/src/tools/todo.rs
@@ -21,8 +21,28 @@ use crate::core::error::HarperError;
 use crate::memory::storage;
 use crate::tools::parsing;
 
-/// Manage todo list operations
-/// Supports: [TODO add "task description"], [TODO list], [TODO remove N]
+/// Manage todo list operations for task tracking
+///
+/// Supports the following commands:
+/// - `[TODO add "task description"]` - Add a new todo item
+/// - `[TODO list]` - List all todo items
+/// - `[TODO remove N]` - Remove todo item by index (1-based)
+///
+/// # Arguments
+/// * `conn` - SQLite database connection
+/// * `response` - Input string containing the todo command
+///
+/// # Returns
+/// A success message or the list of todos
+///
+/// # Errors
+/// Returns `HarperError::Command` for invalid commands or database errors
+///
+/// # Example
+/// ```
+/// let result = manage_todo(&conn, "[TODO add \"fix bug\"]")?;
+/// println!("Result: {}", result);
+/// ```
 pub fn manage_todo(
     conn: &rusqlite::Connection,
     response: &str,

--- a/lib/harper-firmware/src/lib.rs
+++ b/lib/harper-firmware/src/lib.rs
@@ -17,16 +17,22 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
 
+/// Errors that can occur during firmware operations
 #[derive(Debug, Error)]
 pub enum FirmwareError {
+    /// Device is not connected or available
     #[error("Device not connected: {0}")]
     DeviceNotConnected(String),
+    /// Communication failure with the device
     #[error("Communication error: {0}")]
     CommunicationError(String),
+    /// Pin configuration or access error
     #[error("Pin error: {0}")]
     PinError(String),
+    /// Platform is not supported for firmware operations
     #[error("Unsupported platform: {0}")]
     UnsupportedPlatform(String),
+    /// Input/output operation failed
     #[error("IO error: {0}")]
     IoError(String),
 }

--- a/lib/harper-sandbox/src/lib.rs
+++ b/lib/harper-sandbox/src/lib.rs
@@ -64,12 +64,28 @@ pub enum SandboxBackend {
     None,
 }
 
+/// Sandbox execution environment for secure command running
+///
+/// Provides isolated execution of system commands with configurable
+/// restrictions on directories, commands, and network access.
 pub struct Sandbox {
     config: SandboxConfig,
     backend: SandboxBackend,
 }
 
 impl Sandbox {
+    /// Create a new sandbox with the given configuration
+    ///
+    /// Automatically detects the available backend (Bubblewrap, SandboxExec, or None).
+    ///
+    /// # Arguments
+    /// * `config` - Sandbox configuration settings
+    ///
+    /// # Example
+    /// ```
+    /// let config = SandboxConfig::default();
+    /// let sandbox = Sandbox::new(config);
+    /// ```
     pub fn new(config: SandboxConfig) -> Self {
         let backend = Self::detect_backend();
         Self { config, backend }
@@ -92,10 +108,20 @@ impl Sandbox {
         SandboxBackend::None
     }
 
+    /// Check if sandbox execution is available on this system
+    ///
+    /// Returns true if a supported sandbox backend is detected and available.
+    ///
+    /// # Returns
+    /// true if sandboxing is supported, false otherwise
     pub fn is_available(&self) -> bool {
         self.backend != SandboxBackend::None
     }
 
+    /// Get the name of the detected sandbox backend
+    ///
+    /// # Returns
+    /// A string describing the backend: "bubblewrap (bwrap)", "sandbox-exec (macOS)", or "none"
     pub fn backend_name(&self) -> &str {
         match self.backend {
             SandboxBackend::Bubblewrap => "bubblewrap (bwrap)",
@@ -104,6 +130,26 @@ impl Sandbox {
         }
     }
 
+    /// Execute a command in the sandbox environment
+    ///
+    /// Runs the specified command with arguments, applying sandbox restrictions
+    /// based on the configuration. If sandboxing is disabled, executes directly.
+    ///
+    /// # Arguments
+    /// * `command` - The command to execute
+    /// * `args` - Command arguments as string slices
+    ///
+    /// # Returns
+    /// The command output including stdout, stderr, and exit status
+    ///
+    /// # Errors
+    /// Returns `SandboxError` for execution failures, timeouts, or unavailable sandbox
+    ///
+    /// # Example
+    /// ```
+    /// let output = sandbox.execute("echo", &["hello", "world"]).await?;
+    /// println!("Output: {}", String::from_utf8_lossy(&output.stdout));
+    /// ```
     pub async fn execute(&self, command: &str, args: &[&str]) -> Result<std::process::Output> {
         if !self.config.enabled {
             return self.execute_direct(command, args).await;
@@ -266,6 +312,23 @@ impl Sandbox {
         ))
     }
 
+    /// Check if a command is allowed to run based on configured restrictions
+    ///
+    /// Commands are allowed if they match the allowed list (if specified) and
+    /// don't match the blocked list.
+    ///
+    /// # Arguments
+    /// * `command` - The command string to check
+    ///
+    /// # Returns
+    /// true if the command is permitted, false otherwise
+    ///
+    /// # Example
+    /// ```
+    /// if sandbox.is_command_allowed("ls") {
+    ///     println!("ls command is allowed");
+    /// }
+    /// ```
     pub fn is_command_allowed(&self, command: &str) -> bool {
         if let Some(allowed) = &self.config.allowed_commands {
             if !allowed.is_empty() && allowed.iter().any(|c| command.contains(c)) {


### PR DESCRIPTION
Include comprehensive `///` documentation comments for public APIs across the codebase to improve developer experience and API discoverability.

`create_router` in `harper-core/src/server/mod.rs` now documents its arguments and return value

`git_status` and `git_diff` in `harper-core/src/tools/git.rs` include descriptions, error conditions, and usage examples

`manage_todo` in `harper-core/src/tools/todo.rs` documents supported commands, arguments, return values, and errors

`FirmwareError` variants in `harper-firmware/src/lib.rs` have inline doc comments describing each error case

`Sandbox`, `Sandbox::new`, `is_available`, `backend_name`, `execute`, and is_command_allowed in `harper-sandbox/src/lib.rs` are fully documented with descriptions, arguments, return values, error conditions, and examples