### PR TITLE
[chore] overhaul makefile and fix doc block annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,97 +1,70 @@
-.PHONY: help test build clean fmt lint doc install run dev check all
-
 # Copyright 2026 harpertoken
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Licensed under the Apache License, Version 2.0
 
-# Default target
-help:
-	@echo "Harper - AI Agent"
-	@echo ""
-	@echo "Available commands:"
-	@echo "  make test     - Run all tests and checks"
-	@echo "  make build    - Build the project"
-	@echo "  make run      - Run the application"
-	@echo "  make dev      - Run in development mode"
-	@echo "  make fmt      - Format code"
-	@echo "  make lint     - Run linter"
-	@echo "  make doc      - Generate documentation"
-	@echo "  make clean    - Clean build artifacts"
-	@echo "  make install  - Install dependencies"
-	@echo "  make check    - Quick check (fmt + lint)"
-	@echo "  make all      - Run everything (check + test + build)"
+.PHONY: help test test-release build build-debug run run-server dev fmt lint doc clean install update audit deny check all
 
-# Run comprehensive tests
-test:
-	@./scripts/test.sh
+help: ## Show available targets
+	@printf "\nHarper\n\n"
+	@printf "Usage:\n  make <target>\n\n"
+	@printf "Targets:\n"
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?##"} {printf "  %-14s %s\n", $$1, $$2}'
 
-# Build the project
-build:
-	cargo build --release
+test: ## Run tests (unit + integration)
+	@cargo test --lib --workspace
+	@cargo test --tests --workspace
 
-# Run the application
-run:
-	cargo run
+test-release: ## Run tests in release mode
+	@cargo test --release --workspace
 
-# Development mode with file watching (requires cargo-watch)
-dev:
+build: ## Build release
+	@cargo build --release --workspace
+
+build-debug: ## Build debug
+	@cargo build --workspace
+
+run: ## Run harper-ui
+	@cargo run -p harper-ui
+
+run-server: ## Run harper-mcp-server
+	@cargo run -p harper-mcp-server
+
+dev: ## Development mode (watch if available)
 	@if command -v cargo-watch >/dev/null 2>&1; then \
 		cargo watch -x run; \
 	else \
-		echo "cargo-watch not installed. Run: cargo install cargo-watch"; \
-		cargo run; \
+		printf "cargo-watch not installed. Install with:\n  cargo install cargo-watch\n"; \
+		cargo run -p harper-ui; \
 	fi
 
-# Format code
-fmt:
-	cargo fmt --all
+fmt: ## Check formatting
+	@cargo fmt --all --check
 
-# Run linter
-lint:
-	cargo clippy --all-targets --all-features --workspace -- -D warnings
+lint: ## Run clippy
+	@cargo clippy --all-targets --all-features --workspace -- -D warnings
 
-# Generate documentation
-doc:
-	cargo doc --no-deps --document-private-items --all-features --workspace --open
+doc: ## Generate docs
+	@cargo doc --no-deps --document-private-items --all-features --workspace --open
 
-# Clean build artifacts
-clean:
-	cargo clean
-	rm -f chat_sessions.db
-	rm -f session_*.txt
+clean: ## Clean artifacts
+	@cargo clean
+	@rm -f chat_sessions.db session_*.txt
 
-# Install development dependencies
-install:
-	cargo install cargo-audit cargo-deny cargo-watch cargo-llvm-cov
+install: ## Install dev tools
+	@cargo install cargo-audit cargo-deny cargo-watch
 
-# Quick check
-check: fmt lint
-	@echo "Quick check completed"
+update: ## Update dependencies
+	@cargo update
 
-# Run everything
-all: check test build
-	@echo "All tasks completed successfully"
+audit: ## Security audit
+	@cargo audit || true
 
-# Update dependencies
-update:
-	cargo update
+deny: ## Dependency check
+	@cargo deny check || true
 
-# Security audit
-audit:
-	cargo audit
+check: fmt lint doc ## Quick check
+	@printf "✓ check complete\n"
 
-# Dependency check
-deny:
-	cargo deny check
-
-# Updated for v0.1.6
+all: check test test-release build build-debug ## Run everything
+	@printf "✓ all tasks complete\n"

--- a/lib/harper-core/src/tools/git.rs
+++ b/lib/harper-core/src/tools/git.rs
@@ -59,7 +59,7 @@ fn process_git_status_output(output: std::process::Output) -> String {
 /// Returns `HarperError::Command` if the git command fails
 ///
 /// # Example
-/// ```ignore
+/// ```text
 /// match harper_core::tools::git::git_status() {
 ///     Ok(status) => println!("Git status: {}", status),
 ///     Err(e) => println!("Error: {}", e),
@@ -99,7 +99,7 @@ pub async fn git_status_async() -> crate::core::error::HarperResult<String> {
 /// Returns `HarperError::Command` if the git command fails
 ///
 /// # Example
-/// ```ignore
+/// ```text
 /// match harper_core::tools::git::git_diff() {
 ///     Ok(diff) if diff.is_empty() => println!("No unstaged changes"),
 ///     Ok(diff) => println!("Unstaged changes:\n{}", diff),

--- a/lib/harper-core/src/tools/todo.rs
+++ b/lib/harper-core/src/tools/todo.rs
@@ -39,7 +39,7 @@ use crate::tools::parsing;
 /// Returns `HarperError::Command` for invalid commands or database errors
 ///
 /// # Example
-/// ```ignore
+/// ```text
 /// // This function requires a database connection
 /// // Use it in your application with a proper rusqlite::Connection
 /// // let result = manage_todo(&connection, "[TODO add \"fix bug\"]")?;

--- a/lib/harper-sandbox/src/lib.rs
+++ b/lib/harper-sandbox/src/lib.rs
@@ -82,7 +82,7 @@ impl Sandbox {
     /// * `config` - Sandbox configuration settings
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// // let config = SandboxConfig::default();
     /// // let sandbox = Sandbox::new(config);
     /// ```
@@ -149,7 +149,7 @@ impl Sandbox {
     /// Returns `SandboxError` for execution failures, timeouts, or unavailable sandbox
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// // let output = sandbox.execute("echo", &["hello", "world"]).await?;
     /// // println!("Output: {}", String::from_utf8_lossy(&output.stdout));
     /// ```
@@ -324,7 +324,7 @@ impl Sandbox {
     /// true if the command is permitted, false otherwise
     ///
     /// # Example
-    /// ```ignore
+    /// ```text
     /// // if sandbox.is_command_allowed("ls") {
     /// //     println!("ls command is allowed");
     /// // }


### PR DESCRIPTION
## GNU Help System

Uses GNU Make 3.81+ inline docs syntax (`##` comments) to auto-generate help output:

```makefile
help: ## Show available targets
	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \
		awk 'BEGIN {FS = ":.*?##"} {printf "  %-14s %s\n", $$1, $$2}'
```

* The `##` after each target acts as a documentation comment
* `grep` extracts documented targets
* `awk` formats aligned output for CLI display

### Before

```makefile
@echo "Harper - AI Agent"
@echo ""
@echo "Available commands:"
@echo "  make test     - Run all tests and checks"
```

### After

```makefile
help: ## Show available targets
	@printf "\nHarper\n\n"
	@printf "Usage:\n  make <target>\n\n"
```

---

## Build System

* Adopted a GNU-style Makefile with self-documenting targets using `##` comments and auto-generated help output
* Added `run-server` target for `harper-mcp-server`
* Replaced `./scripts/test.sh` with direct `cargo test --lib` and `cargo test --tests`
* Added `test-release` and `build-debug` targets
* Updated `fmt` to use `--check` for validation rather than in-place formatting
* Removed `cargo-llvm-cov` from install dependencies
* Prefixed all commands with `@` to suppress echo output
* Moved `.PHONY` declaration below the license header

---

## Changes

* Shortened license header to a single line
* Switched to inline Makefile docs (`##`) for auto-generated help
* Added `audit` and `deny` targets with `|| true` to allow non-blocking failures
* Added `run-server` for `harper-mcp-server`
* Cleaner CLI output with `printf` and ✓ checkmarks
* Switched doc code blocks from `ignore to `text in `todo.rs` and `harper-sandbox/src/lib.rs`
