### PR TITLE
[feat] use libnudget rust-nightly reusable workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,47 +18,12 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:  # Allow manual trigger
 
-env:
-  CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: 0
-  CARGO_NET_RETRY: 10
-  RUST_BACKTRACE: short
-  RUSTFLAGS: "-D warnings"
-  RUSTUP_MAX_RETRIES: 10
-
 jobs:
   nightly-checks:
     name: nightly-checks
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'harpertoken'
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential pkg-config libsqlite3-dev
-    - name: Install Rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        components: rustfmt, clippy
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-    - name: Run nightly tests
-      run: cargo test --all-features --workspace --verbose
-      env:
-        RUST_LOG: debug
-    - name: Run integration tests
-      run: cargo test --all-features --workspace --verbose -- --test-threads=1
-      env:
-        RUST_LOG: debug
-    - name: Build in release mode
-      run: cargo build --release --all-features --workspace --verbose
-    - name: Dependency scanning (audit)
-      uses: ./.github/actions/audit
-    - name: Install cargo-deny
-      run: cargo install cargo-deny
-    - name: License checks (deny)
-      run: cargo deny check
+    uses: libnudget/rust-nightly/.github/workflows/nightly.yml@main
+    with:
+      rust-version: stable
+      test-flags: --all-features --workspace
+      build-flags: --release --all-features --workspace
+      run-benchmarks: true


### PR DESCRIPTION
Use libnudget/rust-nightly reusable workflow for nightly builds. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.