### PR TITLE
[fix] github-actions bot to cla signers

### DIFF
--- a/signed.json
+++ b/signed.json
@@ -2,6 +2,7 @@
   "signed": [
     "bniladridas",
     "dependabot[bot]",
-    "harper-rel-hq"
+    "harper-rel-hq",
+    "github-actions[bot]"
   ]
 }


### PR DESCRIPTION
Add github-actions[bot] to CLA signed list so cargo-lock-update PR passes