### PR TITLE
[fix] use prerelease for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,5 +29,4 @@ jobs:
       run-benchmarks: false
       create-release: true
       release-tag: nightly
-      release-draft: false
       release-prerelease: true


### PR DESCRIPTION
Remove `release-draft` option, use only `release-prerelease`. Two-step approach: create draft first (for asset upload), then publish as prerelease. Fixed immutable release issue where assets couldn't be uploaded. Pre-commit (`fmt`/`clippy`/`check`/`yaml`) covered the changes.