### PR TITLE
[fix] normalize agents test paths on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "harper-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aes",
  "arboard",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "harper-ui"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/lib/harper-core/src/core/agents.rs
+++ b/lib/harper-core/src/core/agents.rs
@@ -456,8 +456,10 @@ mod tests {
                     .path
                     .strip_prefix(&repo)
                     .expect("strip")
-                    .display()
-                    .to_string()
+                    .components()
+                    .map(|component| component.as_os_str().to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+                    .join("/")
             })
             .collect();
 


### PR DESCRIPTION
- Normalizes AGENTS test path rendering so the assertion is platform-independent.
- Includes the matching Cargo.lock workspace crate version sync needed by local tool runs.
- Fixes the Windows CI unit test failure in `core::agents::tests::resolves_agents_from_repo_root_to_target_directory`.