### PR TITLE
[feat] keyring-backed tui auth session storage with file fallback

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,43 +1,27 @@
-## Why
+## Changes
 
-Explain the motivation in your own words.
+- Use bullet points.
+- Prefer concrete reviewer-facing changes.
+- Use nested bullets when one change needs examples, endpoints, commands, or sub-points.
+- Call out behavior changes, storage changes, migrations, config changes, and docs updates explicitly.
 
-Helpful prompts:
-- What did you notice while working?
-- What felt incorrect, confusing, or unnecessary?
-- What outcome were you aiming for?
+Example shape:
+- Added browser and TUI auth flows using PKCE:
+  - `/auth/login/{provider}`
+  - `/auth/callback`
+  - `/auth/me`
+- Scoped session load and delete operations to the authenticated user.
+- Updated CLI behavior:
+  - `cargo harper` starts the TUI and local server by default.
+  - `--no-server` is the explicit opt-out.
 
-Write naturally — a short explanation is enough.
+## Validation
 
----
+- List the exact commands or manual checks you used.
+- Keep each item concrete and reproducible.
+- Include any important manual verification steps when behavior depends on the local environment.
 
-## What Changed
-
-Describe the change as you would explain it to a teammate.
-
-Helpful prompts:
-- What did you modify or remove?
-- Did you simplify, refactor, or fix something?
-- Are there any visible behavior or UI changes?
-
-A small bullet list is usually enough.
-
----
-
-## Verification
-
-Explain how you checked the change.
-
-Helpful prompts:
-- What steps did you take to test it?
-- What should reviewers try locally?
-- What result should they expect?
-
-Steps to verify:
-
-1.
-2.
-3.
-
-Expected result:
--
+Examples:
+- `cargo check -p harper-core`
+- `cargo test -p harper-ui`
+- manual verification of TUI sign-in and restart persistence

--- a/config/default.toml
+++ b/config/default.toml
@@ -90,6 +90,6 @@ allowed_dirs = []
 # max_execution_time_secs = 30
 
 [server]
-enabled = false
+enabled = true
 host = "127.0.0.1"
 port = 8081

--- a/lib/harper-ui/src/interfaces/ui/auth.rs
+++ b/lib/harper-ui/src/interfaces/ui/auth.rs
@@ -1,7 +1,11 @@
 use harper_core::{AuthSession, SessionStateView};
+use keyring::{Entry, Error as KeyringError};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+
+const KEYRING_SERVICE: &str = "harper";
+const TUI_AUTH_SESSION_ACCOUNT: &str = "tui-auth-session";
 
 #[derive(Debug, Clone)]
 pub enum TuiAuthCommand {
@@ -133,33 +137,42 @@ pub async fn fetch_remote_session_state(
 }
 
 pub fn load_auth_session() -> Option<AuthSession> {
-    let path = auth_session_path()?;
-    let content = fs::read_to_string(path).ok()?;
-    serde_json::from_str::<StoredAuthSession>(&content)
-        .ok()
-        .map(|stored| stored.session)
+    if let Some(session) = load_auth_session_from_keyring() {
+        return Some(session);
+    }
+
+    let session = load_auth_session_from_file()?;
+    if save_auth_session_to_keyring(&session).is_ok() {
+        let _ = delete_legacy_auth_session_file();
+    }
+    Some(session)
 }
 
 pub fn save_auth_session(session: &AuthSession) -> Result<(), String> {
-    let path = auth_session_path().ok_or_else(|| "Home directory not found".to_string())?;
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+    match save_auth_session_to_keyring(session) {
+        Ok(()) => {
+            let _ = delete_legacy_auth_session_file();
+            Ok(())
+        }
+        Err(keyring_error) => {
+            save_auth_session_to_file(session)?;
+            eprintln!(
+                "Warning: falling back to file-backed TUI auth session storage: {}",
+                keyring_error
+            );
+            Ok(())
+        }
     }
-    let content = serde_json::to_string_pretty(&StoredAuthSession {
-        session: session.clone(),
-    })
-    .map_err(|err| err.to_string())?;
-    fs::write(path, content).map_err(|err| err.to_string())
 }
 
 pub fn clear_auth_session() -> Result<(), String> {
-    let Some(path) = auth_session_path() else {
-        return Ok(());
-    };
-    if path.exists() {
-        fs::remove_file(path).map_err(|err| err.to_string())?;
+    if let Ok(entry) = auth_session_entry() {
+        match entry.delete_password() {
+            Ok(()) | Err(KeyringError::NoEntry) => {}
+            Err(err) => return Err(err.to_string()),
+        }
     }
-    Ok(())
+    delete_legacy_auth_session_file()
 }
 
 pub fn launch_browser(url: &str) -> Result<(), String> {
@@ -198,9 +211,71 @@ fn auth_session_path() -> Option<PathBuf> {
     Some(home.join(".harper").join("auth").join("tui-session.json"))
 }
 
+fn auth_session_entry() -> Result<Entry, String> {
+    Entry::new(KEYRING_SERVICE, TUI_AUTH_SESSION_ACCOUNT).map_err(|err| err.to_string())
+}
+
+fn load_auth_session_from_keyring() -> Option<AuthSession> {
+    let entry = auth_session_entry().ok()?;
+    let content = entry.get_password().ok()?;
+    deserialize_auth_session(&content).ok()
+}
+
+fn load_auth_session_from_file() -> Option<AuthSession> {
+    let path = auth_session_path()?;
+    let content = fs::read_to_string(path).ok()?;
+    deserialize_auth_session(&content).ok()
+}
+
+fn save_auth_session_to_keyring(session: &AuthSession) -> Result<(), String> {
+    let entry = auth_session_entry()?;
+    let content = serialize_auth_session(session)?;
+    entry.set_password(&content).map_err(|err| err.to_string())
+}
+
+fn save_auth_session_to_file(session: &AuthSession) -> Result<(), String> {
+    let path = auth_session_path().ok_or_else(|| "Home directory not found".to_string())?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+    }
+    let content = serialize_auth_session(session)?;
+    fs::write(path, content).map_err(|err| err.to_string())
+}
+
+fn delete_legacy_auth_session_file() -> Result<(), String> {
+    let Some(path) = auth_session_path() else {
+        return Ok(());
+    };
+    if path.exists() {
+        fs::remove_file(path).map_err(|err| err.to_string())?;
+    }
+    Ok(())
+}
+
+fn serialize_auth_session(session: &AuthSession) -> Result<String, String> {
+    serde_json::to_string_pretty(&StoredAuthSession {
+        session: session.clone(),
+    })
+    .map_err(|err| err.to_string())
+}
+
+fn deserialize_auth_session(content: &str) -> Result<AuthSession, String> {
+    serde_json::from_str::<StoredAuthSession>(content)
+        .map(|stored| stored.session)
+        .map_err(|err| err.to_string())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{parse_tui_auth_command, TuiAuthCommand};
+    use super::{
+        auth_session_path, clear_auth_session, load_auth_session, parse_tui_auth_command,
+        StoredAuthSession, TuiAuthCommand,
+    };
+    use harper_core::{AuthSession, AuthenticatedUser, UserAuthProvider};
+    use keyring::{mock, set_default_credential_builder};
+    use std::sync::Mutex;
+
+    static KEYRING_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn parses_tui_auth_login_command() {
@@ -208,6 +283,60 @@ mod tests {
         match command {
             TuiAuthCommand::Login { provider } => assert_eq!(provider, "github"),
             _ => panic!("expected login command"),
+        }
+    }
+
+    #[test]
+    fn loads_auth_session_from_legacy_file() {
+        let _guard = KEYRING_TEST_LOCK.lock().expect("lock keyring test");
+        set_default_credential_builder(mock::default_credential_builder());
+
+        let original_home = std::env::var_os("HOME");
+        let temp_dir =
+            std::env::temp_dir().join(format!("harper-keyring-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        std::env::set_var("HOME", &temp_dir);
+
+        let session = AuthSession {
+            access_token: "access-token".to_string(),
+            refresh_token: Some("refresh-token".to_string()),
+            expires_at: Some(12345),
+            user: AuthenticatedUser {
+                user_id: "user-1".to_string(),
+                email: Some("user@example.com".to_string()),
+                display_name: Some("Example User".to_string()),
+                provider: Some(UserAuthProvider::Github),
+            },
+        };
+
+        let legacy_path = auth_session_path().expect("legacy path");
+        let parent = legacy_path.parent().expect("legacy parent");
+        std::fs::create_dir_all(parent).expect("create auth dir");
+        std::fs::write(
+            &legacy_path,
+            serde_json::to_string_pretty(&StoredAuthSession {
+                session: session.clone(),
+            })
+            .expect("serialize session"),
+        )
+        .expect("write legacy session");
+
+        let loaded = load_auth_session().expect("load auth session");
+        assert_eq!(loaded, session);
+
+        clear_auth_session().expect("clear auth session");
+        assert!(load_auth_session().is_none());
+        assert!(!legacy_path.exists());
+
+        restore_home(original_home);
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    fn restore_home(original_home: Option<std::ffi::OsString>) {
+        if let Some(value) = original_home {
+            std::env::set_var("HOME", value);
+        } else {
+            std::env::remove_var("HOME");
         }
     }
 }

--- a/lib/harper-ui/src/main.rs
+++ b/lib/harper-ui/src/main.rs
@@ -288,7 +288,7 @@ async fn main() -> Result<(), HarperError> {
 
     // Try TUI first, fall back to text menu if TUI fails
     let custom_commands = config.custom_commands.commands.clone().unwrap_or_default();
-    let server_base_url = config.server.enabled.unwrap_or(false).then(|| {
+    let server_base_url = server_enabled.then(|| {
         format!(
             "http://{}:{}",
             config

--- a/website/installation.html
+++ b/website/installation.html
@@ -72,6 +72,7 @@ SUPABASE_ALLOWED_PROVIDERS=github</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <p>For auth commands, <code>/auth login github</code> opens the browser, Harper polls the local server for completion, and <code>/auth status</code> reports the currently stored local TUI session.</p>
+                <p>When sign-in succeeds, Harper stores the local TUI auth session in the OS credential store (macOS Keychain, Linux keyring, or Windows Credential Manager) instead of writing the active tokens to a JSON file under your home directory.</p>
 
                 <h2>File references and Tab completion</h2>
                 <p>Type <code>@</code> in the chat input to start a file or directory reference. Press <code>Tab</code> to autocomplete matching paths and keep pressing <code>Tab</code> to cycle through candidates.</p>

--- a/website/server.html
+++ b/website/server.html
@@ -143,6 +143,7 @@ open http://127.0.0.1:8081/auth/login/github</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <p><code>/auth login github</code> starts a local flow, opens the browser, and then stores the resulting TUI session once Harper sees the completed callback. <code>/auth status</code> reports the local TUI auth state. <code>/auth logout</code> clears the local stored TUI session.</p>
+                <p>Successful TUI sign-in stores the local auth session in the system credential store (for example macOS Keychain) rather than a plain JSON token file. If you launch Harper with <code>--no-server</code>, these TUI auth commands are unavailable because the local auth callback and polling endpoints are disabled.</p>
 
                 <h2>Review example</h2>
                 <div class="code-wrapper">


### PR DESCRIPTION
## Changes

- Moved TUI auth session persistence to the OS credential store first, with legacy file migration and fallback.

- Successful TUI sign-in now uses the system keychain/keyring as the primary storage path instead of `~/.harper/auth/tui-session.json`.

- Legacy file-backed TUI auth sessions are still read for migration, then removed after a successful keyring write.

- `clear_auth_session()` now clears both keyring state and any legacy file-backed session.

- Enabled the local server by default in `config/default.toml` so `cargo harper` matches the documented auth flow out of the box.

- Fixed the TUI runtime server base URL to follow the effective `server_enabled` flag instead of only the raw config value.

- Updated website docs:
  - `website/installation.html`
  - `website/server.html`
  - covering keychain-backed TUI auth persistence and the `--no-server` auth limitation

- Updated the PR template to use the same `## Changes` / `## Validation` structure and bullet style used in recent Harper PRs.

## Validation

- `cargo check -p harper-ui`
- `cargo test -p harper-ui`
- manual macOS verification of:
  - TUI sign-in
  - Keychain prompt and approval
  - `/auth status` after login
  - no `~/.harper/auth/tui-session.json` fallback file
  - `/auth status` still working after restart
