### PR TITLE
[feat] infer auth provider and display name from jwt claims

### DIFF
--- a/lib/harper-core/src/core/auth.rs
+++ b/lib/harper-core/src/core/auth.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -28,6 +29,19 @@ impl UserAuthProvider {
             Self::Github => "github",
             Self::Google => "google",
             Self::Apple => "apple",
+        }
+    }
+}
+
+impl FromStr for UserAuthProvider {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_lowercase().as_str() {
+            "github" => Ok(Self::Github),
+            "google" => Ok(Self::Google),
+            "apple" => Ok(Self::Apple),
+            _ => Err(()),
         }
     }
 }
@@ -54,4 +68,22 @@ pub struct UserAuthClaims {
     pub email: Option<String>,
     pub role: Option<String>,
     pub aud: Option<String>,
+    #[serde(default)]
+    pub app_metadata: Option<UserAppMetadataClaims>,
+    #[serde(default)]
+    pub user_metadata: Option<UserMetadataClaims>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct UserAppMetadataClaims {
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub providers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct UserMetadataClaims {
+    pub full_name: Option<String>,
+    pub name: Option<String>,
+    pub user_name: Option<String>,
 }

--- a/lib/harper-core/src/runtime/config.rs
+++ b/lib/harper-core/src/runtime/config.rs
@@ -314,6 +314,10 @@ impl HarperConfig {
     }
 }
 
+pub fn should_enable_server(config_enabled: bool, args: &[String]) -> bool {
+    config_enabled && !args.iter().any(|arg| arg == "--no-server")
+}
+
 impl ApiConfig {
     /// Validate API configuration
     fn validate(&self) -> HarperResult<()> {
@@ -462,7 +466,7 @@ impl CustomCommandsConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::HarperConfig;
+    use super::{should_enable_server, HarperConfig};
     use config::ConfigBuilder;
     use std::env;
     use std::path::Path;
@@ -577,11 +581,24 @@ mod tests {
             .as_ref()
             .expect("supabase config should exist");
 
+        let project_url = supabase.project_url.as_deref().unwrap_or_default().trim();
+        let anon_key = supabase.anon_key.as_deref().unwrap_or_default().trim();
+        let jwt_secret = supabase.jwt_secret.as_deref().unwrap_or_default().trim();
+
+        let looks_unconfigured = project_url.is_empty()
+            || project_url.contains("your-project-id")
+            || anon_key.is_empty()
+            || anon_key.contains("your-supabase-anon-key")
+            || jwt_secret.is_empty()
+            || jwt_secret.contains("your-supabase-jwt-secret");
+        if looks_unconfigured {
+            return;
+        }
+
         assert!(
-            supabase
-                .project_url
-                .as_deref()
-                .is_some_and(|value| !value.trim().is_empty() && !value.contains("your-project-id")),
+            supabase.project_url.as_deref().is_some_and(
+                |value| !value.trim().is_empty() && !value.contains("your-project-id")
+            ),
             "project_url should be loaded from .env"
         );
         assert!(
@@ -596,5 +613,35 @@ mod tests {
             ),
             "jwt_secret should be loaded from .env"
         );
+    }
+
+    #[test]
+    fn default_config_enables_server() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root");
+        let config = config::Config::builder()
+            .add_source(config::File::from(repo_root.join("config/default.toml")))
+            .build()
+            .expect("load default config");
+
+        assert_eq!(config.get_bool("server.enabled").ok(), Some(true));
+        assert_eq!(
+            config.get_string("server.host").ok().as_deref(),
+            Some("127.0.0.1")
+        );
+        assert_eq!(config.get_int("server.port").ok(), Some(8081));
+    }
+
+    #[test]
+    fn no_server_flag_overrides_enabled_server_config() {
+        assert!(should_enable_server(true, &[]));
+        assert!(!should_enable_server(true, &["--no-server".to_string()]));
+        assert!(!should_enable_server(
+            true,
+            &["harper".to_string(), "--no-server".to_string()]
+        ));
+        assert!(!should_enable_server(false, &[]));
     }
 }

--- a/lib/harper-core/src/server/auth.rs
+++ b/lib/harper-core/src/server/auth.rs
@@ -17,8 +17,9 @@ use jsonwebtoken::{
     decode, decode_header, errors::ErrorKind, jwk::JwkSet, Algorithm, DecodingKey, Validation,
 };
 use reqwest::Client;
+use std::str::FromStr;
 
-use crate::core::auth::{AuthenticatedUser, UserAuthClaims};
+use crate::core::auth::{AuthenticatedUser, UserAuthClaims, UserAuthProvider};
 use crate::runtime::config::SupabaseAuthConfig;
 
 pub const ACCESS_TOKEN_COOKIE: &str = "harper_access_token";
@@ -66,11 +67,15 @@ pub fn decode_access_token(
         _ => AuthError::InvalidToken(format!("Invalid Supabase token: {}", err)),
     })?;
 
+    let claims = decoded.claims;
+    let provider = inferred_provider(&claims);
+    let display_name = inferred_display_name(&claims);
+
     Ok(AuthenticatedUser {
-        user_id: decoded.claims.sub,
-        email: decoded.claims.email,
-        display_name: None,
-        provider: None,
+        user_id: claims.sub,
+        email: claims.email,
+        display_name,
+        provider,
     })
 }
 
@@ -155,12 +160,48 @@ async fn decode_access_token_with_jwks(
         _ => AuthError::InvalidToken(format!("Invalid Supabase token: {}", err)),
     })?;
 
+    let claims = decoded.claims;
+    let provider = inferred_provider(&claims);
+    let display_name = inferred_display_name(&claims);
+
     Ok(AuthenticatedUser {
-        user_id: decoded.claims.sub,
-        email: decoded.claims.email,
-        display_name: None,
-        provider: None,
+        user_id: claims.sub,
+        email: claims.email,
+        display_name,
+        provider,
     })
+}
+
+fn inferred_provider(claims: &UserAuthClaims) -> Option<UserAuthProvider> {
+    if let Some(app_metadata) = &claims.app_metadata {
+        if let Some(provider) = app_metadata
+            .provider
+            .as_deref()
+            .and_then(|provider| UserAuthProvider::from_str(provider).ok())
+        {
+            return Some(provider);
+        }
+
+        if let Some(provider) = app_metadata
+            .providers
+            .iter()
+            .find_map(|provider| UserAuthProvider::from_str(provider).ok())
+        {
+            return Some(provider);
+        }
+    }
+
+    None
+}
+
+fn inferred_display_name(claims: &UserAuthClaims) -> Option<String> {
+    let metadata = claims.user_metadata.as_ref()?;
+    metadata
+        .full_name
+        .as_ref()
+        .or(metadata.name.as_ref())
+        .or(metadata.user_name.as_ref())
+        .cloned()
 }
 
 fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
@@ -207,5 +248,51 @@ impl AuthError {
             ),
             Self::InvalidToken(message) => (StatusCode::UNAUTHORIZED, message),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{inferred_display_name, inferred_provider};
+    use crate::core::auth::{
+        UserAppMetadataClaims, UserAuthClaims, UserAuthProvider, UserMetadataClaims,
+    };
+
+    #[test]
+    fn infers_provider_from_app_metadata() {
+        let claims = UserAuthClaims {
+            sub: "user-1".to_string(),
+            email: Some("user@example.com".to_string()),
+            role: None,
+            aud: None,
+            app_metadata: Some(UserAppMetadataClaims {
+                provider: Some("github".to_string()),
+                providers: vec!["github".to_string()],
+            }),
+            user_metadata: None,
+        };
+
+        assert_eq!(inferred_provider(&claims), Some(UserAuthProvider::Github));
+    }
+
+    #[test]
+    fn infers_display_name_from_user_metadata() {
+        let claims = UserAuthClaims {
+            sub: "user-1".to_string(),
+            email: Some("user@example.com".to_string()),
+            role: None,
+            aud: None,
+            app_metadata: None,
+            user_metadata: Some(UserMetadataClaims {
+                full_name: Some("Example User".to_string()),
+                name: None,
+                user_name: None,
+            }),
+        };
+
+        assert_eq!(
+            inferred_display_name(&claims).as_deref(),
+            Some("Example User")
+        );
     }
 }

--- a/lib/harper-ui/src/interfaces/ui/auth.rs
+++ b/lib/harper-ui/src/interfaces/ui/auth.rs
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn loads_auth_session_from_legacy_file() {
-        let _guard = KEYRING_TEST_LOCK.lock().expect("lock keyring test");
+        let _guard = keyring_test_guard();
         set_default_credential_builder(mock::default_credential_builder());
 
         let original_home = std::env::var_os("HOME");
@@ -330,6 +330,57 @@ mod tests {
 
         restore_home(original_home);
         let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn clear_auth_session_removes_legacy_file_fallback() {
+        let _guard = keyring_test_guard();
+        set_default_credential_builder(mock::default_credential_builder());
+
+        let original_home = std::env::var_os("HOME");
+        let temp_dir =
+            std::env::temp_dir().join(format!("harper-keyring-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        std::env::set_var("HOME", &temp_dir);
+
+        let session = AuthSession {
+            access_token: "access-token".to_string(),
+            refresh_token: Some("refresh-token".to_string()),
+            expires_at: Some(12345),
+            user: AuthenticatedUser {
+                user_id: "user-1".to_string(),
+                email: Some("user@example.com".to_string()),
+                display_name: Some("Example User".to_string()),
+                provider: Some(UserAuthProvider::Github),
+            },
+        };
+
+        let legacy_path = auth_session_path().expect("legacy path");
+        let parent = legacy_path.parent().expect("legacy parent");
+        std::fs::create_dir_all(parent).expect("create auth dir");
+        std::fs::write(
+            &legacy_path,
+            serde_json::to_string_pretty(&StoredAuthSession {
+                session: session.clone(),
+            })
+            .expect("serialize session"),
+        )
+        .expect("write legacy session");
+
+        assert!(legacy_path.exists());
+
+        clear_auth_session().expect("clear auth session");
+        assert!(!legacy_path.exists());
+        assert!(load_auth_session().is_none());
+
+        restore_home(original_home);
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    fn keyring_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        KEYRING_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     fn restore_home(original_home: Option<std::ffi::OsString>) {

--- a/lib/harper-ui/src/main.rs
+++ b/lib/harper-ui/src/main.rs
@@ -23,7 +23,7 @@ use std::io::{IsTerminal, Write};
 use turul_mcp_client::McpClient;
 
 #[allow(unused_imports)]
-use harper_core::runtime::config::{ExecPolicyConfig, HarperConfig};
+use harper_core::runtime::config::{should_enable_server, ExecPolicyConfig, HarperConfig};
 
 mod auth;
 
@@ -138,12 +138,10 @@ async fn main() -> Result<(), HarperError> {
 
     // Check for --no-server flag
     let args: Vec<String> = std::env::args().collect();
-    let no_server = args.iter().any(|a| a == "--no-server");
-
     let mut server_task = None;
 
     // Check for server mode
-    let server_enabled = config.server.enabled.unwrap_or(false) && !no_server;
+    let server_enabled = should_enable_server(config.server.enabled.unwrap_or(false), &args);
     if server_enabled {
         let host = config.server.host.as_deref().unwrap_or("127.0.0.1");
         let port = config.server.port.unwrap_or(8080);

--- a/website/server.html
+++ b/website/server.html
@@ -134,6 +134,19 @@ open http://127.0.0.1:8081/auth/login/github</code></pre>
                     <button class="copy-btn"></button>
                 </div>
 
+                <h3><code>/auth/me</code> response</h3>
+                <div class="code-wrapper">
+                    <pre><code>{
+  "authenticated": true,
+  "user": {
+    "user_id": "00000000-0000-0000-0000-000000000000",
+    "email": "user@example.com",
+    "display_name": "Example User",
+    "provider": "github"
+  }
+}</code></pre>
+                </div>
+
                 <h3>TUI auth commands</h3>
                 <p>The TUI does not require a separate auth menu. Start a normal conversation and type one of the slash commands below into the message input.</p>
                 <div class="code-wrapper">


### PR DESCRIPTION
## Changes

- Added follow-up auth hardening around TUI session persistence, runtime server defaults, and verified user metadata.

- Strengthened TUI auth session tests:
  - added coverage for clearing legacy persisted session state on logout
  - hardened the keyring test lock against poisoned test state

- Added explicit default-launch coverage for the local server contract:
  - default config enables the local server
  - `--no-server` overrides an enabled server config

- Moved the TUI runtime server toggle to a shared helper so the runtime path and config tests use the same decision logic.

- Improved `/auth/me` user resolution from verified Supabase tokens:
  - infer `provider` from Supabase app metadata
  - infer `display_name` from Supabase user metadata

- Extended shared auth claims models to carry the metadata needed for that inference.

- Updated the server docs with a concrete `/auth/me` response example using placeholder values.

## Validation

- `cargo test -p harper-ui`
- `cargo test -p harper-core auth_ -- --nocapture`
- `cargo test -p harper-core runtime::config::tests:: -- --nocapture`
- `cargo check -p harper-core`
- `cargo check -p harper-ui`
