### PR TITLE
[feat] first-class plan job model, sse plan stream, and tui jobs browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,6 +1880,7 @@ dependencies = [
  "ctr",
  "dirs",
  "dotenvy",
+ "futures-util",
  "getrandom 0.4.2",
  "h2",
  "harper-firmware",

--- a/PLANNER_NEXT_STEPS.md
+++ b/PLANNER_NEXT_STEPS.md
@@ -8,67 +8,75 @@ There are **10 solid next steps** that can be implemented without changing direc
 
 ## Next Steps
 
-1. **Live command output panel**
-   - Stream stdout/stderr into the TUI while a command is running.
-   - Show the active command, partial output, and final exit state.
-
-2. **Background job model**
+1. **Background job model**
    - Introduce first-class job IDs, job records, and job lifecycle state.
    - Separate long-running jobs from simple synchronous tool calls.
 
-3. **Job list UI**
+2. **Job list UI**
    - Add a panel or overlay showing running, completed, blocked, and failed jobs.
    - Allow selecting a job to inspect its output and status history.
 
-4. **Step-to-job linkage**
+3. **Step-to-job linkage**
    - Explicitly attach a plan step to a spawned/running job.
    - Keep the step `in_progress` while the linked job is active.
 
-5. **Automatic completion from job finish**
+4. **Automatic completion from job finish**
    - Mark a linked step completed when the job succeeds and the match is high-confidence.
    - Move the next pending step to `in_progress` when appropriate.
 
-6. **Failure-aware plan transitions**
+5. **Failure-aware plan transitions**
    - Mark runtime as `failed` or `blocked` when a job exits non-zero or approval is denied.
    - Nudge the model to revise the plan instead of continuing blindly.
 
-7. **HTTP API plan/job events**
+6. **HTTP API plan/job events**
    - Expose live plan/job state through API endpoints or server-sent events.
    - Keep web clients in sync with the same runtime state as the TUI.
+   - Status: implemented with:
+     - `GET /api/sessions/{id}/plan`
+     - `GET /api/sessions/{id}/plan/stream`
+   - Current delivery model:
+     - same-process updates use in-memory broadcast for low-latency push
+     - cross-process updates use the persisted SQLite plan event journal
+   - Remaining boundary:
+     - cross-process delivery is journal-backed, not a dedicated external event bus
 
-8. **Plan editing commands in UI**
+7. **Plan editing commands in UI**
    - Add direct UI actions for promoting, completing, or clearing steps.
    - Make plans editable even when the model is not actively driving the session.
 
-9. **Scoped AGENTS.md resolution**
+8. **Scoped AGENTS.md resolution**
    - Replace the current single-file append behavior with scoped lookup and merge logic.
    - Use nested `AGENTS.md` rules per directory tree instead of only repo-root text.
 
-10. **Planner-quality orchestration**
-    - Add stronger multi-step execution policies around sequencing, retries, checkpoints, and summaries.
-    - Make the model behave more like a planner/executor instead of only a reactive chat loop.
+9. **Planner-quality orchestration**
+   - Add stronger multi-step execution policies around sequencing, retries, checkpoints, and summaries.
+   - Make the model behave more like a planner/executor instead of only a reactive chat loop.
+
+10. **Live command output polish**
+   - Refine the existing command output panel and active runtime display.
+   - Add richer status summaries, truncation controls, and clearer failure surfacing.
 
 ## Recommended Order
 
 If we implement these in sequence, this is the best order:
 
-1. Live command output panel
-2. Background job model
-3. Job list UI
-4. Step-to-job linkage
-5. Automatic completion from job finish
-6. Failure-aware plan transitions
-7. HTTP API plan/job events
-8. Plan editing commands in UI
-9. Scoped `AGENTS.md` resolution
-10. Planner-quality orchestration
+1. Background job model
+2. Job list UI
+3. Step-to-job linkage
+4. Automatic completion from job finish
+5. Failure-aware plan transitions
+6. HTTP API plan/job events
+7. Plan editing commands in UI
+8. Scoped `AGENTS.md` resolution
+9. Planner-quality orchestration
+10. Live command output polish
 
 ## Suggested Milestones
 
-### Milestone 1: Live execution visibility
-- Live command output panel
+### Milestone 1: Runtime jobs
 - Background job model
 - Job list UI
+- Live command output polish
 
 ### Milestone 2: Plan/job coordination
 - Step-to-job linkage
@@ -87,35 +95,21 @@ If we implement these in sequence, this is the best order:
 
 These are ready-to-use plan payloads in Harper-style structure.
 
-### Seed 1: Live execution visibility
+### Seed 1: Runtime jobs
 
 ```json
 {
-  "explanation": "Build the first real live execution UX so running work is visible while a turn is still active.",
-  "items": [
-    { "step": "Design command event model", "status": "pending" },
-    { "step": "Stream command output chunks", "status": "pending" },
-    { "step": "Add live output panel", "status": "pending" },
-    { "step": "Show job status summary", "status": "pending" }
-  ]
-}
-```
-
-### Seed 2: Background jobs
-
-```json
-{
-  "explanation": "Introduce a first-class job model so long-running commands are tracked independently from the chat turn.",
+  "explanation": "Introduce first-class runtime jobs so command execution is tracked explicitly instead of only through one active command slot.",
   "items": [
     { "step": "Define job record schema", "status": "pending" },
     { "step": "Persist job lifecycle state", "status": "pending" },
-    { "step": "Wire worker job messages", "status": "pending" },
-    { "step": "Add job list interactions", "status": "pending" }
+    { "step": "Render job status summary", "status": "pending" },
+    { "step": "Polish command output display", "status": "pending" }
   ]
 }
 ```
 
-### Seed 3: Plan and job coordination
+### Seed 2: Plan and job coordination
 
 ```json
 {
@@ -129,11 +123,11 @@ These are ready-to-use plan payloads in Harper-style structure.
 }
 ```
 
-### Seed 4: Cross-interface support
+### Seed 3: Cross-interface support
 
 ```json
 {
-  "explanation": "Expose plan and job runtime state consistently across TUI and HTTP clients.",
+  "explanation": "Expose plan and job runtime state consistently across TUI and HTTP clients, with the current stream path using in-process broadcast plus a persisted SQLite event journal.",
   "items": [
     { "step": "Add HTTP plan runtime endpoints", "status": "pending" },
     { "step": "Stream API-side runtime events", "status": "pending" },
@@ -143,7 +137,7 @@ These are ready-to-use plan payloads in Harper-style structure.
 }
 ```
 
-### Seed 5: Planner maturity
+### Seed 4: Planner maturity
 
 ```json
 {
@@ -157,6 +151,20 @@ These are ready-to-use plan payloads in Harper-style structure.
 }
 ```
 
+### Seed 5: Live output polish
+
+```json
+{
+  "explanation": "Refine the existing live command output panel so active runtime state is easier to inspect and reason about.",
+  "items": [
+    { "step": "Clarify active command status", "status": "pending" },
+    { "step": "Improve truncation behavior", "status": "pending" },
+    { "step": "Show failure summaries clearly", "status": "pending" },
+    { "step": "Add richer job selection UX", "status": "pending" }
+  ]
+}
+```
+
 ## Single Master Plan
 
 If you want one top-level plan instead of milestone plans, use this:
@@ -165,7 +173,6 @@ If you want one top-level plan instead of milestone plans, use this:
 {
   "explanation": "Finish Harper's planner/runtime system from live execution visibility through planner-quality orchestration.",
   "items": [
-    { "step": "Add live output panel", "status": "pending" },
     { "step": "Introduce job model", "status": "pending" },
     { "step": "Build job list UI", "status": "pending" },
     { "step": "Link steps to jobs", "status": "pending" },
@@ -174,7 +181,8 @@ If you want one top-level plan instead of milestone plans, use this:
     { "step": "Expose runtime over HTTP", "status": "pending" },
     { "step": "Add UI plan editing", "status": "pending" },
     { "step": "Resolve scoped AGENTS rules", "status": "pending" },
-    { "step": "Improve planner orchestration", "status": "pending" }
+    { "step": "Improve planner orchestration", "status": "pending" },
+    { "step": "Polish live command output", "status": "pending" }
   ]
 }
 ```

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "process", "signal"] }
 tower = "0.5"
+futures-util = "0.3"
 uuid = { version = "1.17.0", features = ["v4"] }
 ring = "0.17.14"
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }

--- a/lib/harper-core/src/core/llm_client.rs
+++ b/lib/harper-core/src/core/llm_client.rs
@@ -207,7 +207,7 @@ pub async fn call_llm(
                                             },
                                             "status": {
                                                 "type": "string",
-                                                "enum": ["pending", "in_progress", "completed"],
+                                                "enum": ["pending", "in_progress", "completed", "blocked"],
                                                 "description": "Current status of the step"
                                             }
                                         },

--- a/lib/harper-core/src/core/mod.rs
+++ b/lib/harper-core/src/core/mod.rs
@@ -25,6 +25,7 @@ pub mod io_traits;
 pub mod llm_client;
 pub mod models;
 pub mod plan;
+pub mod plan_events;
 
 /// Supported AI API providers
 #[derive(Debug, Clone, Copy)]

--- a/lib/harper-core/src/core/plan.rs
+++ b/lib/harper-core/src/core/plan.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -20,19 +21,198 @@ pub enum PlanStepStatus {
     Pending,
     InProgress,
     Completed,
+    Blocked,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanItem {
     pub step: String,
     pub status: PlanStepStatus,
+    #[serde(default)]
+    pub job_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanJobStatus {
+    WaitingApproval,
+    Running,
+    Blocked,
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanJobRecord {
+    pub job_id: String,
+    pub tool: String,
+    pub command: Option<String>,
+    pub status: PlanJobStatus,
+    #[serde(default)]
+    pub output_transcript: String,
+    #[serde(default)]
+    pub output_preview: Option<String>,
+    #[serde(default)]
+    pub has_error_output: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlanRuntime {
+    #[serde(default)]
     pub active_tool: Option<String>,
+    #[serde(default)]
     pub active_command: Option<String>,
+    #[serde(default)]
     pub active_status: Option<String>,
+    #[serde(default)]
+    pub active_job_id: Option<String>,
+    #[serde(default)]
+    pub jobs: Vec<PlanJobRecord>,
+}
+
+impl PlanRuntime {
+    pub fn has_active_state(&self) -> bool {
+        self.active_tool.is_some() || self.active_command.is_some() || self.active_status.is_some()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        !self.has_active_state() && self.active_job_id.is_none() && self.jobs.is_empty()
+    }
+
+    pub fn set_active_tool_state(
+        &mut self,
+        tool: impl Into<String>,
+        command: Option<String>,
+        status: impl Into<String>,
+    ) {
+        self.active_tool = Some(tool.into());
+        self.active_command = command;
+        self.active_status = Some(status.into());
+    }
+
+    pub fn start_job(
+        &mut self,
+        tool: impl Into<String>,
+        command: Option<String>,
+        status: PlanJobStatus,
+    ) -> String {
+        let tool = tool.into();
+        let job_id = Uuid::new_v4().to_string();
+        self.active_job_id = Some(job_id.clone());
+        self.active_tool = Some(tool.clone());
+        self.active_command = command.clone();
+        self.active_status = Some(job_status_label(&status).to_string());
+        self.jobs.push(PlanJobRecord {
+            job_id: job_id.clone(),
+            tool,
+            command,
+            status,
+            output_transcript: String::new(),
+            output_preview: None,
+            has_error_output: false,
+        });
+        job_id
+    }
+
+    pub fn update_active_job_status(&mut self, status: PlanJobStatus) {
+        let Some(active_job_id) = self.active_job_id.as_deref() else {
+            return;
+        };
+        if let Some(job) = self
+            .jobs
+            .iter_mut()
+            .rev()
+            .find(|job| job.job_id == active_job_id)
+        {
+            job.status = status.clone();
+        }
+        self.active_status = Some(job_status_label(&status).to_string());
+    }
+
+    pub fn set_active_job_output(
+        &mut self,
+        output_preview: Option<String>,
+        has_error_output: bool,
+    ) {
+        let Some(active_job_id) = self.active_job_id.as_deref() else {
+            return;
+        };
+        if let Some(job) = self
+            .jobs
+            .iter_mut()
+            .rev()
+            .find(|job| job.job_id == active_job_id)
+        {
+            job.output_preview = output_preview;
+            job.has_error_output = has_error_output;
+        }
+    }
+
+    pub fn append_active_job_output(&mut self, chunk: &str, is_error: bool) {
+        const MAX_JOB_TRANSCRIPT_CHARS: usize = 16 * 1024;
+
+        let Some(active_job_id) = self.active_job_id.as_deref() else {
+            return;
+        };
+        if let Some(job) = self
+            .jobs
+            .iter_mut()
+            .rev()
+            .find(|job| job.job_id == active_job_id)
+        {
+            job.output_transcript.push_str(chunk);
+            if job.output_transcript.chars().count() > MAX_JOB_TRANSCRIPT_CHARS {
+                let trimmed: String = job
+                    .output_transcript
+                    .chars()
+                    .rev()
+                    .take(MAX_JOB_TRANSCRIPT_CHARS)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect();
+                job.output_transcript = trimmed;
+            }
+            job.has_error_output |= is_error;
+            job.output_preview = preview_text(&job.output_transcript, 512);
+        }
+    }
+
+    pub fn finish_active_job(&mut self, status: PlanJobStatus) {
+        self.update_active_job_status(status);
+        self.clear_active_state();
+    }
+
+    pub fn clear_active_state(&mut self) {
+        self.active_tool = None;
+        self.active_command = None;
+        self.active_status = None;
+        self.active_job_id = None;
+    }
+}
+
+fn job_status_label(status: &PlanJobStatus) -> &'static str {
+    match status {
+        PlanJobStatus::WaitingApproval => "waiting_approval",
+        PlanJobStatus::Running => "running",
+        PlanJobStatus::Blocked => "blocked",
+        PlanJobStatus::Succeeded => "succeeded",
+        PlanJobStatus::Failed => "failed",
+    }
+}
+
+fn preview_text(text: &str, max_chars: usize) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let preview: String = trimmed.chars().take(max_chars).collect();
+    if trimmed.chars().count() > max_chars {
+        Some(format!("{}…", preview))
+    } else {
+        Some(preview)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -41,4 +221,47 @@ pub struct PlanState {
     pub items: Vec<PlanItem>,
     pub runtime: Option<PlanRuntime>,
     pub updated_at: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PlanJobStatus, PlanRuntime};
+
+    #[test]
+    fn runtime_deserializes_legacy_shape_with_empty_jobs() {
+        let runtime: PlanRuntime = serde_json::from_str(
+            r#"{
+                "active_tool":"run_command",
+                "active_command":"echo hi",
+                "active_status":"running"
+            }"#,
+        )
+        .expect("legacy runtime json should deserialize");
+
+        assert_eq!(runtime.active_tool.as_deref(), Some("run_command"));
+        assert_eq!(runtime.active_command.as_deref(), Some("echo hi"));
+        assert_eq!(runtime.active_status.as_deref(), Some("running"));
+        assert!(runtime.active_job_id.is_none());
+        assert!(runtime.jobs.is_empty());
+    }
+
+    #[test]
+    fn runtime_tracks_job_lifecycle() {
+        let mut runtime = PlanRuntime::default();
+        let job_id = runtime.start_job(
+            "run_command",
+            Some("echo hi".to_string()),
+            PlanJobStatus::Running,
+        );
+
+        assert_eq!(runtime.active_job_id.as_deref(), Some(job_id.as_str()));
+        assert_eq!(runtime.jobs.len(), 1);
+        assert_eq!(runtime.active_status.as_deref(), Some("running"));
+
+        runtime.finish_active_job(PlanJobStatus::Succeeded);
+
+        assert!(runtime.active_job_id.is_none());
+        assert!(!runtime.has_active_state());
+        assert_eq!(runtime.jobs[0].status, PlanJobStatus::Succeeded);
+    }
 }

--- a/lib/harper-core/src/core/plan_events.rs
+++ b/lib/harper-core/src/core/plan_events.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 harpertoken
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::core::plan::PlanState;
+use std::sync::OnceLock;
+use tokio::sync::broadcast;
+
+#[derive(Debug, Clone)]
+pub struct PlanUpdateEvent {
+    pub event_id: i64,
+    pub session_id: String,
+    pub plan: PlanState,
+}
+
+static PLAN_UPDATES: OnceLock<broadcast::Sender<PlanUpdateEvent>> = OnceLock::new();
+
+fn sender() -> &'static broadcast::Sender<PlanUpdateEvent> {
+    PLAN_UPDATES.get_or_init(|| {
+        let (tx, _rx) = broadcast::channel(256);
+        tx
+    })
+}
+
+pub fn subscribe() -> broadcast::Receiver<PlanUpdateEvent> {
+    sender().subscribe()
+}
+
+pub fn notify(event_id: i64, session_id: &str, plan: PlanState) {
+    let _ = sender().send(PlanUpdateEvent {
+        event_id,
+        session_id: session_id.to_string(),
+        plan,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{notify, subscribe};
+    use crate::core::plan::PlanState;
+
+    #[tokio::test]
+    async fn broadcasts_plan_updates() {
+        let mut rx = subscribe();
+        let plan = PlanState::default();
+
+        notify(42, "session-a", plan.clone());
+
+        let event = rx.recv().await.expect("event");
+        assert_eq!(event.event_id, 42);
+        assert_eq!(event.session_id, "session-a");
+        assert_eq!(event.plan, plan);
+    }
+}

--- a/lib/harper-core/src/lib.rs
+++ b/lib/harper-core/src/lib.rs
@@ -298,10 +298,12 @@ mod tests {
                 PlanItem {
                     step: "Add storage".to_string(),
                     status: PlanStepStatus::Completed,
+                    job_id: None,
                 },
                 PlanItem {
                     step: "Render UI".to_string(),
                     status: PlanStepStatus::InProgress,
+                    job_id: None,
                 },
             ],
             runtime: None,

--- a/lib/harper-core/src/memory/session_service.rs
+++ b/lib/harper-core/src/memory/session_service.rs
@@ -526,6 +526,7 @@ impl<'a> SessionService<'a> {
                         crate::core::plan::PlanStepStatus::Pending => "pending",
                         crate::core::plan::PlanStepStatus::InProgress => "in_progress",
                         crate::core::plan::PlanStepStatus::Completed => "completed",
+                        crate::core::plan::PlanStepStatus::Blocked => "blocked",
                     },
                     item.step
                 ))?;
@@ -590,6 +591,7 @@ impl<'a> SessionService<'a> {
                     crate::core::plan::PlanStepStatus::Pending => "pending",
                     crate::core::plan::PlanStepStatus::InProgress => "in_progress",
                     crate::core::plan::PlanStepStatus::Completed => "completed",
+                    crate::core::plan::PlanStepStatus::Blocked => "blocked",
                 };
                 writeln!(writer, "- [{}] {}", status, item.step)?;
             }

--- a/lib/harper-core/src/memory/storage/mod.rs
+++ b/lib/harper-core/src/memory/storage/mod.rs
@@ -156,6 +156,19 @@ pub fn init_db(conn: &Connection) -> HarperResult<()> {
         [],
     )?;
     conn.execute(
+        "CREATE TABLE IF NOT EXISTS session_plan_events (
+             id INTEGER PRIMARY KEY AUTOINCREMENT,
+             session_id TEXT NOT NULL,
+             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+         )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_session_plan_events_session_id_id
+         ON session_plan_events(session_id, id)",
+        [],
+    )?;
+    conn.execute(
         "CREATE TABLE IF NOT EXISTS session_agents (
              session_id TEXT PRIMARY KEY,
              sources_json TEXT NOT NULL,
@@ -307,7 +320,29 @@ pub fn save_plan_state(conn: &Connection, session_id: &str, plan: &PlanState) ->
         params![session_id, plan.explanation, items_json],
     )?;
     save_plan_runtime(conn, session_id, plan.runtime.as_ref())?;
+    let event_id = insert_plan_event(conn, session_id)?;
+    crate::core::plan_events::notify(event_id, session_id, plan.clone());
     Ok(())
+}
+
+fn insert_plan_event(conn: &Connection, session_id: &str) -> HarperResult<i64> {
+    conn.execute(
+        "INSERT INTO session_plan_events (session_id) VALUES (?1)",
+        params![session_id],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn load_latest_plan_event_id(conn: &Connection, session_id: &str) -> HarperResult<Option<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT id FROM session_plan_events WHERE session_id = ?1 ORDER BY id DESC LIMIT 1",
+    )?;
+    let mut rows = stmt.query(params![session_id])?;
+    if let Some(row) = rows.next()? {
+        Ok(Some(row.get(0)?))
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn load_plan_state(conn: &Connection, session_id: &str) -> HarperResult<Option<PlanState>> {
@@ -684,6 +719,7 @@ pub fn insert_command_log(conn: &Connection, record: &CommandLogRecord) -> Harpe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::plan::{PlanItem, PlanState, PlanStepStatus};
 
     #[test]
     fn init_db_adds_session_user_id_column() {
@@ -702,6 +738,33 @@ mod tests {
         assert!(session_belongs_to_user(&conn, "session-1", "user-a").expect("ownership lookup"));
         assert!(!save_session_for_user(&conn, "session-1", "user-b").expect("second claim denied"));
         assert!(!session_belongs_to_user(&conn, "session-1", "user-b").expect("other owner lookup"));
+    }
+
+    #[test]
+    fn save_plan_state_records_plan_event_id() {
+        let conn = Connection::open_in_memory().expect("in-memory sqlite");
+        init_db(&conn).expect("db init");
+
+        save_plan_state(
+            &conn,
+            "session-a",
+            &PlanState {
+                explanation: Some("Track work".to_string()),
+                items: vec![PlanItem {
+                    step: "Inspect".to_string(),
+                    status: PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        assert_eq!(
+            load_latest_plan_event_id(&conn, "session-a").expect("latest event id"),
+            Some(1)
+        );
     }
 }
 

--- a/lib/harper-core/src/server/mod.rs
+++ b/lib/harper-core/src/server/mod.rs
@@ -17,15 +17,20 @@ mod auth;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
-    response::{Html, IntoResponse, Json, Redirect, Response},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        Html, IntoResponse, Json, Redirect, Response,
+    },
     routing::{delete, get, post},
     Router,
 };
 use base64::Engine;
+use futures_util::{stream, StreamExt};
 use reqwest::Client;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::convert::Infallible;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -33,6 +38,7 @@ use crate::agent::intent::route_intent;
 use crate::core::auth::{AuthSession, AuthenticatedUser, UserAuthProvider};
 use crate::core::error::{HarperError, HarperResult};
 use crate::core::llm_client::call_llm;
+use crate::core::plan_events;
 use crate::core::{ApiConfig, Message};
 use crate::memory::storage::{save_message, save_session, save_session_for_user, CommandLogRecord};
 use crate::runtime::config::ExecPolicyConfig;
@@ -663,6 +669,100 @@ pub async fn get_session(
     Ok(Json(serde_json::json!(session_view)))
 }
 
+pub async fn get_session_plan(
+    State(state): State<Arc<ServerState>>,
+    headers: axum::http::HeaderMap,
+    Path(session_id): Path<String>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let user = optional_authenticated_user_from_headers(&state, &headers)
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    let plan = load_session_plan_value(&state, &session_id, user.as_ref())?;
+    Ok(Json(plan))
+}
+
+pub async fn get_session_plan_stream(
+    State(state): State<Arc<ServerState>>,
+    headers: axum::http::HeaderMap,
+    Path(session_id): Path<String>,
+) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, StatusCode> {
+    let user = optional_authenticated_user_from_headers(&state, &headers)
+        .await
+        .map_err(|_| StatusCode::UNAUTHORIZED)?;
+    let initial_payload = load_session_plan_value(&state, &session_id, user.as_ref())?;
+    let initial_json =
+        serde_json::to_string(&initial_payload).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let last_event_id = load_latest_plan_event_id(&state, &session_id)?;
+
+    let receiver = plan_events::subscribe();
+    let stream = stream::unfold(
+        (state.clone(), receiver, session_id, user, last_event_id),
+        |(state, mut receiver, session_id, user, mut last_event_id)| async move {
+            loop {
+                let sleep = tokio::time::sleep(Duration::from_millis(500));
+                tokio::pin!(sleep);
+
+                tokio::select! {
+                    recv = receiver.recv() => {
+                        match recv {
+                            Ok(update) if update.session_id == session_id => {
+                                last_event_id = Some(update.event_id);
+                                let next_json = match serde_json::to_string(&update.plan) {
+                                    Ok(json) => json,
+                                    Err(_) => return None,
+                                };
+                                let event = Event::default().event("plan").data(next_json);
+                                return Some((Ok(event), (state, receiver, session_id, user, last_event_id)));
+                            }
+                            Ok(_) => continue,
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+                        }
+                    }
+                    _ = &mut sleep => {
+                        let latest_event_id = match load_latest_plan_event_id(&state, &session_id) {
+                            Ok(event_id) => event_id,
+                            Err(_) => return None,
+                        };
+                        if latest_event_id.is_some() && latest_event_id > last_event_id {
+                            let plan = match load_session_plan_value(&state, &session_id, user.as_ref()) {
+                                Ok(plan) => plan,
+                                Err(_) => return None,
+                            };
+                            let next_json = match serde_json::to_string(&plan) {
+                                Ok(json) => json,
+                                Err(_) => return None,
+                            };
+                            last_event_id = latest_event_id;
+                            let event = Event::default().event("plan").data(next_json);
+                            return Some((Ok(event), (state, receiver, session_id, user, last_event_id)));
+                        }
+                    }
+                }
+            }
+        },
+    );
+
+    let initial_event = stream::once(async move {
+        Ok::<Event, Infallible>(Event::default().event("plan").data(initial_json))
+    })
+    .chain(stream);
+
+    Ok(Sse::new(initial_event).keep_alive(KeepAlive::default()))
+}
+
+fn load_latest_plan_event_id(
+    state: &ServerState,
+    session_id: &str,
+) -> Result<Option<i64>, StatusCode> {
+    let conn = state
+        .conn
+        .lock()
+        .expect("Failed to lock database connection");
+    crate::memory::storage::load_latest_plan_event_id(&conn, session_id)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
 pub async fn delete_session(
     State(state): State<Arc<ServerState>>,
     headers: axum::http::HeaderMap,
@@ -690,6 +790,28 @@ pub async fn delete_session(
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
         },
     }
+}
+
+fn load_session_plan_value(
+    state: &ServerState,
+    session_id: &str,
+    user: Option<&AuthenticatedUser>,
+) -> Result<serde_json::Value, StatusCode> {
+    let conn = state
+        .conn
+        .lock()
+        .expect("Failed to lock database connection");
+    let session_service = crate::memory::session_service::SessionService::new(&conn);
+    let session_view = match user {
+        Some(user) => session_service
+            .load_session_state_view_for_user(session_id, &user.user_id)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .ok_or(StatusCode::NOT_FOUND)?,
+        None => session_service
+            .load_session_state_view(session_id)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+    };
+    Ok(serde_json::json!(session_view.plan))
 }
 
 pub async fn chat_endpoint(
@@ -1298,6 +1420,11 @@ pub fn create_router(
         .route("/auth/logout", get(auth_logout))
         .route("/api/sessions", get(list_sessions))
         .route("/api/sessions/{id}", get(get_session))
+        .route("/api/sessions/{id}/plan", get(get_session_plan))
+        .route(
+            "/api/sessions/{id}/plan/stream",
+            get(get_session_plan_stream),
+        )
         .route("/api/sessions/{id}", delete(delete_session))
         .route("/api/chat", post(chat_endpoint))
         .route("/api/approvals/{session_id}", get(list_pending_approvals))
@@ -1838,9 +1965,10 @@ pub async fn approve_pending_tool(
 mod tests {
     use super::{
         auth_me, auth_tui_poll, build_authorize_url, delete_session, extract_json_payload,
-        get_session, list_sessions, normalize_finding_range, render_auth_status_page,
-        render_auth_success, review_code, CodeReviewFinding, CodeSuggestion, ReviewRange,
-        ReviewRequest, ServerState, SupabaseAuthConfig, TuiAuthFlowState,
+        get_session, get_session_plan, get_session_plan_stream, list_sessions,
+        normalize_finding_range, render_auth_status_page, render_auth_success, review_code,
+        CodeReviewFinding, CodeSuggestion, ReviewRange, ReviewRequest, ServerState,
+        SupabaseAuthConfig, TuiAuthFlowState,
     };
     use crate::core::auth::{AuthSession, AuthenticatedUser, UserAuthProvider};
     use crate::core::{ApiConfig, ApiProvider};
@@ -1849,6 +1977,7 @@ mod tests {
     use axum::body::to_bytes;
     use axum::extract::{Path, State};
     use axum::http::{header::AUTHORIZATION, HeaderMap, HeaderValue, StatusCode};
+    use axum::response::IntoResponse;
     use axum::Json;
     use chrono::{Duration, Utc};
     use jsonwebtoken::{encode, EncodingKey, Header};
@@ -2060,6 +2189,167 @@ mod tests {
         assert_eq!(body["session_id"], "local-session");
         assert_eq!(body["messages"].as_array().map(Vec::len), Some(1));
         assert!(body["user_id"].is_null());
+    }
+
+    #[tokio::test]
+    async fn get_session_includes_plan_runtime_jobs() {
+        let state = test_server_state(None);
+        {
+            let conn = state.conn.lock().expect("db lock");
+            save_session(&conn, "job-session").expect("save session");
+            crate::memory::storage::save_plan_state(
+                &conn,
+                "job-session",
+                &crate::core::plan::PlanState {
+                    explanation: Some("Track runtime".to_string()),
+                    items: vec![crate::core::plan::PlanItem {
+                        step: "Run command".to_string(),
+                        status: crate::core::plan::PlanStepStatus::InProgress,
+                        job_id: Some("job-1".to_string()),
+                    }],
+                    runtime: Some(crate::core::plan::PlanRuntime {
+                        active_tool: Some("run_command".to_string()),
+                        active_command: Some("echo hi".to_string()),
+                        active_status: Some("running".to_string()),
+                        active_job_id: Some("job-1".to_string()),
+                        jobs: vec![crate::core::plan::PlanJobRecord {
+                            job_id: "job-1".to_string(),
+                            tool: "run_command".to_string(),
+                            command: Some("echo hi".to_string()),
+                            status: crate::core::plan::PlanJobStatus::Running,
+                            output_transcript: "echo hi\n".to_string(),
+                            output_preview: Some("echo hi".to_string()),
+                            has_error_output: false,
+                        }],
+                    }),
+                    updated_at: None,
+                },
+            )
+            .expect("save plan state");
+        }
+
+        let response = get_session(
+            State(state),
+            HeaderMap::new(),
+            Path("job-session".to_string()),
+        )
+        .await
+        .expect("job session should be readable");
+
+        let body = response.0;
+        assert_eq!(body["plan"]["runtime"]["active_job_id"], "job-1");
+        assert_eq!(body["plan"]["items"][0]["job_id"], "job-1");
+        assert_eq!(body["plan"]["runtime"]["jobs"][0]["status"], "running");
+        assert_eq!(body["plan"]["runtime"]["jobs"][0]["command"], "echo hi");
+    }
+
+    #[tokio::test]
+    async fn get_session_plan_returns_runtime_jobs_only() {
+        let state = test_server_state(None);
+        {
+            let conn = state.conn.lock().expect("db lock");
+            save_session(&conn, "plan-session").expect("save session");
+            crate::memory::storage::save_plan_state(
+                &conn,
+                "plan-session",
+                &crate::core::plan::PlanState {
+                    explanation: Some("Track runtime".to_string()),
+                    items: vec![crate::core::plan::PlanItem {
+                        step: "Run command".to_string(),
+                        status: crate::core::plan::PlanStepStatus::InProgress,
+                        job_id: Some("job-1".to_string()),
+                    }],
+                    runtime: Some(crate::core::plan::PlanRuntime {
+                        active_tool: Some("run_command".to_string()),
+                        active_command: Some("echo hi".to_string()),
+                        active_status: Some("running".to_string()),
+                        active_job_id: Some("job-1".to_string()),
+                        jobs: vec![crate::core::plan::PlanJobRecord {
+                            job_id: "job-1".to_string(),
+                            tool: "run_command".to_string(),
+                            command: Some("echo hi".to_string()),
+                            status: crate::core::plan::PlanJobStatus::Running,
+                            output_transcript: "echo hi\n".to_string(),
+                            output_preview: Some("echo hi".to_string()),
+                            has_error_output: false,
+                        }],
+                    }),
+                    updated_at: None,
+                },
+            )
+            .expect("save plan state");
+        }
+
+        let response = get_session_plan(
+            State(state),
+            HeaderMap::new(),
+            Path("plan-session".to_string()),
+        )
+        .await
+        .expect("plan should be readable");
+
+        let body = response.0;
+        assert_eq!(body["runtime"]["active_job_id"], "job-1");
+        assert_eq!(body["runtime"]["jobs"][0]["output_preview"], "echo hi");
+        assert_eq!(body["items"][0]["job_id"], "job-1");
+    }
+
+    #[tokio::test]
+    async fn get_session_plan_stream_responds_with_sse() {
+        let state = test_server_state(None);
+        {
+            let conn = state.conn.lock().expect("db lock");
+            save_session(&conn, "plan-stream-session").expect("save session");
+            crate::memory::storage::save_plan_state(
+                &conn,
+                "plan-stream-session",
+                &crate::core::plan::PlanState {
+                    explanation: Some("Track runtime".to_string()),
+                    items: vec![crate::core::plan::PlanItem {
+                        step: "Run command".to_string(),
+                        status: crate::core::plan::PlanStepStatus::InProgress,
+                        job_id: Some("job-1".to_string()),
+                    }],
+                    runtime: Some(crate::core::plan::PlanRuntime {
+                        active_tool: Some("run_command".to_string()),
+                        active_command: Some("echo hi".to_string()),
+                        active_status: Some("running".to_string()),
+                        active_job_id: Some("job-1".to_string()),
+                        jobs: vec![crate::core::plan::PlanJobRecord {
+                            job_id: "job-1".to_string(),
+                            tool: "run_command".to_string(),
+                            command: Some("echo hi".to_string()),
+                            status: crate::core::plan::PlanJobStatus::Running,
+                            output_transcript: "echo hi\n".to_string(),
+                            output_preview: Some("echo hi".to_string()),
+                            has_error_output: false,
+                        }],
+                    }),
+                    updated_at: None,
+                },
+            )
+            .expect("save plan state");
+        }
+
+        let response = get_session_plan_stream(
+            State(state),
+            HeaderMap::new(),
+            Path("plan-stream-session".to_string()),
+        )
+        .await
+        .expect("stream should be readable")
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .expect("content-type header")
+                .to_str()
+                .ok(),
+            Some("text/event-stream")
+        );
     }
 
     #[tokio::test]

--- a/lib/harper-core/src/tools/mod.rs
+++ b/lib/harper-core/src/tools/mod.rs
@@ -773,16 +773,15 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
         if plan.items.is_empty() {
             return Ok(());
         }
+        let mut runtime = plan.runtime.unwrap_or_default();
+
         if plan
             .items
             .iter()
             .any(|item| matches!(item.status, crate::core::plan::PlanStepStatus::InProgress))
         {
-            plan.runtime = Some(crate::core::plan::PlanRuntime {
-                active_tool: Some(tool_name.to_string()),
-                active_command: None,
-                active_status: Some("running".to_string()),
-            });
+            runtime.set_active_tool_state(tool_name.to_string(), None, "running".to_string());
+            plan.runtime = Some(runtime);
             crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
             return Ok(());
         }
@@ -794,11 +793,8 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
         {
             first_pending.status = crate::core::plan::PlanStepStatus::InProgress;
         }
-        plan.runtime = Some(crate::core::plan::PlanRuntime {
-            active_tool: Some(tool_name.to_string()),
-            active_command: None,
-            active_status: Some("running".to_string()),
-        });
+        runtime.set_active_tool_state(tool_name.to_string(), None, "running".to_string());
+        plan.runtime = Some(runtime);
         crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
 
         Ok(())
@@ -824,8 +820,11 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
             return Ok(());
         };
         if !Self::is_safe_auto_advance_tool(&tool_name) {
-            if plan.runtime.is_some() {
-                plan.runtime = None;
+            if let Some(runtime) = plan.runtime.as_mut() {
+                runtime.clear_active_state();
+                if runtime.is_empty() {
+                    plan.runtime = None;
+                }
                 crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
             }
             return Ok(());
@@ -833,8 +832,11 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
 
         let step_text = plan.items[current_index].step.to_ascii_lowercase();
         if !Self::step_matches_safe_tool(&step_text, &tool_name) {
-            if plan.runtime.is_some() {
-                plan.runtime = None;
+            if let Some(runtime) = plan.runtime.as_mut() {
+                runtime.clear_active_state();
+                if runtime.is_empty() {
+                    plan.runtime = None;
+                }
                 crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
             }
             return Ok(());
@@ -848,7 +850,12 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
         {
             next_pending.status = crate::core::plan::PlanStepStatus::InProgress;
         }
-        plan.runtime = None;
+        if let Some(runtime) = plan.runtime.as_mut() {
+            runtime.clear_active_state();
+            if runtime.is_empty() {
+                plan.runtime = None;
+            }
+        }
         crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
         Ok(())
     }
@@ -1059,10 +1066,12 @@ mod tests {
                     PlanItem {
                         step: "Inspect".to_string(),
                         status: PlanStepStatus::Pending,
+                        job_id: None,
                     },
                     PlanItem {
                         step: "Patch".to_string(),
                         status: PlanStepStatus::Pending,
+                        job_id: None,
                     },
                 ],
                 runtime: None,
@@ -1105,10 +1114,12 @@ mod tests {
                     PlanItem {
                         step: "Inspect server file".to_string(),
                         status: PlanStepStatus::InProgress,
+                        job_id: None,
                     },
                     PlanItem {
                         step: "Patch handler".to_string(),
                         status: PlanStepStatus::Pending,
+                        job_id: None,
                     },
                 ],
                 runtime: None,
@@ -1150,6 +1161,7 @@ mod tests {
                 items: vec![PlanItem {
                     step: "Patch handler".to_string(),
                     status: PlanStepStatus::InProgress,
+                    job_id: None,
                 }],
                 runtime: None,
                 updated_at: None,

--- a/lib/harper-core/src/tools/plan.rs
+++ b/lib/harper-core/src/tools/plan.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::core::error::{HarperError, HarperResult};
-use crate::core::plan::{PlanItem, PlanRuntime, PlanState, PlanStepStatus};
+use crate::core::plan::{PlanItem, PlanJobStatus, PlanRuntime, PlanState, PlanStepStatus};
 use rusqlite::Connection;
 
 pub fn update_plan(
@@ -49,6 +49,7 @@ pub fn update_plan(
         items.push(PlanItem {
             step: step.to_string(),
             status,
+            job_id: None,
         });
     }
 
@@ -104,6 +105,136 @@ pub fn set_plan_runtime(
     crate::memory::storage::save_plan_state(conn, session_id, &plan)
 }
 
+pub fn set_plan_runtime_state(
+    conn: &Connection,
+    session_id: &str,
+    tool_name: &str,
+    command: Option<String>,
+    status: &str,
+) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.set_active_tool_state(tool_name.to_string(), command, status.to_string());
+    })
+}
+
+pub fn start_plan_job(
+    conn: &Connection,
+    session_id: &str,
+    tool_name: &str,
+    command: Option<String>,
+    status: PlanJobStatus,
+) -> HarperResult<()> {
+    let Some(mut plan) = crate::memory::storage::load_plan_state(conn, session_id)? else {
+        return Ok(());
+    };
+    let mut runtime = plan.runtime.unwrap_or_default();
+    let job_id = runtime.start_job(tool_name.to_string(), command, status);
+    if let Some(item) = plan
+        .items
+        .iter_mut()
+        .find(|item| matches!(item.status, PlanStepStatus::InProgress))
+    {
+        item.job_id = Some(job_id);
+    }
+    plan.runtime = (!runtime.is_empty()).then_some(runtime);
+    crate::memory::storage::save_plan_state(conn, session_id, &plan)
+}
+
+pub fn update_active_plan_job(
+    conn: &Connection,
+    session_id: &str,
+    status: PlanJobStatus,
+) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.update_active_job_status(status);
+    })
+}
+
+pub fn finish_active_plan_job(
+    conn: &Connection,
+    session_id: &str,
+    status: PlanJobStatus,
+) -> HarperResult<()> {
+    finish_active_plan_job_with_output(conn, session_id, status, None, false)
+}
+
+pub fn finish_active_plan_job_with_output(
+    conn: &Connection,
+    session_id: &str,
+    status: PlanJobStatus,
+    output_preview: Option<String>,
+    has_error_output: bool,
+) -> HarperResult<()> {
+    let Some(mut plan) = crate::memory::storage::load_plan_state(conn, session_id)? else {
+        return Ok(());
+    };
+    let Some(mut runtime) = plan.runtime.take() else {
+        return Ok(());
+    };
+    let active_job_id = runtime.active_job_id.clone();
+    runtime.set_active_job_output(output_preview, has_error_output);
+    runtime.finish_active_job(status.clone());
+
+    if let Some(active_job_id) = active_job_id {
+        if let Some(item_index) = plan
+            .items
+            .iter()
+            .position(|item| item.job_id.as_deref() == Some(active_job_id.as_str()))
+        {
+            plan.items[item_index].job_id = None;
+            match status {
+                PlanJobStatus::Succeeded => {
+                    plan.items[item_index].status = PlanStepStatus::Completed;
+                    if let Some(next_pending) = plan
+                        .items
+                        .iter_mut()
+                        .find(|item| matches!(item.status, PlanStepStatus::Pending))
+                    {
+                        next_pending.status = PlanStepStatus::InProgress;
+                    }
+                }
+                PlanJobStatus::Blocked | PlanJobStatus::Failed => {
+                    plan.items[item_index].status = PlanStepStatus::Blocked;
+                }
+                PlanJobStatus::WaitingApproval | PlanJobStatus::Running => {}
+            }
+        }
+    }
+
+    plan.runtime = (!runtime.is_empty()).then_some(runtime);
+    crate::memory::storage::save_plan_state(conn, session_id, &plan)
+}
+
+pub fn clear_active_plan_runtime(conn: &Connection, session_id: &str) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.clear_active_state();
+    })
+}
+
+pub fn append_active_plan_job_output(
+    conn: &Connection,
+    session_id: &str,
+    chunk: &str,
+    is_error: bool,
+) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.append_active_job_output(chunk, is_error);
+    })
+}
+
+fn update_plan_runtime<F>(conn: &Connection, session_id: &str, mutator: F) -> HarperResult<()>
+where
+    F: FnOnce(&mut PlanRuntime),
+{
+    let Some(mut plan) = crate::memory::storage::load_plan_state(conn, session_id)? else {
+        return Ok(());
+    };
+    let mut runtime = plan.runtime.unwrap_or_default();
+    mutator(&mut runtime);
+    plan.runtime = (!runtime.is_empty()).then_some(runtime);
+    crate::memory::storage::save_plan_state(conn, session_id, &plan)
+}
+
 fn parse_status(value: Option<&serde_json::Value>) -> HarperResult<PlanStepStatus> {
     let raw = value
         .and_then(|status| status.as_str())
@@ -115,9 +246,242 @@ fn parse_status(value: Option<&serde_json::Value>) -> HarperResult<PlanStepStatu
         "pending" => Ok(PlanStepStatus::Pending),
         "in_progress" | "in-progress" | "in progress" => Ok(PlanStepStatus::InProgress),
         "completed" | "done" => Ok(PlanStepStatus::Completed),
+        "blocked" => Ok(PlanStepStatus::Blocked),
         _ => Err(HarperError::Validation(format!(
             "invalid plan status '{}'",
             raw
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        append_active_plan_job_output, finish_active_plan_job, finish_active_plan_job_with_output,
+        start_plan_job,
+    };
+    use crate::core::plan::{PlanItem, PlanJobStatus, PlanState, PlanStepStatus};
+    use rusqlite::Connection;
+
+    #[test]
+    fn start_plan_job_links_current_in_progress_step() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-job-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Run migration".to_string(),
+                    status: PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        start_plan_job(
+            &conn,
+            "plan-job-session",
+            "run_command",
+            Some("cargo test".to_string()),
+            PlanJobStatus::Running,
+        )
+        .expect("start job");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-job-session")
+            .expect("load plan")
+            .expect("plan present");
+        assert_eq!(plan.runtime.as_ref().map(|rt| rt.jobs.len()), Some(1));
+        assert_eq!(
+            plan.items[0].job_id,
+            plan.runtime
+                .as_ref()
+                .and_then(|runtime| runtime.active_job_id.clone())
+        );
+    }
+
+    #[test]
+    fn finish_active_plan_job_advances_linked_step_on_success() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-finish-session",
+            &PlanState {
+                explanation: None,
+                items: vec![
+                    PlanItem {
+                        step: "Run migration".to_string(),
+                        status: PlanStepStatus::InProgress,
+                        job_id: None,
+                    },
+                    PlanItem {
+                        step: "Check output".to_string(),
+                        status: PlanStepStatus::Pending,
+                        job_id: None,
+                    },
+                ],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        start_plan_job(
+            &conn,
+            "plan-finish-session",
+            "run_command",
+            Some("cargo test".to_string()),
+            PlanJobStatus::Running,
+        )
+        .expect("start job");
+        finish_active_plan_job(&conn, "plan-finish-session", PlanJobStatus::Succeeded)
+            .expect("finish job");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-finish-session")
+            .expect("load plan")
+            .expect("plan present");
+        assert_eq!(plan.items[0].status, PlanStepStatus::Completed);
+        assert!(plan.items[0].job_id.is_none());
+        assert_eq!(plan.items[1].status, PlanStepStatus::InProgress);
+        assert_eq!(plan.runtime.as_ref().map(|rt| rt.jobs.len()), Some(1));
+        assert!(plan
+            .runtime
+            .as_ref()
+            .is_some_and(|rt| rt.active_job_id.is_none()));
+    }
+
+    #[test]
+    fn finish_active_plan_job_blocks_linked_step_on_failure() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-block-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Run migration".to_string(),
+                    status: PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        start_plan_job(
+            &conn,
+            "plan-block-session",
+            "run_command",
+            Some("cargo test".to_string()),
+            PlanJobStatus::Running,
+        )
+        .expect("start job");
+        finish_active_plan_job(&conn, "plan-block-session", PlanJobStatus::Failed)
+            .expect("finish job");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-block-session")
+            .expect("load plan")
+            .expect("plan present");
+        assert_eq!(plan.items[0].status, PlanStepStatus::Blocked);
+        assert!(plan.items[0].job_id.is_none());
+    }
+
+    #[test]
+    fn finish_active_plan_job_persists_output_preview() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-output-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Run command".to_string(),
+                    status: PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        start_plan_job(
+            &conn,
+            "plan-output-session",
+            "run_command",
+            Some("cargo test".to_string()),
+            PlanJobStatus::Running,
+        )
+        .expect("start job");
+        finish_active_plan_job_with_output(
+            &conn,
+            "plan-output-session",
+            PlanJobStatus::Succeeded,
+            Some("ok\nall green".to_string()),
+            false,
+        )
+        .expect("finish job");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-output-session")
+            .expect("load plan")
+            .expect("plan present");
+        let runtime = plan.runtime.expect("runtime kept for job history");
+        assert_eq!(runtime.jobs.len(), 1);
+        assert_eq!(
+            runtime.jobs[0].output_preview.as_deref(),
+            Some("ok\nall green")
+        );
+        assert!(!runtime.jobs[0].has_error_output);
+    }
+
+    #[test]
+    fn append_active_plan_job_output_updates_live_transcript_and_preview() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-live-output-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Run command".to_string(),
+                    status: PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        start_plan_job(
+            &conn,
+            "plan-live-output-session",
+            "run_command",
+            Some("cargo test".to_string()),
+            PlanJobStatus::Running,
+        )
+        .expect("start job");
+        append_active_plan_job_output(&conn, "plan-live-output-session", "line one\n", false)
+            .expect("append stdout");
+        append_active_plan_job_output(&conn, "plan-live-output-session", "line two\n", true)
+            .expect("append stderr");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-live-output-session")
+            .expect("load plan")
+            .expect("plan present");
+        let runtime = plan.runtime.expect("runtime kept for live output");
+        let job = runtime.jobs.first().expect("job present");
+        assert_eq!(job.output_transcript, "line one\nline two\n");
+        assert_eq!(job.output_preview.as_deref(), Some("line one\nline two"));
+        assert!(job.has_error_output);
     }
 }

--- a/lib/harper-core/src/tools/shell.rs
+++ b/lib/harper-core/src/tools/shell.rs
@@ -17,7 +17,7 @@
 //! This module provides functionality for executing shell commands
 //! with safety checks and user approval.
 
-use crate::core::plan::PlanRuntime;
+use crate::core::plan::PlanJobStatus;
 use crate::core::{error::HarperError, ApiConfig};
 use crate::memory::storage::{self, CommandLogRecord};
 use crate::runtime::config::ExecPolicyConfig;
@@ -63,6 +63,19 @@ async fn emit_command_output(
             .command_output_updated(session_id, command.to_string(), chunk, is_error, done)
             .await;
     }
+}
+
+fn database_path(conn: &Connection) -> Option<String> {
+    let mut stmt = conn.prepare("PRAGMA database_list").ok()?;
+    let mut rows = stmt.query([]).ok()?;
+    while let Ok(Some(row)) = rows.next() {
+        let name: String = row.get(1).ok()?;
+        let path: String = row.get(2).ok()?;
+        if name == "main" && !path.trim().is_empty() {
+            return Some(path);
+        }
+    }
+    None
 }
 
 /// Execute a shell command with safety checks
@@ -211,14 +224,12 @@ pub async fn execute_command(
         if let Some(ctx) =
             audit_ctx.and_then(|ctx| ctx.session_id.map(|session_id| (ctx.conn, session_id)))
         {
-            let _ = crate::tools::plan::set_plan_runtime(
+            let _ = crate::tools::plan::start_plan_job(
                 ctx.0,
                 ctx.1,
-                Some(PlanRuntime {
-                    active_tool: Some("run_command".to_string()),
-                    active_command: Some(command_str.to_string()),
-                    active_status: Some("waiting_approval".to_string()),
-                }),
+                "run_command",
+                Some(command_str.to_string()),
+                PlanJobStatus::WaitingApproval,
             );
             emit_plan_update(runtime_events.as_ref(), ctx.0, ctx.1).await;
         }
@@ -259,14 +270,10 @@ pub async fn execute_command(
             if let Some(ctx) =
                 audit_ctx.and_then(|ctx| ctx.session_id.map(|session_id| (ctx.conn, session_id)))
             {
-                let _ = crate::tools::plan::set_plan_runtime(
+                let _ = crate::tools::plan::finish_active_plan_job(
                     ctx.0,
                     ctx.1,
-                    Some(PlanRuntime {
-                        active_tool: Some("run_command".to_string()),
-                        active_command: Some(command_str.to_string()),
-                        active_status: Some("blocked".to_string()),
-                    }),
+                    PlanJobStatus::Blocked,
                 );
                 emit_plan_update(runtime_events.as_ref(), ctx.0, ctx.1).await;
             }
@@ -296,15 +303,16 @@ pub async fn execute_command(
             Some(format!("running command: {}", command_str)),
         )
         .await;
-        let _ = crate::tools::plan::set_plan_runtime(
-            ctx.0,
-            ctx.1,
-            Some(PlanRuntime {
-                active_tool: Some("run_command".to_string()),
-                active_command: Some(command_str.to_string()),
-                active_status: Some("running".to_string()),
-            }),
-        );
+        let _ = crate::tools::plan::update_active_plan_job(ctx.0, ctx.1, PlanJobStatus::Running)
+            .or_else(|_| {
+                crate::tools::plan::start_plan_job(
+                    ctx.0,
+                    ctx.1,
+                    "run_command",
+                    Some(command_str.to_string()),
+                    PlanJobStatus::Running,
+                )
+            });
         emit_plan_update(runtime_events.as_ref(), ctx.0, ctx.1).await;
     }
 
@@ -336,13 +344,31 @@ pub async fn execute_command(
     if let Some(stdout) = child.stdout.take() {
         let runtime_events = runtime_events.clone();
         let session_id = audit_ctx.and_then(|ctx| ctx.session_id).map(str::to_string);
+        let db_path = audit_ctx.and_then(|ctx| database_path(ctx.conn));
         let command = command_str.to_string();
         stdout_task = Some(tokio::spawn(async move {
+            let live_conn = db_path
+                .as_deref()
+                .and_then(|path| crate::memory::storage::create_connection(path).ok());
             let mut lines = BufReader::new(stdout).lines();
             let mut collected = String::new();
             while let Ok(Some(line)) = lines.next_line().await {
                 collected.push_str(&line);
                 collected.push('\n');
+                if let (Some(conn), Some(session_id)) = (&live_conn, session_id.as_deref()) {
+                    let _ = crate::tools::plan::append_active_plan_job_output(
+                        conn,
+                        session_id,
+                        &format!("{}\n", line),
+                        false,
+                    );
+                    if let Some(sink) = runtime_events.as_ref() {
+                        let plan = crate::memory::storage::load_plan_state(conn, session_id)
+                            .ok()
+                            .flatten();
+                        let _ = sink.plan_updated(session_id, plan).await;
+                    }
+                }
                 emit_command_output(
                     runtime_events.as_ref(),
                     session_id.as_deref(),
@@ -361,13 +387,31 @@ pub async fn execute_command(
     if let Some(stderr) = child.stderr.take() {
         let runtime_events = runtime_events.clone();
         let session_id = audit_ctx.and_then(|ctx| ctx.session_id).map(str::to_string);
+        let db_path = audit_ctx.and_then(|ctx| database_path(ctx.conn));
         let command = command_str.to_string();
         stderr_task = Some(tokio::spawn(async move {
+            let live_conn = db_path
+                .as_deref()
+                .and_then(|path| crate::memory::storage::create_connection(path).ok());
             let mut lines = BufReader::new(stderr).lines();
             let mut collected = String::new();
             while let Ok(Some(line)) = lines.next_line().await {
                 collected.push_str(&line);
                 collected.push('\n');
+                if let (Some(conn), Some(session_id)) = (&live_conn, session_id.as_deref()) {
+                    let _ = crate::tools::plan::append_active_plan_job_output(
+                        conn,
+                        session_id,
+                        &format!("{}\n", line),
+                        true,
+                    );
+                    if let Some(sink) = runtime_events.as_ref() {
+                        let plan = crate::memory::storage::load_plan_state(conn, session_id)
+                            .ok()
+                            .flatten();
+                        let _ = sink.plan_updated(session_id, plan).await;
+                    }
+                }
                 emit_command_output(
                     runtime_events.as_ref(),
                     session_id.as_deref(),
@@ -407,6 +451,14 @@ pub async fn execute_command(
     let exit_code = status.code();
     let stdout_preview = bytes_to_preview(stdout_text.as_bytes());
     let stderr_preview = bytes_to_preview(stderr_text.as_bytes());
+    let output_preview = if status.success() {
+        preview_text(&stdout_text)
+    } else if !stderr_text.trim().is_empty() {
+        preview_text(&stderr_text)
+    } else {
+        preview_text(&stdout_text)
+    };
+    let has_error_output = !status.success() || !stderr_text.trim().is_empty();
 
     let result = if status.success() {
         let out = stdout_text;
@@ -443,7 +495,17 @@ pub async fn execute_command(
     if let Some(ctx) =
         audit_ctx.and_then(|ctx| ctx.session_id.map(|session_id| (ctx.conn, session_id)))
     {
-        let _ = crate::tools::plan::set_plan_runtime(ctx.0, ctx.1, None);
+        let _ = crate::tools::plan::finish_active_plan_job_with_output(
+            ctx.0,
+            ctx.1,
+            if status.success() {
+                PlanJobStatus::Succeeded
+            } else {
+                PlanJobStatus::Failed
+            },
+            output_preview,
+            has_error_output,
+        );
         emit_plan_update(runtime_events.as_ref(), ctx.0, ctx.1).await;
     }
 
@@ -493,6 +555,20 @@ fn maybe_log_command(
         if let Err(err) = storage::insert_command_log(ctx.conn, &record) {
             eprintln!("Warning: failed to persist command log: {}", err);
         }
+    }
+}
+
+fn preview_text(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let preview: String = trimmed.chars().take(OUTPUT_PREVIEW_LIMIT).collect();
+    if trimmed.chars().count() > OUTPUT_PREVIEW_LIMIT {
+        Some(format!("{}…", preview))
+    } else {
+        Some(preview)
     }
 }
 

--- a/lib/harper-ui/src/interfaces/ui/app.rs
+++ b/lib/harper-ui/src/interfaces/ui/app.rs
@@ -45,6 +45,7 @@ pub struct ReviewState {
 pub enum NavigationFocus {
     Messages,
     Review,
+    PlanJobs,
     Agents,
 }
 
@@ -57,6 +58,9 @@ pub struct ChatState {
     pub active_agents: Option<ResolvedAgents>,
     pub active_review: Option<ReviewState>,
     pub review_selected: usize,
+    pub plan_job_selected: usize,
+    pub plan_jobs_expanded: bool,
+    pub plan_job_output_scroll: usize,
     pub navigation_focus: NavigationFocus,
     pub command_output: Option<CommandOutputState>,
     pub agents_panel_expanded: bool,
@@ -200,6 +204,22 @@ pub async fn gather_sidebar_entries_async(messages: &[Message]) -> Vec<String> {
 }
 
 impl ChatState {
+    pub fn refresh_plan_state(&mut self) {
+        if let Some(plan) = &self.active_plan {
+            let max_jobs = plan
+                .runtime
+                .as_ref()
+                .map(|runtime| runtime.jobs.len().saturating_sub(1))
+                .unwrap_or(0);
+            self.plan_job_selected = self.plan_job_selected.min(max_jobs);
+        } else {
+            self.plan_job_selected = 0;
+            self.plan_jobs_expanded = false;
+            self.plan_job_output_scroll = 0;
+        }
+        self.normalize_navigation_focus();
+    }
+
     pub fn reset_completion(&mut self) {
         self.completion_candidates.clear();
         self.completion_index = 0;
@@ -216,6 +236,11 @@ impl ChatState {
             .active_review
             .as_ref()
             .is_some_and(|review| !review.findings.is_empty());
+        let has_jobs = self
+            .active_plan
+            .as_ref()
+            .and_then(|plan| plan.runtime.as_ref())
+            .is_some_and(|runtime| !runtime.jobs.is_empty());
         let has_agents = self.agents_panel_expanded
             && self
                 .active_agents
@@ -224,6 +249,7 @@ impl ChatState {
 
         self.navigation_focus = match self.navigation_focus {
             NavigationFocus::Review if has_review => NavigationFocus::Review,
+            NavigationFocus::PlanJobs if has_jobs => NavigationFocus::PlanJobs,
             NavigationFocus::Agents if has_agents => NavigationFocus::Agents,
             _ => NavigationFocus::Messages,
         };
@@ -233,6 +259,7 @@ impl ChatState {
         match self.navigation_focus {
             NavigationFocus::Messages => "messages",
             NavigationFocus::Review => "findings",
+            NavigationFocus::PlanJobs => "jobs",
             NavigationFocus::Agents => "agents",
         }
     }
@@ -248,7 +275,7 @@ impl ChatState {
         } else {
             self.review_selected = 0;
         }
-        self.normalize_navigation_focus();
+        self.refresh_plan_state();
     }
 }
 
@@ -446,6 +473,22 @@ impl TuiApp {
                             }
                         }
                     }
+                    NavigationFocus::PlanJobs => {
+                        if chat_state.plan_jobs_expanded {
+                            chat_state.plan_job_output_scroll =
+                                chat_state.plan_job_output_scroll.saturating_add(1);
+                        } else if let Some(runtime) = chat_state
+                            .active_plan
+                            .as_ref()
+                            .and_then(|plan| plan.runtime.as_ref())
+                        {
+                            if !runtime.jobs.is_empty() {
+                                chat_state.plan_job_selected =
+                                    (chat_state.plan_job_selected + 1).min(runtime.jobs.len() - 1);
+                                chat_state.plan_job_output_scroll = 0;
+                            }
+                        }
+                    }
                     NavigationFocus::Agents => {
                         chat_state.agents_scroll_offset =
                             chat_state.agents_scroll_offset.saturating_add(1);
@@ -489,6 +532,16 @@ impl TuiApp {
                 match chat_state.navigation_focus {
                     NavigationFocus::Review => {
                         chat_state.review_selected = chat_state.review_selected.saturating_sub(1);
+                    }
+                    NavigationFocus::PlanJobs => {
+                        if chat_state.plan_jobs_expanded {
+                            chat_state.plan_job_output_scroll =
+                                chat_state.plan_job_output_scroll.saturating_sub(1);
+                        } else {
+                            chat_state.plan_job_selected =
+                                chat_state.plan_job_selected.saturating_sub(1);
+                            chat_state.plan_job_output_scroll = 0;
+                        }
                     }
                     NavigationFocus::Agents => {
                         chat_state.agents_scroll_offset =

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 // Keyboard shortcut constants
 const HELP_MESSAGE: &str =
-    "G:Help | Tab:Complete | Esc:Back | ↑↓:Navigate | Y/V:Prev/Next | Enter:Select/Approve | T:Send | L/→:Preview | X:Exit | W:Web | B:Sidebar | A:Agents | F:Findings | M:Msgs | C:ID";
+    "G:Help | Tab:Complete | Esc:Back | ↑↓:Navigate | Y/V:Prev/Next | Enter:Select/Approve | T:Send | L/→:Preview | X:Exit | W:Web | B:Sidebar | A:Agents | F:Findings | P:Jobs | M:Msgs | C:ID";
 
 use super::app::{AppState, ChatState, NavigationFocus, SessionInfo, TuiApp};
 use harper_core::memory::session_service::SessionService;
@@ -53,6 +53,9 @@ pub(crate) fn create_chat_state(
         active_agents,
         active_review: None,
         review_selected: 0,
+        plan_job_selected: 0,
+        plan_jobs_expanded: false,
+        plan_job_output_scroll: 0,
         navigation_focus: NavigationFocus::Messages,
         command_output: None,
         agents_panel_expanded: false,
@@ -302,6 +305,42 @@ pub fn handle_event(
                         }
                         return EventResult::Continue;
                     }
+                    KeyCode::Char('p') => {
+                        let mut status_message = None;
+                        if let AppState::Chat(chat_state) = &mut app.state {
+                            if chat_state
+                                .active_plan
+                                .as_ref()
+                                .and_then(|plan| plan.runtime.as_ref())
+                                .is_some_and(|runtime| !runtime.jobs.is_empty())
+                            {
+                                if !chat_state.plan_jobs_expanded {
+                                    chat_state.plan_jobs_expanded = true;
+                                    chat_state.set_navigation_focus(NavigationFocus::PlanJobs);
+                                    status_message =
+                                        Some("Planner jobs browser expanded".to_string());
+                                } else if matches!(
+                                    chat_state.navigation_focus,
+                                    NavigationFocus::PlanJobs
+                                ) {
+                                    chat_state.plan_jobs_expanded = false;
+                                    chat_state.plan_job_output_scroll = 0;
+                                    chat_state.set_navigation_focus(NavigationFocus::Messages);
+                                    status_message =
+                                        Some("Planner jobs browser closed".to_string());
+                                } else {
+                                    chat_state.set_navigation_focus(NavigationFocus::PlanJobs);
+                                    status_message = Some("Focus on planner jobs".to_string());
+                                }
+                            } else {
+                                status_message = Some("No planner jobs".to_string());
+                            }
+                        }
+                        if let Some(message) = status_message {
+                            app.set_status_message(message);
+                        }
+                        return EventResult::Continue;
+                    }
                     KeyCode::Char('y') => {
                         app.previous();
                         return EventResult::Continue;
@@ -336,9 +375,18 @@ pub fn handle_event(
                 {
                     handle_image_paste(app);
                 }
-                KeyCode::Esc => match &app.state {
+                KeyCode::Esc => match &mut app.state {
                     AppState::Menu(_) => {}
-                    AppState::Chat(_) => app.state = AppState::Menu(0),
+                    AppState::Chat(chat_state) => {
+                        if chat_state.plan_jobs_expanded {
+                            chat_state.plan_jobs_expanded = false;
+                            chat_state.plan_job_output_scroll = 0;
+                            chat_state.set_navigation_focus(NavigationFocus::Messages);
+                            app.set_status_message("Planner jobs browser closed".to_string());
+                        } else {
+                            app.state = AppState::Menu(0);
+                        }
+                    }
                     AppState::Sessions(_, _) => app.state = AppState::Menu(0),
                     AppState::ExportSessions(_, _) => app.state = AppState::Menu(0),
                     AppState::Tools(_) => app.state = AppState::Menu(0),

--- a/lib/harper-ui/src/interfaces/ui/tui.rs
+++ b/lib/harper-ui/src/interfaces/ui/tui.rs
@@ -510,6 +510,7 @@ pub async fn run_tui(
                                     chat_state.awaiting_response = false;
                                     chat_state.active_plan = session_view.plan;
                                     chat_state.active_agents = session_view.agents;
+                                    chat_state.refresh_plan_state();
                                     chat_state.refresh_review_state();
                                     should_clear_activity = true;
                                     if chat_state.sidebar_visible {
@@ -564,6 +565,7 @@ pub async fn run_tui(
                             if let AppState::Chat(chat_state) = &mut app.state {
                                 if chat_state.session_id == session_id {
                                     chat_state.active_plan = active_plan;
+                                    chat_state.refresh_plan_state();
                                 }
                             }
                         }

--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -20,10 +20,11 @@ use super::app::{
     AppState, ApprovalState, CommandOutputState, ReviewState, SessionInfo, TuiApp, UiMessage,
 };
 use super::theme::Theme;
+use harper_core::core::plan::{PlanJobRecord, PlanJobStatus};
 use harper_core::{PlanRuntime, PlanState, PlanStepStatus, ResolvedAgents};
 
 // Refined shortcuts for a cleaner footer
-const FOOTER_SHORTCUTS: [[(&str, &str); 8]; 2] = [
+const FOOTER_SHORTCUTS: [[(&str, &str); 9]; 2] = [
     [
         ("G", "Help"),
         ("W", "Search"),
@@ -33,6 +34,7 @@ const FOOTER_SHORTCUTS: [[(&str, &str); 8]; 2] = [
         ("M", "Msgs"),
         ("C", "ID"),
         ("O", "Export"),
+        ("P", "Jobs"),
     ],
     [
         ("X", "Exit"),
@@ -43,6 +45,7 @@ const FOOTER_SHORTCUTS: [[(&str, &str); 8]; 2] = [
         ("Y", "Prev"),
         ("V", "Next"),
         ("Esc", "Back"),
+        ("P", "Jobs"),
     ],
 ];
 
@@ -288,7 +291,17 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
 
             if has_plan {
                 if let Some(plan) = &chat_state.active_plan {
-                    draw_plan_panel(frame, plan, theme, chunks[next_panel_index]);
+                    draw_plan_panel(
+                        frame,
+                        plan,
+                        chat_state.plan_job_selected,
+                        matches!(
+                            chat_state.navigation_focus,
+                            super::app::NavigationFocus::PlanJobs
+                        ),
+                        theme,
+                        chunks[next_panel_index],
+                    );
                 }
                 next_panel_index += 1;
             }
@@ -355,6 +368,12 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
         draw_approval(frame, approval, theme);
     }
 
+    if let AppState::Chat(chat_state) = &app.state {
+        if chat_state.plan_jobs_expanded {
+            draw_plan_jobs_browser(frame, chat_state, theme);
+        }
+    }
+
     if let Some(msg) = &app.message {
         draw_message_overlay(frame, msg, theme);
     }
@@ -388,12 +407,19 @@ fn draw_chat_summary(
                 .iter()
                 .filter(|item| matches!(item.status, PlanStepStatus::Completed))
                 .count();
+            let blocked = plan
+                .items
+                .iter()
+                .filter(|item| matches!(item.status, PlanStepStatus::Blocked))
+                .count();
             let in_progress = plan
                 .items
                 .iter()
                 .any(|item| matches!(item.status, PlanStepStatus::InProgress));
             if total == 0 {
                 "plan: empty".to_string()
+            } else if blocked > 0 {
+                format!("plan: {}/{} done, {} blocked", completed, total, blocked)
             } else if in_progress {
                 format!("plan: {}/{} done, active", completed, total)
             } else {
@@ -583,8 +609,28 @@ fn plan_panel_height(plan: &PlanState) -> u16 {
     if plan.explanation.is_some() {
         lines += 1;
     }
-    if plan.runtime.is_some() {
+    if plan
+        .runtime
+        .as_ref()
+        .is_some_and(PlanRuntime::has_active_state)
+    {
         lines += 1;
+    }
+    if let Some(runtime) = &plan.runtime {
+        lines += runtime.jobs.len().min(3);
+        if runtime.jobs.len() > 3 {
+            lines += 1;
+        }
+        if !runtime.jobs.is_empty() {
+            lines += 1;
+            if runtime.jobs.iter().any(|job| {
+                job.output_preview
+                    .as_ref()
+                    .is_some_and(|preview| !preview.is_empty())
+            }) {
+                lines += 2;
+            }
+        }
     }
     lines as u16
 }
@@ -707,17 +753,61 @@ fn draw_review_panel(
     frame.render_widget(widget, area);
 }
 
-fn draw_plan_panel(frame: &mut Frame, plan: &PlanState, theme: &Theme, area: Rect) {
+fn draw_plan_panel(
+    frame: &mut Frame,
+    plan: &PlanState,
+    selected_job: usize,
+    focused: bool,
+    theme: &Theme,
+    area: Rect,
+) {
     let mut lines = Vec::new();
 
     if let Some(explanation) = &plan.explanation {
         lines.push(Line::styled(explanation.as_str(), theme.muted_style()));
     }
-    if let Some(runtime) = &plan.runtime {
+    if let Some(runtime) = plan
+        .runtime
+        .as_ref()
+        .filter(|runtime| runtime.has_active_state())
+    {
         lines.push(Line::styled(
             format_plan_runtime(runtime),
             theme.muted_style().add_modifier(Modifier::ITALIC),
         ));
+    }
+    if let Some(runtime) = &plan.runtime {
+        lines.extend(plan_job_lines(runtime, selected_job, focused, theme));
+        if let Some(selected) = runtime
+            .jobs
+            .get(selected_job.min(runtime.jobs.len().saturating_sub(1)))
+        {
+            lines.push(Line::styled(
+                format!(
+                    "job {} • {}",
+                    &selected.job_id[..selected.job_id.len().min(8)],
+                    selected.tool
+                ),
+                theme.muted_style(),
+            ));
+            if let Some(preview) = selected
+                .output_preview
+                .as_ref()
+                .filter(|preview| !preview.is_empty())
+            {
+                let preview_color = if selected.has_error_output {
+                    Color::Rgb(245, 158, 11)
+                } else {
+                    theme.output
+                };
+                for line in preview.lines().take(2) {
+                    lines.push(Line::styled(
+                        format!("  {}", truncate_chat_summary(line, 88)),
+                        Style::default().fg(preview_color),
+                    ));
+                }
+            }
+        }
     }
 
     for item in plan.items.iter().take(4) {
@@ -725,6 +815,7 @@ fn draw_plan_panel(frame: &mut Frame, plan: &PlanState, theme: &Theme, area: Rec
             PlanStepStatus::Pending => ("○", theme.muted),
             PlanStepStatus::InProgress => ("◐", theme.accent),
             PlanStepStatus::Completed => ("●", theme.output),
+            PlanStepStatus::Blocked => ("■", Color::Rgb(245, 158, 11)),
         };
         lines.push(Line::from(vec![
             Span::styled(marker, Style::default().fg(color)),
@@ -740,8 +831,13 @@ fn draw_plan_panel(frame: &mut Frame, plan: &PlanState, theme: &Theme, area: Rec
         ));
     }
 
+    let title = if focused {
+        " Plan (focused • Y/V or ↑/↓) "
+    } else {
+        " Plan (Ctrl+P jobs) "
+    };
     let block = Block::default()
-        .title(" Plan ")
+        .title(title)
         .borders(Borders::TOP)
         .border_style(theme.muted_style())
         .padding(Padding::horizontal(1));
@@ -887,6 +983,70 @@ fn format_plan_runtime(runtime: &PlanRuntime) -> String {
         .or(runtime.active_tool.as_deref())
         .unwrap_or("task");
     format!("{}: {}", status, target)
+}
+
+fn plan_job_lines(
+    runtime: &PlanRuntime,
+    selected_job: usize,
+    focused: bool,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let jobs = &runtime.jobs;
+    let selected_job = selected_job.min(jobs.len().saturating_sub(1));
+    let window_end = (selected_job + 1).max(3).min(jobs.len());
+    let window_start = window_end.saturating_sub(3);
+
+    for (index, job) in jobs
+        .iter()
+        .enumerate()
+        .skip(window_start)
+        .take(window_end.saturating_sub(window_start))
+    {
+        let (marker, color) = match job.status {
+            PlanJobStatus::WaitingApproval => ("◌", theme.muted),
+            PlanJobStatus::Running => ("◐", theme.accent),
+            PlanJobStatus::Blocked => ("■", Color::Rgb(245, 158, 11)),
+            PlanJobStatus::Succeeded => ("●", theme.output),
+            PlanJobStatus::Failed => ("✕", Color::Rgb(239, 68, 68)),
+        };
+        let is_selected = focused && index == selected_job;
+        lines.push(Line::from(vec![
+            Span::styled(marker, Style::default().fg(color)),
+            Span::raw(" "),
+            Span::styled(
+                format_plan_job(job),
+                if is_selected {
+                    Style::default()
+                        .fg(theme.foreground)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    theme.muted_style().add_modifier(Modifier::ITALIC)
+                },
+            ),
+        ]));
+    }
+
+    if runtime.jobs.len() > window_end {
+        lines.push(Line::styled(
+            format!("{} more jobs", runtime.jobs.len() - window_end),
+            theme.muted_style(),
+        ));
+    }
+
+    lines
+}
+
+fn format_plan_job(job: &PlanJobRecord) -> String {
+    let target = job.command.as_deref().unwrap_or(&job.tool);
+    let status = match job.status {
+        PlanJobStatus::WaitingApproval => "waiting approval",
+        PlanJobStatus::Running => "running",
+        PlanJobStatus::Blocked => "blocked",
+        PlanJobStatus::Succeeded => "succeeded",
+        PlanJobStatus::Failed => "failed",
+    };
+    format!("{}: {}", status, truncate_chat_summary(target, 64))
 }
 
 fn draw_stats(
@@ -1306,9 +1466,95 @@ fn draw_message_overlay(frame: &mut Frame, message: &UiMessage, theme: &Theme) {
     frame.render_widget(overlay, overlay_area);
 }
 
+fn draw_plan_jobs_browser(frame: &mut Frame, chat_state: &super::app::ChatState, theme: &Theme) {
+    let Some(plan) = &chat_state.active_plan else {
+        return;
+    };
+    let Some(runtime) = &plan.runtime else {
+        return;
+    };
+    if runtime.jobs.is_empty() {
+        return;
+    }
+
+    let selected_index = chat_state
+        .plan_job_selected
+        .min(runtime.jobs.len().saturating_sub(1));
+    let selected = &runtime.jobs[selected_index];
+    let overlay_area = centered_rect(80, 70, frame.area());
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Length(4),
+            Constraint::Min(8),
+        ])
+        .split(overlay_area);
+
+    frame.render_widget(Clear, overlay_area);
+
+    let title = Paragraph::new(format!(
+        "Planner Jobs • job {} • {} • Esc close • Y/V select • ↑/↓ scroll",
+        &selected.job_id[..selected.job_id.len().min(8)],
+        selected.tool
+    ))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.muted_style())
+            .style(Style::default().bg(theme.background)),
+    )
+    .style(Style::default().fg(theme.foreground));
+    frame.render_widget(title, chunks[0]);
+
+    let summary_lines = plan_job_lines(runtime, selected_index, true, theme);
+    let summary = Paragraph::new(summary_lines)
+        .block(
+            Block::default()
+                .title(" Recent Jobs ")
+                .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                .border_style(theme.muted_style())
+                .style(Style::default().bg(theme.background)),
+        )
+        .wrap(Wrap { trim: true });
+    frame.render_widget(summary, chunks[1]);
+
+    let detail_lines = plan_job_transcript_lines(selected, theme);
+    let detail = Paragraph::new(detail_lines)
+        .block(
+            Block::default()
+                .title(" Output Transcript ")
+                .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                .border_style(theme.muted_style())
+                .style(Style::default().bg(theme.background))
+                .padding(Padding::horizontal(1)),
+        )
+        .scroll((chat_state.plan_job_output_scroll as u16, 0))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(detail, chunks[2]);
+}
+
+fn plan_job_transcript_lines(job: &PlanJobRecord, theme: &Theme) -> Vec<Line<'static>> {
+    let transcript = if job.output_transcript.trim().is_empty() {
+        "No output recorded yet".to_string()
+    } else {
+        job.output_transcript.clone()
+    };
+    let detail_color = if job.has_error_output {
+        Color::Rgb(245, 158, 11)
+    } else {
+        theme.output
+    };
+    transcript
+        .lines()
+        .map(|line| Line::styled(line.to_string(), Style::default().fg(detail_color)))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use harper_core::PlanItem;
     use ratatui::style::Color;
 
     fn setup() -> (SyntaxSet, ThemeSet) {
@@ -1329,5 +1575,143 @@ mod tests {
             "base16-ocean.dark",
         );
         assert_eq!(spans.len(), 1);
+    }
+
+    #[test]
+    fn plan_panel_height_accounts_for_recent_jobs() {
+        let plan = PlanState {
+            explanation: Some("Track execution".to_string()),
+            items: vec![PlanItem {
+                step: "Run command".to_string(),
+                status: PlanStepStatus::InProgress,
+                job_id: None,
+            }],
+            runtime: Some(PlanRuntime {
+                active_tool: Some("run_command".to_string()),
+                active_command: Some("echo hi".to_string()),
+                active_status: Some("running".to_string()),
+                active_job_id: Some("job-1".to_string()),
+                jobs: vec![
+                    PlanJobRecord {
+                        job_id: "job-1".to_string(),
+                        tool: "run_command".to_string(),
+                        command: Some("echo hi".to_string()),
+                        status: PlanJobStatus::Running,
+                        output_transcript: "line one\nline two".to_string(),
+                        output_preview: Some("line one\nline two".to_string()),
+                        has_error_output: false,
+                    },
+                    PlanJobRecord {
+                        job_id: "job-2".to_string(),
+                        tool: "run_command".to_string(),
+                        command: Some("ls".to_string()),
+                        status: PlanJobStatus::Succeeded,
+                        output_transcript: String::new(),
+                        output_preview: None,
+                        has_error_output: false,
+                    },
+                ],
+            }),
+            updated_at: None,
+        };
+
+        assert_eq!(plan_panel_height(&plan), 10);
+    }
+
+    #[test]
+    fn plan_job_lines_show_recent_jobs_and_overflow() {
+        let runtime = PlanRuntime {
+            active_tool: None,
+            active_command: None,
+            active_status: None,
+            active_job_id: None,
+            jobs: vec![
+                PlanJobRecord {
+                    job_id: "job-1".to_string(),
+                    tool: "run_command".to_string(),
+                    command: Some("echo one".to_string()),
+                    status: PlanJobStatus::Succeeded,
+                    output_transcript: String::new(),
+                    output_preview: None,
+                    has_error_output: false,
+                },
+                PlanJobRecord {
+                    job_id: "job-2".to_string(),
+                    tool: "run_command".to_string(),
+                    command: Some("echo two".to_string()),
+                    status: PlanJobStatus::Failed,
+                    output_transcript: "boom".to_string(),
+                    output_preview: Some("boom".to_string()),
+                    has_error_output: true,
+                },
+                PlanJobRecord {
+                    job_id: "job-3".to_string(),
+                    tool: "run_command".to_string(),
+                    command: Some("echo three".to_string()),
+                    status: PlanJobStatus::Running,
+                    output_transcript: String::new(),
+                    output_preview: None,
+                    has_error_output: false,
+                },
+                PlanJobRecord {
+                    job_id: "job-4".to_string(),
+                    tool: "run_command".to_string(),
+                    command: Some("echo four".to_string()),
+                    status: PlanJobStatus::WaitingApproval,
+                    output_transcript: String::new(),
+                    output_preview: None,
+                    has_error_output: false,
+                },
+            ],
+        };
+
+        let lines = plan_job_lines(&runtime, 0, true, &Theme::default());
+
+        assert_eq!(lines.len(), 4);
+        assert!(lines[0].to_string().contains("succeeded: echo one"));
+        assert!(lines[1].to_string().contains("failed: echo two"));
+        assert!(lines[2].to_string().contains("running: echo three"));
+        assert!(lines[3].to_string().contains("1 more jobs"));
+    }
+
+    #[test]
+    fn format_plan_job_prefers_command_text() {
+        let job = PlanJobRecord {
+            job_id: "job-1".to_string(),
+            tool: "run_command".to_string(),
+            command: Some("echo hi".to_string()),
+            status: PlanJobStatus::Blocked,
+            output_transcript: String::new(),
+            output_preview: None,
+            has_error_output: false,
+        };
+
+        assert_eq!(format_plan_job(&job), "blocked: echo hi");
+    }
+
+    #[test]
+    fn plan_job_transcript_lines_use_full_transcript_and_placeholder() {
+        let theme = Theme::default();
+        let job = PlanJobRecord {
+            job_id: "job-1".to_string(),
+            tool: "run_command".to_string(),
+            command: Some("echo hi".to_string()),
+            status: PlanJobStatus::Succeeded,
+            output_transcript: "line one\nline two\nline three".to_string(),
+            output_preview: Some("line one\nline two".to_string()),
+            has_error_output: false,
+        };
+        let placeholder_job = PlanJobRecord {
+            output_transcript: String::new(),
+            ..job.clone()
+        };
+
+        let transcript_lines = plan_job_transcript_lines(&job, &theme);
+        let placeholder_lines = plan_job_transcript_lines(&placeholder_job, &theme);
+
+        assert_eq!(transcript_lines.len(), 3);
+        assert_eq!(transcript_lines[0].to_string(), "line one");
+        assert_eq!(transcript_lines[2].to_string(), "line three");
+        assert_eq!(placeholder_lines[0].to_string(), "No output recorded yet");
     }
 }

--- a/website/blog.html
+++ b/website/blog.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Blog</title>
+    <meta name="harper-update-version" content="2026-04-28-blog" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -12,14 +13,14 @@
         <header class="site-header">
             <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
             <nav class="nav">
-                <a href="index.html">Home</a>
-                <a href="installation.html">Install</a>
-                <a href="troubleshooting.html">Troubleshooting</a>
-                <a href="blog.html" aria-current="page">Blog</a>
-                <a href="changelog.html">Changelog</a>
-                <a href="server.html">API Server</a>
-                <a href="terms.html">Terms</a>
-                <a href="privacy.html">Privacy</a>
+                <a href="index.html" data-update-target="home">Home</a>
+                <a href="installation.html" data-update-target="install">Install</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog" aria-current="page">Blog</a>
+                <a href="changelog.html" data-update-target="changelog">Changelog</a>
+                <a href="server.html" data-update-target="server">API Server</a>
+                <a href="terms.html" data-update-target="terms">Terms</a>
+                <a href="privacy.html" data-update-target="privacy">Privacy</a>
             </nav>
         </header>
 
@@ -69,6 +70,7 @@
             <a class="button secondary" href="index.html">← Back</a>
         </footer>
     </div>
+    <script src="nav-updates.js"></script>
     <script>
         const header = document.querySelector('.site-header');
         window.addEventListener('scroll', () => {

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Changelog</title>
+    <meta name="harper-update-version" content="2026-04-28-changelog" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -12,14 +13,14 @@
         <header class="site-header">
             <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
             <nav class="nav">
-                <a href="index.html">Home</a>
-                <a href="installation.html">Install</a>
-                <a href="troubleshooting.html">Troubleshooting</a>
-                <a href="blog.html">Blog</a>
-                <a href="changelog.html" aria-current="page">Changelog</a>
-                <a href="server.html">API Server</a>
-                <a href="terms.html">Terms</a>
-                <a href="privacy.html">Privacy</a>
+                <a href="index.html" data-update-target="home">Home</a>
+                <a href="installation.html" data-update-target="install">Install</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog">Blog</a>
+                <a href="changelog.html" data-update-target="changelog" aria-current="page">Changelog</a>
+                <a href="server.html" data-update-target="server">API Server</a>
+                <a href="terms.html" data-update-target="terms">Terms</a>
+                <a href="privacy.html" data-update-target="privacy">Privacy</a>
             </nav>
         </header>
 
@@ -41,6 +42,7 @@
             <a class="button secondary" href="index.html">← Back</a>
         </footer>
     </div>
+    <script src="nav-updates.js"></script>
     <script>
         const header = document.querySelector('.site-header');
         window.addEventListener('scroll', () => {

--- a/website/index.html
+++ b/website/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Terminal AI</title>
+    <meta name="harper-update-version" content="2026-04-28-home" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -12,14 +13,14 @@
         <header class="site-header">
             <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
             <nav class="nav">
-                <a href="index.html" aria-current="page">Home</a>
-                <a href="installation.html">Install</a>
-                <a href="troubleshooting.html">Troubleshooting</a>
-                <a href="blog.html">Blog</a>
-                <a href="changelog.html">Changelog</a>
-                <a href="server.html">API Server</a>
-                <a href="terms.html">Terms</a>
-                <a href="privacy.html">Privacy</a>
+                <a href="index.html" data-update-target="home" aria-current="page">Home</a>
+                <a href="installation.html" data-update-target="install">Install</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog">Blog</a>
+                <a href="changelog.html" data-update-target="changelog">Changelog</a>
+                <a href="server.html" data-update-target="server">API Server</a>
+                <a href="terms.html" data-update-target="terms">Terms</a>
+                <a href="privacy.html" data-update-target="privacy">Privacy</a>
             </nav>
         </header>
 
@@ -53,6 +54,7 @@
             <a href="changelog.html">Design</a> · v2
         </footer>
     </div>
+    <script src="nav-updates.js"></script>
     <script>
         const header = document.querySelector('.site-header');
         window.addEventListener('scroll', () => {

--- a/website/installation.html
+++ b/website/installation.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Installation</title>
+    <meta name="harper-update-version" content="2026-04-28-install" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -12,14 +13,14 @@
         <header class="site-header">
             <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
             <nav class="nav">
-                <a href="index.html">Home</a>
-                <a href="installation.html" aria-current="page">Install</a>
-                <a href="troubleshooting.html">Troubleshooting</a>
-                <a href="blog.html">Blog</a>
-                <a href="changelog.html">Changelog</a>
-                <a href="server.html">API Server</a>
-                <a href="terms.html">Terms</a>
-                <a href="privacy.html">Privacy</a>
+                <a href="index.html" data-update-target="home">Home</a>
+                <a href="installation.html" data-update-target="install" aria-current="page">Install</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog">Blog</a>
+                <a href="changelog.html" data-update-target="changelog">Changelog</a>
+                <a href="server.html" data-update-target="server">API Server</a>
+                <a href="terms.html" data-update-target="terms">Terms</a>
+                <a href="privacy.html" data-update-target="privacy">Privacy</a>
             </nav>
         </header>
 
@@ -180,6 +181,7 @@ Tab</code></pre>
             <a class="button secondary" href="index.html">← Back</a>
         </footer>
     </div>
+    <script src="nav-updates.js"></script>
     <script>
         const header = document.querySelector('.site-header');
         window.addEventListener('scroll', () => {

--- a/website/nav-updates.js
+++ b/website/nav-updates.js
@@ -1,0 +1,39 @@
+const STORAGE_PREFIX = "harper.site.seen.";
+
+async function applyNavUpdateIndicators() {
+    const currentPath = window.location.pathname.split("/").pop() || "index.html";
+    const currentVersion = document
+        .querySelector('meta[name="harper-update-version"]')
+        ?.getAttribute("content");
+    const response = await fetch("nav-updates.json", {
+        headers: { Accept: "application/json" }
+    });
+
+    if (!response.ok) {
+        return;
+    }
+
+    const updates = await response.json();
+
+    if (currentVersion) {
+        localStorage.setItem(`${STORAGE_PREFIX}${currentPath}`, currentVersion);
+    }
+
+    document.querySelectorAll(".nav a[data-update-target]").forEach((link) => {
+        const targetHref = link.getAttribute("href");
+        const latestVersion = targetHref ? updates[targetHref] : null;
+        if (!targetHref || !latestVersion) {
+            return;
+        }
+
+        const seenVersion = localStorage.getItem(`${STORAGE_PREFIX}${targetHref}`);
+        const hasUnread = seenVersion !== latestVersion;
+        link.classList.toggle("has-update", hasUnread);
+
+        link.addEventListener("click", () => {
+            localStorage.setItem(`${STORAGE_PREFIX}${targetHref}`, latestVersion);
+        });
+    });
+}
+
+applyNavUpdateIndicators().catch(() => {});

--- a/website/nav-updates.json
+++ b/website/nav-updates.json
@@ -1,0 +1,10 @@
+{
+  "index.html": "2026-04-28-home",
+  "installation.html": "2026-04-28-install",
+  "troubleshooting.html": "2026-04-28-troubleshooting",
+  "blog.html": "2026-04-28-blog",
+  "changelog.html": "2026-04-28-changelog",
+  "server.html": "2026-04-28-server",
+  "terms.html": "2026-04-28-terms",
+  "privacy.html": "2026-04-28-privacy"
+}

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Privacy</title>
+    <meta name="harper-update-version" content="2026-04-28-privacy" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -12,14 +13,14 @@
         <header class="site-header">
             <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
             <nav class="nav">
-                <a href="index.html">Home</a>
-                <a href="installation.html">Install</a>
-                <a href="troubleshooting.html">Troubleshooting</a>
-                <a href="blog.html">Blog</a>
-                <a href="changelog.html">Changelog</a>
-                <a href="server.html">API Server</a>
-                <a href="terms.html">Terms</a>
-                <a href="privacy.html" aria-current="page">Privacy</a>
+                <a href="index.html" data-update-target="home">Home</a>
+                <a href="installation.html" data-update-target="install">Install</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog">Blog</a>
+                <a href="changelog.html" data-update-target="changelog">Changelog</a>
+                <a href="server.html" data-update-target="server">API Server</a>
+                <a href="terms.html" data-update-target="terms">Terms</a>
+                <a href="privacy.html" data-update-target="privacy" aria-current="page">Privacy</a>
             </nav>
         </header>
 
@@ -43,6 +44,7 @@
             <a class="button secondary" href="index.html">← Back</a>
         </footer>
     </div>
+    <script src="nav-updates.js"></script>
     <script>
         const header = document.querySelector('.site-header');
         window.addEventListener('scroll', () => {

--- a/website/server.html
+++ b/website/server.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · API Server</title>
+    <meta name="harper-update-version" content="2026-04-28-server" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -12,14 +13,14 @@
         <header class="site-header">
             <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
             <nav class="nav">
-                <a href="index.html">Home</a>
-                <a href="installation.html">Install</a>
-                <a href="troubleshooting.html">Troubleshooting</a>
-                <a href="blog.html">Blog</a>
-                <a href="changelog.html">Changelog</a>
-                <a href="server.html" aria-current="page">API Server</a>
-                <a href="terms.html">Terms</a>
-                <a href="privacy.html">Privacy</a>
+                <a href="index.html" data-update-target="home">Home</a>
+                <a href="installation.html" data-update-target="install">Install</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog">Blog</a>
+                <a href="changelog.html" data-update-target="changelog">Changelog</a>
+                <a href="server.html" data-update-target="server" aria-current="page">API Server</a>
+                <a href="terms.html" data-update-target="terms">Terms</a>
+                <a href="privacy.html" data-update-target="privacy">Privacy</a>
             </nav>
         </header>
 
@@ -55,6 +56,8 @@ cargo run -p harper-ui --bin harper -- --no-server</code></pre>
                     <li>GET /health - health check</li>
                     <li>GET /api/sessions - list sessions</li>
                     <li>GET /api/sessions/{id} - get session</li>
+                    <li>GET /api/sessions/{id}/plan - fetch the current planner/runtime state only</li>
+                    <li>GET /api/sessions/{id}/plan/stream - stream planner/runtime SSE updates</li>
                     <li>DELETE /api/sessions/{id} - delete</li>
                     <li>POST /api/chat - send message</li>
                     <li>POST /api/review - inline code review findings and fix suggestions</li>
@@ -107,6 +110,24 @@ curl http://127.0.0.1:8081/api/sessions</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <p>The session endpoint returns messages plus any active plan and resolved AGENTS context for that session. Session list items also include a human-readable <code>title</code> derived from the first user message when available. When Supabase auth is enabled, session list, load, and delete operations are scoped to the signed-in user.</p>
+
+                <h2>Planner runtime API</h2>
+                <p>Harper exposes planner/runtime state through a pull endpoint and a server-sent events stream. Use the pull endpoint for snapshots and the SSE endpoint when a client needs to follow running jobs incrementally.</p>
+                <div class="code-wrapper">
+                    <pre><code># Planner/runtime snapshot
+curl http://127.0.0.1:8081/api/sessions/demo-session/plan
+
+# Planner/runtime SSE stream
+curl -N http://127.0.0.1:8081/api/sessions/demo-session/plan/stream</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <p>The stream sends an initial <code>plan</code> event immediately, then emits new <code>plan</code> events whenever persisted planner state changes.</p>
+                <p>Delivery model:</p>
+                <ul>
+                    <li>Same-process updates are pushed through an in-memory broadcast channel for low-latency delivery.</li>
+                    <li>Cross-process updates are observed through a persisted SQLite plan event journal, so separate Harper server processes sharing the same database still converge on the same stream state.</li>
+                </ul>
+                <p>This is the current architectural boundary: cross-process delivery is journal-backed rather than powered by a separate external event bus.</p>
 
                 <h2>Auth</h2>
                 <p>Harper can use Supabase Auth for local browser or TUI sign-in. The current supported local pattern is GitHub-backed login through Supabase, with the authenticated session then available to the local API server.</p>
@@ -266,6 +287,7 @@ port = 8082</code></pre>
             <a class="button secondary" href="index.html">← Back</a>
         </footer>
     </div>
+    <script src="nav-updates.js"></script>
     <script>
         const header = document.querySelector('.site-header');
         window.addEventListener('scroll', () => {

--- a/website/styles.css
+++ b/website/styles.css
@@ -75,6 +75,22 @@ body {
 .nav a:hover,
 .nav a[aria-current="page"] { color: var(--text); }
 
+.nav a.has-update {
+    color: #c4c4c4;
+}
+
+.nav a.has-update::after {
+    content: "";
+    display: inline-block;
+    width: 0.38rem;
+    height: 0.38rem;
+    margin-left: 0.42rem;
+    margin-bottom: 0.08rem;
+    border-radius: 999px;
+    background: rgba(34, 211, 238, 0.55);
+    box-shadow: 0 0 8px rgba(34, 211, 238, 0.16);
+}
+
 /* Surface */
 .surface {
     flex: 1;

--- a/website/terms.html
+++ b/website/terms.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Terms</title>
+    <meta name="harper-update-version" content="2026-04-28-terms" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -12,14 +13,14 @@
         <header class="site-header">
             <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
             <nav class="nav">
-                <a href="index.html">Home</a>
-                <a href="installation.html">Install</a>
-                <a href="troubleshooting.html">Troubleshooting</a>
-                <a href="blog.html">Blog</a>
-                <a href="changelog.html">Changelog</a>
-                <a href="server.html">API Server</a>
-                <a href="terms.html" aria-current="page">Terms</a>
-                <a href="privacy.html">Privacy</a>
+                <a href="index.html" data-update-target="home">Home</a>
+                <a href="installation.html" data-update-target="install">Install</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog">Blog</a>
+                <a href="changelog.html" data-update-target="changelog">Changelog</a>
+                <a href="server.html" data-update-target="server">API Server</a>
+                <a href="terms.html" data-update-target="terms" aria-current="page">Terms</a>
+                <a href="privacy.html" data-update-target="privacy">Privacy</a>
             </nav>
         </header>
 
@@ -46,6 +47,7 @@
             <a class="button secondary" href="index.html">← Back</a>
         </footer>
     </div>
+    <script src="nav-updates.js"></script>
     <script>
         const header = document.querySelector('.site-header');
         window.addEventListener('scroll', () => {

--- a/website/troubleshooting.html
+++ b/website/troubleshooting.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Troubleshooting</title>
+    <meta name="harper-update-version" content="2026-04-28-troubleshooting" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -12,14 +13,14 @@
         <header class="site-header">
             <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
             <nav class="nav">
-                <a href="index.html">Home</a>
-                <a href="installation.html">Install</a>
-                <a href="troubleshooting.html" aria-current="page">Troubleshooting</a>
-                <a href="blog.html">Blog</a>
-                <a href="changelog.html">Changelog</a>
-                <a href="server.html">API Server</a>
-                <a href="terms.html">Terms</a>
-                <a href="privacy.html">Privacy</a>
+                <a href="index.html" data-update-target="home">Home</a>
+                <a href="installation.html" data-update-target="install">Install</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting" aria-current="page">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog">Blog</a>
+                <a href="changelog.html" data-update-target="changelog">Changelog</a>
+                <a href="server.html" data-update-target="server">API Server</a>
+                <a href="terms.html" data-update-target="terms">Terms</a>
+                <a href="privacy.html" data-update-target="privacy">Privacy</a>
             </nav>
         </header>
 
@@ -82,6 +83,7 @@ cargo test</code></pre>
             <a class="button secondary" href="index.html">← Back</a>
         </footer>
     </div>
+    <script src="nav-updates.js"></script>
     <script>
         const header = document.querySelector('.site-header');
         window.addEventListener('scroll', () => {


### PR DESCRIPTION
## Changes

- Introduced first-class planner runtime jobs with persisted job records, blocked step state, and explicit step-to-job linkage.
- Persisted live job transcripts and previews while commands are still running instead of only capturing output on job completion.
- Added a dedicated planner jobs browser in the TUI, including job selection, full transcript drilldown, and output scrolling.
- Added planner/runtime HTTP endpoints:
  - `GET /api/sessions/{id}/plan`
  - `GET /api/sessions/{id}/plan/stream`
- Implemented planner runtime SSE streaming with a hybrid delivery model:
  - in-process broadcast for low-latency push
  - persisted SQLite event journal for cross-process convergence
- Updated planner/runtime docs and roadmap:
  - `PLANNER_NEXT_STEPS.md`
  - `website/server.html`
- Added site-wide nav update indicators backed by a single static manifest and per-page version metadata.

## Validation

- `cargo test -p harper-core core::plan_events::tests:: -- --nocapture`
- `cargo test -p harper-core memory::storage::tests::save_plan_state_records_plan_event_id -- --nocapture`
- `cargo test -p harper-core server::tests::get_session_plan_ -- --nocapture`
- `cargo test -p harper-core tools::plan::tests:: -- --nocapture`
- `cargo test -p harper-ui interfaces::ui::widgets::tests:: -- --nocapture`
- `cargo check -p harper-core`
- `cargo check -p harper-ui`
- `cargo fmt --check`