### PR TITLE
[feat] account-scoped history, token refresh, profile screen, and session delete

### DIFF
--- a/lib/harper-core/src/memory/session_service.rs
+++ b/lib/harper-core/src/memory/session_service.rs
@@ -129,6 +129,57 @@ impl<'a> SessionService<'a> {
         })
     }
 
+    pub fn get_global_stats_for_user(&self, user_id: &str) -> HarperResult<GlobalStats> {
+        let total_sessions: usize = self.conn.query_row(
+            "SELECT COUNT(*) FROM sessions WHERE user_id = ?1",
+            [user_id],
+            |r| r.get(0),
+        )?;
+        let total_messages: usize = self.conn.query_row(
+            "SELECT COUNT(*)
+             FROM messages m
+             JOIN sessions s ON s.id = m.session_id
+             WHERE s.user_id = ?1",
+            [user_id],
+            |r| r.get(0),
+        )?;
+        let total_commands: usize = self.conn.query_row(
+            "SELECT COUNT(*)
+             FROM command_logs c
+             JOIN sessions s ON s.id = c.session_id
+             WHERE s.user_id = ?1",
+            [user_id],
+            |r| r.get(0),
+        )?;
+        let approved_commands: usize = self.conn.query_row(
+            "SELECT COUNT(*)
+             FROM command_logs c
+             JOIN sessions s ON s.id = c.session_id
+             WHERE s.user_id = ?1 AND c.approved = 1",
+            [user_id],
+            |r| r.get(0),
+        )?;
+        let avg_duration: f64 = self
+            .conn
+            .query_row(
+                "SELECT AVG(c.duration_ms)
+                 FROM command_logs c
+                 JOIN sessions s ON s.id = c.session_id
+                 WHERE s.user_id = ?1 AND c.duration_ms IS NOT NULL",
+                [user_id],
+                |r| r.get::<_, Option<f64>>(0),
+            )?
+            .unwrap_or(0.0);
+
+        Ok(GlobalStats {
+            total_sessions,
+            total_messages,
+            total_commands,
+            approved_commands,
+            avg_command_duration_ms: avg_duration,
+        })
+    }
+
     /// List all previous sessions (returns data)
     pub fn list_sessions_data(&self) -> HarperResult<Vec<Session>> {
         self.list_sessions_data_inner(None)
@@ -457,6 +508,16 @@ impl<'a> SessionService<'a> {
         Ok(output_path)
     }
 
+    pub fn export_session_by_id_for_user(
+        &self,
+        session_id: &str,
+        user_id: &str,
+    ) -> HarperResult<String> {
+        self.load_session_state_view_for_user(session_id, user_id)?
+            .ok_or_else(|| HarperError::Validation("session not found".to_string()))?;
+        self.export_session_by_id(session_id)
+    }
+
     fn write_transcript<W: Write>(&self, writer: &mut W, history: &[Message]) -> HarperResult<()> {
         for msg in history {
             writeln!(
@@ -613,5 +674,72 @@ impl<'a> SessionService<'a> {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionService;
+    use crate::memory::storage::{
+        init_db, insert_command_log, save_message, save_session_for_user, CommandLogRecord,
+    };
+    use rusqlite::Connection;
+
+    #[test]
+    fn user_scoped_stats_only_count_owned_sessions() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        init_db(&conn).expect("init db");
+
+        save_session_for_user(&conn, "session-a", "user-a").expect("save session a");
+        save_session_for_user(&conn, "session-b", "user-b").expect("save session b");
+
+        save_message(&conn, "session-a", "user", "hello from a").expect("message a");
+        save_message(&conn, "session-b", "user", "hello from b").expect("message b");
+
+        insert_command_log(
+            &conn,
+            &CommandLogRecord::new(
+                Some("session-a"),
+                "cargo test",
+                "tui",
+                false,
+                true,
+                "completed",
+                Some(0),
+                Some(25),
+                None,
+                None,
+                None,
+            ),
+        )
+        .expect("command a");
+        insert_command_log(
+            &conn,
+            &CommandLogRecord::new(
+                Some("session-b"),
+                "cargo check",
+                "tui",
+                false,
+                false,
+                "failed",
+                Some(1),
+                Some(50),
+                None,
+                None,
+                Some("boom".to_string()),
+            ),
+        )
+        .expect("command b");
+
+        let service = SessionService::new(&conn);
+        let stats = service
+            .get_global_stats_for_user("user-a")
+            .expect("stats for user a");
+
+        assert_eq!(stats.total_sessions, 1);
+        assert_eq!(stats.total_messages, 1);
+        assert_eq!(stats.total_commands, 1);
+        assert_eq!(stats.approved_commands, 1);
+        assert_eq!(stats.avg_command_duration_ms, 25.0);
     }
 }

--- a/lib/harper-core/src/server/mod.rs
+++ b/lib/harper-core/src/server/mod.rs
@@ -174,6 +174,11 @@ pub struct TuiAuthPollResponse {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct TuiRefreshRequest {
+    pub refresh_token: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct ReviewRequest {
     pub file_path: String,
     pub content: String,
@@ -322,6 +327,14 @@ pub async fn auth_tui_poll(
         status: "pending".to_string(),
         session: None,
     }))
+}
+
+pub async fn auth_tui_refresh(
+    State(state): State<Arc<ServerState>>,
+    Json(request): Json<TuiRefreshRequest>,
+) -> Result<Json<AuthSession>, (StatusCode, String)> {
+    let session = refresh_supabase_session(&state, request.refresh_token).await?;
+    Ok(Json(session))
 }
 
 fn build_authorize_url(
@@ -486,7 +499,8 @@ pub async fn auth_callback(
         )
     })?;
 
-    let auth_session = auth_session_from_supabase_tokens(token_payload, Some(pending.provider));
+    let auth_session =
+        auth_session_from_supabase_tokens(&state, token_payload, Some(pending.provider)).await;
     if let Some(flow_id) = pending.tui_flow_id.clone() {
         let mut flows = state.tui_auth_flows.lock().map_err(|_| {
             (
@@ -1414,6 +1428,7 @@ pub fn create_router(
         .route("/auth/login/{provider}", get(auth_login))
         .route("/auth/tui/start/{provider}", get(auth_tui_start))
         .route("/auth/tui/flow/{flow_id}", get(auth_tui_poll))
+        .route("/auth/tui/refresh", post(auth_tui_refresh))
         .route("/auth/callback", get(auth_callback))
         .route("/auth/me", get(auth_me))
         .route("/auth/status", get(auth_status_page))
@@ -1509,7 +1524,7 @@ fn render_auth_success(session: &AuthSession) -> String {
     )
 }
 
-fn auth_session_from_supabase_tokens(
+fn fallback_auth_session_from_supabase_tokens(
     token_payload: SupabaseTokenResponse,
     provider: Option<UserAuthProvider>,
 ) -> AuthSession {
@@ -1535,6 +1550,25 @@ fn auth_session_from_supabase_tokens(
             .map(|seconds| chrono::Utc::now().timestamp() + seconds),
         user: authenticated_user,
     }
+}
+
+async fn auth_session_from_supabase_tokens(
+    state: &ServerState,
+    token_payload: SupabaseTokenResponse,
+    provider: Option<UserAuthProvider>,
+) -> AuthSession {
+    let mut session = fallback_auth_session_from_supabase_tokens(token_payload, provider);
+
+    if let Some(supabase) = state.supabase_auth.as_ref() {
+        if let Ok(user) =
+            auth::decode_access_token_with_client(&session.access_token, supabase, &state.client)
+                .await
+        {
+            session.user = user;
+        }
+    }
+
+    session
 }
 
 async fn refresh_supabase_session(
@@ -1589,7 +1623,7 @@ async fn refresh_supabase_session(
         )
     })?;
 
-    Ok(auth_session_from_supabase_tokens(token_payload, None))
+    Ok(auth_session_from_supabase_tokens(state, token_payload, None).await)
 }
 
 fn append_auth_session_cookies(headers: &mut axum::http::HeaderMap, session: &AuthSession) {
@@ -1964,11 +1998,11 @@ pub async fn approve_pending_tool(
 #[cfg(test)]
 mod tests {
     use super::{
-        auth_me, auth_tui_poll, build_authorize_url, delete_session, extract_json_payload,
-        get_session, get_session_plan, get_session_plan_stream, list_sessions,
-        normalize_finding_range, render_auth_status_page, render_auth_success, review_code,
-        CodeReviewFinding, CodeSuggestion, ReviewRange, ReviewRequest, ServerState,
-        SupabaseAuthConfig, TuiAuthFlowState,
+        auth_me, auth_tui_poll, auth_tui_refresh, build_authorize_url, delete_session,
+        extract_json_payload, get_session, get_session_plan, get_session_plan_stream,
+        list_sessions, normalize_finding_range, render_auth_status_page, render_auth_success,
+        review_code, CodeReviewFinding, CodeSuggestion, ReviewRange, ReviewRequest, ServerState,
+        SupabaseAuthConfig, TuiAuthFlowState, TuiRefreshRequest,
     };
     use crate::core::auth::{AuthSession, AuthenticatedUser, UserAuthProvider};
     use crate::core::{ApiConfig, ApiProvider};
@@ -2514,5 +2548,21 @@ mod tests {
             .expect("poll should succeed");
         assert_eq!(response.0.status, "pending");
         assert!(response.0.session.is_none());
+    }
+
+    #[tokio::test]
+    async fn auth_tui_refresh_requires_supabase_config() {
+        let state = test_server_state(None);
+        let error = auth_tui_refresh(
+            State(state),
+            Json(TuiRefreshRequest {
+                refresh_token: "refresh-token".to_string(),
+            }),
+        )
+        .await
+        .expect_err("refresh should require supabase config");
+
+        assert_eq!(error.0, StatusCode::NOT_IMPLEMENTED);
+        assert!(error.1.contains("Supabase auth is not configured"));
     }
 }

--- a/lib/harper-ui/src/interfaces/ui/app.rs
+++ b/lib/harper-ui/src/interfaces/ui/app.rs
@@ -301,9 +301,10 @@ impl Clone for ApprovalState {
 pub enum AppState {
     Menu(usize),
     Chat(Box<ChatState>),
-    Sessions(Vec<SessionInfo>, usize),        // sessions, selected
-    ExportSessions(Vec<SessionInfo>, usize),  // sessions, selected for export
-    Tools(usize),                             // selected tool
+    Sessions(Vec<SessionInfo>, usize),       // sessions, selected
+    ExportSessions(Vec<SessionInfo>, usize), // sessions, selected for export
+    Tools(usize),                            // selected tool
+    Profile(usize),
     ViewSession(String, Vec<Message>, usize), // name, messages, selected
     Stats(GlobalStats),
 }
@@ -369,6 +370,14 @@ impl Default for TuiApp {
 impl TuiApp {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn profile_action_count(&self) -> usize {
+        if self.auth_session.is_some() {
+            2
+        } else {
+            3
+        }
     }
 
     pub fn set_error_message(&mut self, content: String) {
@@ -460,6 +469,7 @@ impl TuiApp {
             return;
         }
 
+        let profile_action_count = self.profile_action_count();
         match &mut self.state {
             AppState::Menu(sel) => *sel = (*sel + 1) % 6,
             AppState::Chat(chat_state) => {
@@ -504,7 +514,8 @@ impl TuiApp {
                     *sel = (*sel + 1) % sessions.len();
                 }
             }
-            AppState::Tools(sel) => *sel = (*sel + 1) % 4,
+            AppState::Tools(sel) => *sel = (*sel + 1) % 5,
+            AppState::Profile(sel) => *sel = (*sel + 1) % profile_action_count,
             AppState::ExportSessions(sessions, sel) => {
                 if !sessions.is_empty() {
                     *sel = (*sel + 1) % sessions.len();
@@ -525,6 +536,7 @@ impl TuiApp {
             return;
         }
 
+        let profile_action_count = self.profile_action_count();
         match &mut self.state {
             AppState::Menu(sel) => *sel = if *sel == 0 { 5 } else { *sel - 1 },
             AppState::Chat(chat_state) => {
@@ -561,7 +573,14 @@ impl TuiApp {
                     };
                 }
             }
-            AppState::Tools(sel) => *sel = if *sel == 0 { 3 } else { *sel - 1 },
+            AppState::Tools(sel) => *sel = if *sel == 0 { 4 } else { *sel - 1 },
+            AppState::Profile(sel) => {
+                *sel = if *sel == 0 {
+                    profile_action_count - 1
+                } else {
+                    *sel - 1
+                };
+            }
             AppState::ExportSessions(sessions, sel) => {
                 if !sessions.is_empty() {
                     *sel = if *sel == 0 {

--- a/lib/harper-ui/src/interfaces/ui/auth.rs
+++ b/lib/harper-ui/src/interfaces/ui/auth.rs
@@ -1,6 +1,8 @@
 use harper_core::{AuthSession, SessionStateView};
 use keyring::{Entry, Error as KeyringError};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::fs;
 use std::path::PathBuf;
 
@@ -33,6 +35,11 @@ pub struct RemoteSessionListItem {
     pub created_at: String,
     pub updated_at: String,
     pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct TuiRefreshRequest<'a> {
+    refresh_token: &'a str,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,7 +76,7 @@ pub async fn start_tui_auth_flow(
         .await
         .map_err(|err| err.to_string())?;
     if !response.status().is_success() {
-        return Err(response.text().await.unwrap_or_default());
+        return Err(extract_http_error(response).await);
     }
     response.json().await.map_err(|err| err.to_string())
 }
@@ -90,7 +97,7 @@ pub async fn poll_tui_auth_flow(
         .await
         .map_err(|err| err.to_string())?;
     if !response.status().is_success() {
-        return Err(response.text().await.unwrap_or_default());
+        return Err(extract_http_error(response).await);
     }
     response.json().await.map_err(|err| err.to_string())
 }
@@ -98,25 +105,16 @@ pub async fn poll_tui_auth_flow(
 pub async fn fetch_remote_sessions(
     client: &reqwest::Client,
     server_base_url: &str,
-    session: &AuthSession,
+    session: &mut AuthSession,
 ) -> Result<Vec<RemoteSessionListItem>, String> {
     let url = format!("{}/api/sessions", server_base_url.trim_end_matches('/'));
-    let response = client
-        .get(&url)
-        .bearer_auth(&session.access_token)
-        .send()
-        .await
-        .map_err(|err| err.to_string())?;
-    if !response.status().is_success() {
-        return Err(response.text().await.unwrap_or_default());
-    }
-    response.json().await.map_err(|err| err.to_string())
+    fetch_remote_json_with_refresh(client, &url, session).await
 }
 
 pub async fn fetch_remote_session_state(
     client: &reqwest::Client,
     server_base_url: &str,
-    session: &AuthSession,
+    session: &mut AuthSession,
     session_id: &str,
 ) -> Result<SessionStateView, String> {
     let url = format!(
@@ -124,16 +122,35 @@ pub async fn fetch_remote_session_state(
         server_base_url.trim_end_matches('/'),
         session_id
     );
-    let response = client
-        .get(&url)
-        .bearer_auth(&session.access_token)
-        .send()
-        .await
-        .map_err(|err| err.to_string())?;
-    if !response.status().is_success() {
-        return Err(response.text().await.unwrap_or_default());
-    }
-    response.json().await.map_err(|err| err.to_string())
+    fetch_remote_json_with_refresh(client, &url, session).await
+}
+
+pub async fn delete_remote_session(
+    client: &reqwest::Client,
+    server_base_url: &str,
+    session: &mut AuthSession,
+    session_id: &str,
+) -> Result<(), String> {
+    let url = format!(
+        "{}/api/sessions/{}",
+        server_base_url.trim_end_matches('/'),
+        session_id
+    );
+    send_remote_delete_with_refresh(client, &url, session).await
+}
+
+pub async fn refresh_auth_session(
+    client: &reqwest::Client,
+    server_base_url: &str,
+    session: &mut AuthSession,
+) -> Result<(), String> {
+    let refresh_token = session
+        .refresh_token
+        .clone()
+        .ok_or_else(|| "No refresh token available".to_string())?;
+    let refreshed = refresh_tui_auth_session(client, server_base_url, &refresh_token).await?;
+    *session = refreshed;
+    save_auth_session(session)
 }
 
 pub fn load_auth_session() -> Option<AuthSession> {
@@ -265,14 +282,197 @@ fn deserialize_auth_session(content: &str) -> Result<AuthSession, String> {
         .map_err(|err| err.to_string())
 }
 
+async fn extract_http_error(response: reqwest::Response) -> String {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    format_http_error(status, &body)
+}
+
+async fn refresh_tui_auth_session(
+    client: &reqwest::Client,
+    server_base_url: &str,
+    refresh_token: &str,
+) -> Result<AuthSession, String> {
+    let url = format!("{}/auth/tui/refresh", server_base_url.trim_end_matches('/'));
+    let response = client
+        .post(&url)
+        .json(&TuiRefreshRequest { refresh_token })
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+    if !response.status().is_success() {
+        return Err(extract_http_error(response).await);
+    }
+    response.json().await.map_err(|err| err.to_string())
+}
+
+async fn fetch_remote_json_with_refresh<T>(
+    client: &reqwest::Client,
+    url: &str,
+    session: &mut AuthSession,
+) -> Result<T, String>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let response = client
+        .get(url)
+        .bearer_auth(&session.access_token)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+    if response.status().is_success() {
+        return response.json().await.map_err(|err| err.to_string());
+    }
+
+    if response.status() == StatusCode::UNAUTHORIZED {
+        let refresh_token = session
+            .refresh_token
+            .clone()
+            .ok_or_else(|| extract_http_error_blocking(StatusCode::UNAUTHORIZED, ""))?;
+        let refreshed =
+            refresh_tui_auth_session(client, infer_base_url(url), &refresh_token).await?;
+        *session = refreshed.clone();
+        save_auth_session(session)?;
+
+        let retry = client
+            .get(url)
+            .bearer_auth(&session.access_token)
+            .send()
+            .await
+            .map_err(|err| err.to_string())?;
+        if !retry.status().is_success() {
+            return Err(extract_http_error(retry).await);
+        }
+        return retry.json().await.map_err(|err| err.to_string());
+    }
+
+    Err(extract_http_error(response).await)
+}
+
+async fn send_remote_delete_with_refresh(
+    client: &reqwest::Client,
+    url: &str,
+    session: &mut AuthSession,
+) -> Result<(), String> {
+    let response = client
+        .delete(url)
+        .bearer_auth(&session.access_token)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+
+    if response.status().is_success() {
+        return Ok(());
+    }
+
+    if response.status() == StatusCode::UNAUTHORIZED {
+        let refresh_token = session
+            .refresh_token
+            .clone()
+            .ok_or_else(|| extract_http_error_blocking(StatusCode::UNAUTHORIZED, ""))?;
+        let refreshed =
+            refresh_tui_auth_session(client, infer_base_url(url), &refresh_token).await?;
+        *session = refreshed;
+        save_auth_session(session)?;
+
+        let retry = client
+            .delete(url)
+            .bearer_auth(&session.access_token)
+            .send()
+            .await
+            .map_err(|err| err.to_string())?;
+        if retry.status().is_success() {
+            return Ok(());
+        }
+        return Err(extract_http_error(retry).await);
+    }
+
+    Err(extract_http_error(response).await)
+}
+
+fn infer_base_url(url: &str) -> &str {
+    url.rsplit_once("/api/")
+        .map(|(base, _)| base)
+        .unwrap_or(url)
+}
+
+fn extract_http_error_blocking(status: StatusCode, body: &str) -> String {
+    format_http_error(status, body)
+}
+
+fn format_http_error(status: StatusCode, body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return format!(
+            "HTTP {} {}",
+            status.as_u16(),
+            status.canonical_reason().unwrap_or("Unknown")
+        );
+    }
+
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+        if let Some(message) = extract_json_error_message(&value) {
+            return format!(
+                "HTTP {} {}: {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("Unknown"),
+                message
+            );
+        }
+    }
+
+    format!(
+        "HTTP {} {}: {}",
+        status.as_u16(),
+        status.canonical_reason().unwrap_or("Unknown"),
+        trimmed
+    )
+}
+
+fn extract_json_error_message(value: &Value) -> Option<String> {
+    match value {
+        Value::String(message) => Some(message.clone()),
+        Value::Object(map) => {
+            for key in ["error", "message", "detail"] {
+                if let Some(raw) = map.get(key) {
+                    match raw {
+                        Value::String(message) if !message.trim().is_empty() => {
+                            return Some(message.clone())
+                        }
+                        Value::Array(items) => {
+                            let joined = items
+                                .iter()
+                                .filter_map(extract_json_error_message)
+                                .collect::<Vec<_>>()
+                                .join(": ");
+                            if !joined.is_empty() {
+                                return Some(joined);
+                            }
+                        }
+                        Value::Object(_) => {
+                            if let Some(message) = extract_json_error_message(raw) {
+                                return Some(message);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        auth_session_path, clear_auth_session, load_auth_session, parse_tui_auth_command,
-        StoredAuthSession, TuiAuthCommand,
+        auth_session_path, clear_auth_session, format_http_error, infer_base_url,
+        load_auth_session, parse_tui_auth_command, StoredAuthSession, TuiAuthCommand,
     };
     use harper_core::{AuthSession, AuthenticatedUser, UserAuthProvider};
     use keyring::{mock, set_default_credential_builder};
+    use reqwest::StatusCode;
     use std::sync::Mutex;
 
     static KEYRING_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -375,6 +575,26 @@ mod tests {
 
         restore_home(original_home);
         let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn format_http_error_uses_status_when_body_is_empty() {
+        let message = format_http_error(StatusCode::UNAUTHORIZED, "");
+        assert_eq!(message, "HTTP 401 Unauthorized");
+    }
+
+    #[test]
+    fn format_http_error_extracts_json_message() {
+        let message = format_http_error(StatusCode::BAD_REQUEST, r#"{"error":"session expired"}"#);
+        assert_eq!(message, "HTTP 400 Bad Request: session expired");
+    }
+
+    #[test]
+    fn infer_base_url_strips_api_path() {
+        assert_eq!(
+            infer_base_url("http://127.0.0.1:8081/api/sessions/session-1"),
+            "http://127.0.0.1:8081"
+        );
     }
 
     fn keyring_test_guard() -> std::sync::MutexGuard<'static, ()> {

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 
 // Keyboard shortcut constants
 const HELP_MESSAGE: &str =
-    "G:Help | Tab:Complete | Esc:Back | ↑↓:Navigate | Y/V:Prev/Next | Enter:Select/Approve | T:Send | L/→:Preview | X:Exit | W:Web | B:Sidebar | A:Agents | F:Findings | P:Jobs | M:Msgs | C:ID";
+    "G:Help | Tab:Complete | Esc:Back | ↑↓:Navigate | Y/V:Prev/Next | Enter:Select/Approve | T:Send | L/→:Preview | D/Delete:Remove Session | X:Exit | W:Web | B:Sidebar | A:Agents | F:Findings | P:Jobs | M:Msgs | C:ID";
 
 use super::app::{AppState, ChatState, NavigationFocus, SessionInfo, TuiApp};
 use harper_core::memory::session_service::SessionService;
@@ -34,7 +34,19 @@ pub enum EventResult {
     Continue,
     SendMessage(String),
     LoadSessions,
-    OpenSession { session_id: String, preview: bool },
+    OpenSession {
+        session_id: String,
+        preview: bool,
+    },
+    RefreshAuthSession,
+    StartProfileLogin {
+        provider: String,
+    },
+    DeleteSession {
+        session_id: String,
+        remote: bool,
+        export_view: bool,
+    },
     GatherSidebarEntries,
     Quit,
 }
@@ -84,7 +96,12 @@ fn record_approval_history(app: &mut TuiApp, command: &str, approved: bool) {
 }
 
 fn load_export_sessions_into_state(app: &mut TuiApp, session_service: &SessionService) {
-    match session_service.list_sessions_data() {
+    let sessions_result = if let Some(auth_session) = app.auth_session.as_ref() {
+        session_service.list_sessions_data_for_user(&auth_session.user.user_id)
+    } else {
+        session_service.list_sessions_data()
+    };
+    match sessions_result {
         Ok(sessions) => {
             let session_infos: Vec<SessionInfo> = sessions
                 .into_iter()
@@ -271,7 +288,16 @@ pub fn handle_event(
                                     status_message = Some("Focus on AGENTS panel".to_string());
                                 }
                             } else {
-                                status_message = Some("No active AGENTS sources".to_string());
+                                if !chat_state.agents_panel_expanded {
+                                    chat_state.agents_panel_expanded = true;
+                                    chat_state.agents_scroll_offset = 0;
+                                    status_message = Some(
+                                        "AGENTS panel opened; no active sources yet".to_string(),
+                                    );
+                                } else {
+                                    chat_state.agents_panel_expanded = false;
+                                    status_message = Some("AGENTS panel collapsed".to_string());
+                                }
                             }
                         }
                         if let Some(message) = status_message {
@@ -390,6 +416,7 @@ pub fn handle_event(
                     AppState::Sessions(_, _) => app.state = AppState::Menu(0),
                     AppState::ExportSessions(_, _) => app.state = AppState::Menu(0),
                     AppState::Tools(_) => app.state = AppState::Menu(0),
+                    AppState::Profile(_) => app.state = AppState::Menu(0),
                     AppState::ViewSession(_, _, _) => app.state = AppState::Menu(0),
                     AppState::Stats(_) => app.state = AppState::Menu(0),
                 },
@@ -417,6 +444,7 @@ pub fn handle_event(
                 }
                 KeyCode::Enter => return handle_enter(app, session_service),
                 KeyCode::Right => return preview_selected_session(app, session_service),
+                KeyCode::Delete => return delete_selected_session(app),
                 KeyCode::Tab => handle_tab(app),
                 KeyCode::Char(c) => {
                     // Handle q for quitting/returning only in non-input states
@@ -434,6 +462,9 @@ pub fn handle_event(
                             return EventResult::Continue;
                         }
                         return preview_selected_session(app, session_service);
+                    }
+                    if c == 'd' && !matches!(app.state, AppState::Chat(_)) {
+                        return delete_selected_session(app);
                     }
                     handle_char_input(app, c)
                 }
@@ -464,10 +495,17 @@ fn handle_enter(app: &mut TuiApp, session_service: &SessionService) -> EventResu
                 } // Start Chat
                 1 => return EventResult::LoadSessions,
                 2 => load_export_sessions_into_state(app, session_service),
-                3 => match session_service.get_global_stats() {
-                    Ok(stats) => app.state = AppState::Stats(stats),
-                    Err(e) => app.set_error_message(format!("Error loading stats: {}", e)),
-                },
+                3 => {
+                    let stats_result = if let Some(auth_session) = app.auth_session.as_ref() {
+                        session_service.get_global_stats_for_user(&auth_session.user.user_id)
+                    } else {
+                        session_service.get_global_stats()
+                    };
+                    match stats_result {
+                        Ok(stats) => app.state = AppState::Stats(stats),
+                        Err(e) => app.set_error_message(format!("Error loading stats: {}", e)),
+                    }
+                }
                 4 => app.state = AppState::Tools(0), // Tools
                 5 => return EventResult::Quit,       // Exit
                 _ => {}
@@ -491,17 +529,54 @@ fn handle_enter(app: &mut TuiApp, session_service: &SessionService) -> EventResu
             if !sessions.is_empty() && *selected < sessions.len() =>
         {
             let session = &sessions[*selected];
-            match session_service.export_session_by_id(&session.id) {
+            let export_result = if let Some(auth_session) = app.auth_session.as_ref() {
+                session_service
+                    .export_session_by_id_for_user(&session.id, &auth_session.user.user_id)
+            } else {
+                session_service.export_session_by_id(&session.id)
+            };
+            match export_result {
                 Ok(path) => app.set_info_message(format!("Session exported to {}", path)),
                 Err(e) => app.set_error_message(format!("Export failed: {}", e)),
             }
             app.state = AppState::Menu(0);
         }
         AppState::Tools(selected) => match *selected {
-            0 => handle_web_search(app),
-            1 => handle_system_info(app),
-            2 => handle_process_list(app),
-            3 => handle_git_commands(app),
+            0 => app.state = AppState::Profile(0),
+            1 => handle_web_search(app),
+            2 => handle_system_info(app),
+            3 => handle_process_list(app),
+            4 => handle_git_commands(app),
+            _ => {}
+        },
+        AppState::Profile(selected) => match *selected {
+            0 if app.auth_session.is_some() => {
+                if let Err(err) = crate::interfaces::ui::auth::clear_auth_session() {
+                    app.set_error_message(format!("Auth logout failed: {}", err));
+                } else {
+                    app.auth_session = None;
+                    app.auth_flow_id = None;
+                    app.auth_last_poll_at = None;
+                    app.set_status_message("Cleared local TUI auth session".to_string());
+                    app.state = AppState::Profile(0);
+                }
+            }
+            1 if app.auth_session.is_some() => return EventResult::RefreshAuthSession,
+            0 => {
+                return EventResult::StartProfileLogin {
+                    provider: "github".to_string(),
+                }
+            }
+            1 => {
+                return EventResult::StartProfileLogin {
+                    provider: "google".to_string(),
+                }
+            }
+            2 => {
+                return EventResult::StartProfileLogin {
+                    provider: "apple".to_string(),
+                }
+            }
             _ => {}
         },
         AppState::ViewSession(session_id, _, _) => {
@@ -547,6 +622,32 @@ fn preview_selected_session(app: &mut TuiApp, session_service: &SessionService) 
                 EventResult::Continue
             }
         }
+    }
+}
+
+fn delete_selected_session(app: &mut TuiApp) -> EventResult {
+    match &app.state {
+        AppState::Sessions(sessions, selected)
+            if !sessions.is_empty() && *selected < sessions.len() =>
+        {
+            let session = &sessions[*selected];
+            EventResult::DeleteSession {
+                session_id: session.id.clone(),
+                remote: app.auth_session.is_some() && app.auth_server_base_url.is_some(),
+                export_view: false,
+            }
+        }
+        AppState::ExportSessions(sessions, selected)
+            if !sessions.is_empty() && *selected < sessions.len() =>
+        {
+            let session = &sessions[*selected];
+            EventResult::DeleteSession {
+                session_id: session.id.clone(),
+                remote: false,
+                export_view: true,
+            }
+        }
+        _ => EventResult::Continue,
     }
 }
 
@@ -963,6 +1064,69 @@ mod tests {
     }
 
     #[test]
+    fn test_enter_settings_profile() {
+        let mut app = TuiApp::new();
+        app.state = AppState::Tools(0); // Profile
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Enter.into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(result, EventResult::Continue));
+        assert!(matches!(app.state, AppState::Profile(0)));
+    }
+
+    #[test]
+    fn test_enter_profile_refresh_returns_async_event() {
+        let mut app = TuiApp::new();
+        app.auth_session = Some(harper_core::AuthSession {
+            access_token: "access".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            expires_at: None,
+            user: harper_core::AuthenticatedUser {
+                user_id: "user-1".to_string(),
+                email: Some("user@example.com".to_string()),
+                display_name: Some("Example User".to_string()),
+                provider: Some(harper_core::UserAuthProvider::Github),
+            },
+        });
+        app.state = AppState::Profile(1); // Refresh Session
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Enter.into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(result, EventResult::RefreshAuthSession));
+    }
+
+    #[test]
+    fn test_enter_profile_login_returns_async_event() {
+        let mut app = TuiApp::new();
+        app.state = AppState::Profile(0); // Login with GitHub
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Enter.into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(
+            result,
+            EventResult::StartProfileLogin { provider } if provider == "github"
+        ));
+    }
+
+    #[test]
     fn chat_mode_treats_l_as_text_input() {
         let mut app = TuiApp::new();
         app.state = AppState::Chat(Box::new(create_chat_state(
@@ -1002,5 +1166,65 @@ mod tests {
         );
         assert!(matches!(result, EventResult::LoadSessions));
         assert!(matches!(app.state, AppState::Menu(1)));
+    }
+
+    #[test]
+    fn delete_key_on_sessions_returns_delete_event() {
+        let mut app = TuiApp::new();
+        app.state = AppState::Sessions(
+            vec![SessionInfo {
+                id: "session-1".to_string(),
+                name: "Example".to_string(),
+                created_at: "2026-04-28".to_string(),
+            }],
+            0,
+        );
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Delete.into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(
+            result,
+            EventResult::DeleteSession {
+                session_id,
+                remote: false,
+                export_view: false
+            } if session_id == "session-1"
+        ));
+    }
+
+    #[test]
+    fn delete_key_on_export_sessions_returns_delete_event() {
+        let mut app = TuiApp::new();
+        app.state = AppState::ExportSessions(
+            vec![SessionInfo {
+                id: "session-1".to_string(),
+                name: "Example".to_string(),
+                created_at: "2026-04-28".to_string(),
+            }],
+            0,
+        );
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Delete.into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(
+            result,
+            EventResult::DeleteSession {
+                session_id,
+                remote: false,
+                export_view: true
+            } if session_id == "session-1"
+        ));
     }
 }

--- a/lib/harper-ui/src/interfaces/ui/tui.rs
+++ b/lib/harper-ui/src/interfaces/ui/tui.rs
@@ -160,6 +160,7 @@ enum WorkerMsg {
         user_msg: String,
         session_id: String,
         web_search: bool,
+        auth_user_id: Option<String>,
     },
 }
 
@@ -272,6 +273,7 @@ pub async fn run_tui(
                         user_msg,
                         session_id,
                         web_search,
+                        auth_user_id,
                     } => {
                         let mut chat_service = ChatService::new(
                             &worker_conn,
@@ -290,23 +292,46 @@ pub async fn run_tui(
                             harper_core::memory::storage::load_history(&worker_conn, &session_id)
                                 .unwrap_or_default();
 
+                        if let Some(user_id) = auth_user_id.as_deref() {
+                            let _ = harper_core::memory::storage::save_session_for_user(
+                                &worker_conn,
+                                &session_id,
+                                user_id,
+                            );
+                        }
+
                         match chat_service
                             .send_message(&user_msg, &mut history, web_search, &session_id)
                             .await
                         {
                             Ok(_) => {
                                 let session_service = SessionService::new(&worker_conn);
-                                let session_view = session_service
-                                    .load_session_state_view(&session_id)
-                                    .unwrap_or_else(|_| SessionStateView {
-                                        session_id: session_id.clone(),
-                                        user_id: None,
-                                        messages: history.clone(),
-                                        plan: None,
-                                        agents: None,
-                                        agents_rendered: None,
-                                        agents_effective_rendered: None,
-                                    });
+                                let session_view = match auth_user_id.as_deref() {
+                                    Some(user_id) => session_service
+                                        .load_session_state_view_for_user(&session_id, user_id)
+                                        .ok()
+                                        .flatten()
+                                        .unwrap_or_else(|| SessionStateView {
+                                            session_id: session_id.clone(),
+                                            user_id: Some(user_id.to_string()),
+                                            messages: history.clone(),
+                                            plan: None,
+                                            agents: None,
+                                            agents_rendered: None,
+                                            agents_effective_rendered: None,
+                                        }),
+                                    None => session_service
+                                        .load_session_state_view(&session_id)
+                                        .unwrap_or_else(|_| SessionStateView {
+                                            session_id: session_id.clone(),
+                                            user_id: None,
+                                            messages: history.clone(),
+                                            plan: None,
+                                            agents: None,
+                                            agents_rendered: None,
+                                            agents_effective_rendered: None,
+                                        }),
+                                };
                                 let _ = ui_tx_clone
                                     .send(UiUpdate::MessageProcessed(session_view))
                                     .await;
@@ -401,6 +426,10 @@ pub async fn run_tui(
                                     user_msg: msg,
                                     session_id,
                                     web_search,
+                                    auth_user_id: app
+                                        .auth_session
+                                        .as_ref()
+                                        .map(|session| session.user.user_id.clone()),
                                 }).await;
                             }
                         }
@@ -409,8 +438,10 @@ pub async fn run_tui(
                                 app.auth_server_base_url.clone(),
                                 app.auth_session.clone(),
                             ) {
-                                match auth::fetch_remote_sessions(&auth_client, &base_url, &session).await {
+                                let mut session = session;
+                                match auth::fetch_remote_sessions(&auth_client, &base_url, &mut session).await {
                                     Ok(sessions) => {
+                                        app.auth_session = Some(session);
                                         let session_infos = sessions
                                             .into_iter()
                                             .map(|s| super::app::SessionInfo {
@@ -445,8 +476,10 @@ pub async fn run_tui(
                                 app.auth_server_base_url.clone(),
                                 app.auth_session.clone(),
                             ) {
-                                match auth::fetch_remote_session_state(&auth_client, &base_url, &session, &session_id).await {
+                                let mut session = session;
+                                match auth::fetch_remote_session_state(&auth_client, &base_url, &mut session, &session_id).await {
                                     Ok(session_view) => {
+                                        app.auth_session = Some(session);
                                         if preview {
                                             app.state = AppState::ViewSession(
                                                 session_view.session_id,
@@ -486,6 +519,168 @@ pub async fn run_tui(
                                     }
                                     Err(e) => app.set_error_message(format!("Error loading session: {}", e)),
                                 }
+                            }
+                        }
+                        EventResult::DeleteSession {
+                            session_id,
+                            remote,
+                            export_view,
+                        } => {
+                            if remote {
+                                if let (Some(base_url), Some(session)) = (
+                                    app.auth_server_base_url.clone(),
+                                    app.auth_session.clone(),
+                                ) {
+                                    let mut session = session;
+                                    match auth::delete_remote_session(
+                                        &auth_client,
+                                        &base_url,
+                                        &mut session,
+                                        &session_id,
+                                    )
+                                    .await
+                                    {
+                                        Ok(()) => {
+                                            app.auth_session = Some(session);
+                                            app.set_status_message(
+                                                "Remote session deleted".to_string(),
+                                            );
+                                            match auth::fetch_remote_sessions(
+                                                &auth_client,
+                                                &base_url,
+                                                app.auth_session.as_mut().expect("session set"),
+                                            )
+                                            .await
+                                            {
+                                                Ok(sessions) => {
+                                                    let session_infos = sessions
+                                                        .into_iter()
+                                                        .map(|s| super::app::SessionInfo {
+                                                            id: s.id.clone(),
+                                                            name: s.title.unwrap_or(s.id),
+                                                            created_at: s.created_at,
+                                                        })
+                                                        .collect();
+                                                    app.state = AppState::Sessions(session_infos, 0);
+                                                }
+                                                Err(err) => app.set_error_message(format!(
+                                                    "Error reloading remote sessions: {}",
+                                                    err
+                                                )),
+                                            }
+                                        }
+                                        Err(err) => app.set_error_message(format!(
+                                            "Error deleting remote session: {}",
+                                            err
+                                        )),
+                                    }
+                                }
+                            } else {
+                                let delete_result = if export_view {
+                                    if let Some(auth_session) = app.auth_session.as_ref() {
+                                        session_service.delete_session_for_user(
+                                            &session_id,
+                                            &auth_session.user.user_id,
+                                        )
+                                    } else {
+                                        session_service.delete_session(&session_id)
+                                    }
+                                } else {
+                                    session_service.delete_session(&session_id)
+                                };
+                                match delete_result {
+                                    Ok(true) => {
+                                        app.set_status_message("Local session deleted".to_string());
+                                        let sessions_result = if export_view {
+                                            if let Some(auth_session) = app.auth_session.as_ref() {
+                                                session_service.list_sessions_data_for_user(
+                                                    &auth_session.user.user_id,
+                                                )
+                                            } else {
+                                                session_service.list_sessions_data()
+                                            }
+                                        } else {
+                                            session_service.list_sessions_data()
+                                        };
+                                        match sessions_result {
+                                            Ok(sessions) => {
+                                                let session_infos = sessions
+                                                    .into_iter()
+                                                    .map(|s| super::app::SessionInfo {
+                                                        id: s.id.clone(),
+                                                        name: s.title.unwrap_or(s.id),
+                                                        created_at: s.created_at,
+                                                    })
+                                                    .collect();
+                                                app.state = if export_view {
+                                                    AppState::ExportSessions(session_infos, 0)
+                                                } else {
+                                                    AppState::Sessions(session_infos, 0)
+                                                };
+                                            }
+                                            Err(e) => app.set_error_message(format!(
+                                                "Error reloading sessions: {}",
+                                                e
+                                            )),
+                                        }
+                                    }
+                                    Ok(false) => app.set_error_message(
+                                        "Session not found for deletion".to_string(),
+                                    ),
+                                    Err(err) => app.set_error_message(format!(
+                                        "Error deleting local session: {}",
+                                        err
+                                    )),
+                                }
+                            }
+                        }
+                        EventResult::RefreshAuthSession => {
+                            if let (Some(base_url), Some(session)) = (
+                                app.auth_server_base_url.clone(),
+                                app.auth_session.clone(),
+                            ) {
+                                let mut session = session;
+                                match auth::refresh_auth_session(&auth_client, &base_url, &mut session).await {
+                                    Ok(()) => {
+                                        let status = session
+                                            .user
+                                            .email
+                                            .clone()
+                                            .unwrap_or_else(|| session.user.user_id.clone());
+                                        app.auth_session = Some(session);
+                                        app.set_status_message(format!(
+                                            "Auth session refreshed for {}",
+                                            status
+                                        ));
+                                    }
+                                    Err(err) => app.set_error_message(format!(
+                                        "Auth session refresh failed: {}",
+                                        err
+                                    )),
+                                }
+                            } else {
+                                app.set_error_message("No signed-in auth session to refresh".to_string());
+                            }
+                        }
+                        EventResult::StartProfileLogin { provider } => {
+                            let Some(base_url) = app.auth_server_base_url.clone() else {
+                                app.set_error_message("TUI auth requires the Harper server to be enabled".to_string());
+                                continue;
+                            };
+                            match auth::start_tui_auth_flow(&auth_client, &base_url, &provider).await {
+                                Ok(flow) => {
+                                    app.auth_flow_id = Some(flow.flow_id.clone());
+                                    app.auth_last_poll_at = None;
+                                    match auth::launch_browser(&flow.login_url) {
+                                        Ok(_) => app.set_status_message(format!("Opened browser for {} sign-in", provider)),
+                                        Err(_) => app.set_info_message(format!(
+                                            "Open this URL to sign in:\n{}",
+                                            flow.login_url
+                                        )),
+                                    }
+                                    app.set_activity_status(Some("waiting for browser sign-in".to_string()));
+                                }
+                                Err(err) => app.set_error_message(format!("Auth login failed: {}", err)),
                             }
                         }
                         EventResult::Continue => {}

--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -34,7 +34,7 @@ const FOOTER_SHORTCUTS: [[(&str, &str); 9]; 2] = [
         ("M", "Msgs"),
         ("C", "ID"),
         ("O", "Export"),
-        ("P", "Jobs"),
+        ("D", "Delete"),
     ],
     [
         ("X", "Exit"),
@@ -140,10 +140,11 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 .active_plan
                 .as_ref()
                 .is_some_and(|plan| !plan.items.is_empty() || plan.explanation.is_some());
-            let has_agents = chat_state
-                .active_agents
-                .as_ref()
-                .is_some_and(|agents| !agents.sources.is_empty());
+            let has_agents = chat_state.agents_panel_expanded
+                || chat_state
+                    .active_agents
+                    .as_ref()
+                    .is_some_and(|agents| !agents.sources.is_empty());
             let has_review = chat_state.active_review.is_some();
             let has_command_output = chat_state.command_output.is_some();
             let plan_height = chat_state
@@ -160,7 +161,7 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 .active_agents
                 .as_ref()
                 .map(|agents| agents_panel_height(agents, chat_state.agents_panel_expanded))
-                .unwrap_or(0);
+                .unwrap_or(6);
             let review_height = chat_state
                 .active_review
                 .as_ref()
@@ -306,20 +307,18 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 next_panel_index += 1;
             }
             if has_agents {
-                if let Some(agents) = &chat_state.active_agents {
-                    draw_agents_panel(
-                        frame,
-                        agents,
-                        theme,
-                        chunks[next_panel_index],
-                        chat_state.agents_panel_expanded,
-                        chat_state.agents_scroll_offset,
-                        matches!(
-                            chat_state.navigation_focus,
-                            super::app::NavigationFocus::Agents
-                        ),
-                    );
-                }
+                draw_agents_panel(
+                    frame,
+                    chat_state.active_agents.as_ref(),
+                    theme,
+                    chunks[next_panel_index],
+                    chat_state.agents_panel_expanded,
+                    chat_state.agents_scroll_offset,
+                    matches!(
+                        chat_state.navigation_focus,
+                        super::app::NavigationFocus::Agents
+                    ),
+                );
             }
 
             // Input area - Minimalist
@@ -349,13 +348,19 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 + usize::from(has_agents);
             frame.render_widget(input_widget, chunks[input_index]);
         }
-        AppState::Sessions(sessions, selected) => {
-            draw_sessions(frame, sessions, *selected, theme, main_area)
-        }
+        AppState::Sessions(sessions, selected) => draw_sessions(
+            frame,
+            sessions,
+            *selected,
+            app.auth_session.is_some() && app.auth_server_base_url.is_some(),
+            theme,
+            main_area,
+        ),
         AppState::ExportSessions(sessions, selected) => {
             draw_export_sessions(frame, sessions, *selected, theme, main_area)
         }
         AppState::Tools(selected) => draw_tools(frame, *selected, theme, main_area),
+        AppState::Profile(selected) => draw_profile(frame, app, *selected, theme, main_area),
         AppState::ViewSession(name, messages, selected) => {
             draw_view_session(frame, name, messages, *selected, theme, main_area)
         }
@@ -862,17 +867,30 @@ fn agents_panel_height(agents: &ResolvedAgents, expanded: bool) -> u16 {
 
 fn draw_agents_panel(
     frame: &mut Frame,
-    agents: &ResolvedAgents,
+    agents: Option<&ResolvedAgents>,
     theme: &Theme,
     area: Rect,
     expanded: bool,
     scroll_offset: usize,
     focused: bool,
 ) {
-    let lines = if expanded {
-        expanded_agents_lines(agents, theme, scroll_offset, area.height)
+    let lines = if let Some(agents) = agents {
+        if expanded {
+            expanded_agents_lines(agents, theme, scroll_offset, area.height)
+        } else {
+            compact_agents_lines(agents, theme)
+        }
     } else {
-        compact_agents_lines(agents, theme)
+        vec![
+            Line::styled(
+                "No active AGENTS sources yet.",
+                Style::default().fg(theme.foreground),
+            ),
+            Line::styled(
+                "Send a message or open a session with resolved AGENTS context.",
+                theme.muted_style(),
+            ),
+        ]
     };
 
     let title = if expanded && focused {
@@ -1283,9 +1301,40 @@ fn draw_sessions(
     frame: &mut Frame,
     sessions: &[SessionInfo],
     selected: usize,
+    remote_mode: bool,
     theme: &Theme,
     area: Rect,
 ) {
+    if sessions.is_empty() {
+        let detail = if remote_mode {
+            "No remote sessions were found for the signed-in user. Local-only sessions remain available under Export."
+        } else {
+            "Start a conversation first, then return here to resume it."
+        };
+        let empty = Paragraph::new(vec![
+            Line::from(vec![Span::styled(
+                "No sessions found",
+                Style::default()
+                    .fg(theme.foreground)
+                    .add_modifier(Modifier::BOLD),
+            )]),
+            Line::from(""),
+            Line::from(vec![Span::styled(detail, theme.muted_style())]),
+        ])
+        .block(
+            Block::default()
+                .title(if remote_mode {
+                    " Remote Sessions "
+                } else {
+                    " Sessions "
+                })
+                .padding(Padding::uniform(1)),
+        )
+        .wrap(Wrap { trim: true });
+        frame.render_widget(empty, area);
+        return;
+    }
+
     let items: Vec<ListItem> = sessions
         .iter()
         .enumerate()
@@ -1314,7 +1363,11 @@ fn draw_sessions(
 
     let sessions_list = List::new(items).block(
         Block::default()
-            .title(" Sessions (Enter resume • → preview) ")
+            .title(if remote_mode {
+                " Remote Sessions (Enter resume • → preview) "
+            } else {
+                " Sessions (Enter resume • → preview) "
+            })
             .padding(Padding::uniform(1)),
     );
 
@@ -1328,6 +1381,30 @@ fn draw_export_sessions(
     theme: &Theme,
     area: Rect,
 ) {
+    if sessions.is_empty() {
+        let empty = Paragraph::new(vec![
+            Line::from(vec![Span::styled(
+                "No sessions available to export",
+                Style::default()
+                    .fg(theme.foreground)
+                    .add_modifier(Modifier::BOLD),
+            )]),
+            Line::from(""),
+            Line::from(vec![Span::styled(
+                "Create a conversation first, then return here to export it.",
+                theme.muted_style(),
+            )]),
+        ])
+        .block(
+            Block::default()
+                .title(" Export Sessions ")
+                .padding(Padding::uniform(1)),
+        )
+        .wrap(Wrap { trim: true });
+        frame.render_widget(empty, area);
+        return;
+    }
+
     let items: Vec<ListItem> = sessions
         .iter()
         .enumerate()
@@ -1339,21 +1416,45 @@ fn draw_export_sessions(
             } else {
                 Style::default().fg(theme.foreground)
             };
-            ListItem::new(format!("Export › {}", session.name)).style(style)
+            ListItem::new(vec![
+                Line::from(vec![
+                    Span::styled(display_session_name(session), style),
+                    Span::styled("  ", theme.muted_style()),
+                    Span::styled(session.created_at.clone(), theme.muted_style()),
+                ]),
+                Line::from(vec![Span::styled(
+                    truncate_chat_summary(&session.id, 48),
+                    theme.muted_style(),
+                )]),
+            ])
+            .style(style)
         })
         .collect();
 
     let sessions_list = List::new(items).block(
         Block::default()
-            .title(" Export ")
+            .title(" Export Local Sessions ")
             .padding(Padding::uniform(1)),
     );
 
     frame.render_widget(sessions_list, area);
 }
 
+fn display_session_name(session: &SessionInfo) -> String {
+    let trimmed = session.name.trim();
+    if !trimmed.is_empty() && trimmed != session.id {
+        return trimmed.to_string();
+    }
+
+    if session.id.len() >= 8 {
+        return format!("Session {}", &session.id[..8]);
+    }
+
+    "Untitled session".to_string()
+}
+
 fn draw_tools(frame: &mut Frame, selected: usize, theme: &Theme, area: Rect) {
-    let tools = ["Search", "System", "Processes", "Git"];
+    let tools = ["Profile", "Search", "System", "Processes", "Git"];
     let items: Vec<ListItem> = tools
         .iter()
         .enumerate()
@@ -1371,11 +1472,126 @@ fn draw_tools(frame: &mut Frame, selected: usize, theme: &Theme, area: Rect) {
 
     let tools_list = List::new(items).block(
         Block::default()
-            .title(" Tools ")
+            .title(" Settings ")
             .padding(Padding::uniform(1)),
     );
 
     frame.render_widget(tools_list, area);
+}
+
+fn draw_profile(frame: &mut Frame, app: &TuiApp, selected: usize, theme: &Theme, area: Rect) {
+    let info_lines = if let Some(session) = app.auth_session.as_ref() {
+        vec![
+            Line::from(vec![
+                Span::styled("Status: ", Style::default().fg(theme.foreground)),
+                Span::styled("Signed in", Style::default().fg(theme.accent)),
+            ]),
+            Line::from(vec![
+                Span::styled("Email: ", Style::default().fg(theme.foreground)),
+                Span::styled(
+                    session
+                        .user
+                        .email
+                        .clone()
+                        .unwrap_or_else(|| "—".to_string()),
+                    theme.muted_style(),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Name: ", Style::default().fg(theme.foreground)),
+                Span::styled(
+                    session
+                        .user
+                        .display_name
+                        .clone()
+                        .unwrap_or_else(|| "—".to_string()),
+                    theme.muted_style(),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("Provider: ", Style::default().fg(theme.foreground)),
+                Span::styled(
+                    session
+                        .user
+                        .provider
+                        .as_ref()
+                        .map(|provider| format!("{provider:?}"))
+                        .unwrap_or_else(|| "—".to_string()),
+                    theme.muted_style(),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("User ID: ", Style::default().fg(theme.foreground)),
+                Span::styled(session.user.user_id.clone(), theme.muted_style()),
+            ]),
+            Line::from(""),
+            Line::styled(
+                "Session storage uses the local OS keychain/keyring.",
+                theme.muted_style(),
+            ),
+            Line::styled(
+                "History, Export, and Statistics are scoped to this signed-in account.",
+                theme.muted_style(),
+            ),
+        ]
+    } else {
+        vec![
+            Line::from(vec![
+                Span::styled("Status: ", Style::default().fg(theme.foreground)),
+                Span::styled("Not signed in", theme.muted_style()),
+            ]),
+            Line::from(""),
+            Line::styled(
+                "Sign in with /auth login <provider> in chat to enable account-scoped History, Export, and Statistics.",
+                theme.muted_style(),
+            ),
+            Line::styled(
+                "Without sign-in, Harper stays in local-only mode on this machine.",
+                theme.muted_style(),
+            ),
+        ]
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(8), Constraint::Length(6)])
+        .split(area);
+
+    let profile = Paragraph::new(info_lines)
+        .block(
+            Block::default()
+                .title(" Profile ")
+                .padding(Padding::uniform(1)),
+        )
+        .wrap(Wrap { trim: true });
+    frame.render_widget(profile, chunks[0]);
+
+    let actions: Vec<&str> = if app.auth_session.is_some() {
+        vec!["Logout", "Refresh Session"]
+    } else {
+        vec!["Login with GitHub", "Login with Google", "Login with Apple"]
+    };
+    let items: Vec<ListItem> = actions
+        .iter()
+        .enumerate()
+        .map(|(index, label)| {
+            let style = if index == selected {
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.foreground)
+            };
+            ListItem::new(*label).style(style)
+        })
+        .collect();
+
+    let actions_list = List::new(items).block(
+        Block::default()
+            .title(" Actions ")
+            .padding(Padding::uniform(1)),
+    );
+    frame.render_widget(actions_list, chunks[1]);
 }
 
 fn draw_view_session(
@@ -1439,6 +1655,26 @@ fn draw_view_session(
 }
 
 fn draw_message_overlay(frame: &mut Frame, message: &UiMessage, theme: &Theme) {
+    let area = frame.area();
+    let max_overlay_width = area.width.saturating_mul(3) / 4;
+    let content_width = message
+        .content
+        .lines()
+        .map(|line| line.chars().count() as u16)
+        .max()
+        .unwrap_or(0);
+    let overlay_width = (content_width + 8).clamp(24, max_overlay_width.max(24));
+    let text_width = overlay_width.saturating_sub(4).max(1) as usize;
+    let wrapped_line_count = message
+        .content
+        .lines()
+        .map(|line| {
+            let len = line.chars().count();
+            usize::max(1, len.div_ceil(text_width))
+        })
+        .sum::<usize>() as u16;
+    let overlay_height = (wrapped_line_count + 4).clamp(5, area.height.saturating_mul(3) / 4);
+
     let overlay = Paragraph::new(message.content.as_str())
         .block(
             Block::default()
@@ -1449,11 +1685,6 @@ fn draw_message_overlay(frame: &mut Frame, message: &UiMessage, theme: &Theme) {
         .style(Style::default().bg(theme.background).fg(theme.foreground))
         .alignment(Alignment::Center)
         .wrap(Wrap { trim: true });
-
-    let area = frame.area();
-    let message_lines = message.content.lines().count().max(1) as u16;
-    let overlay_height = (message_lines + 4).min(area.height / 2);
-    let overlay_width = (message.content.len() as u16 + 8).min(area.width * 3 / 4);
 
     let overlay_area = Rect {
         x: (area.width - overlay_width) / 2,

--- a/website/blog.html
+++ b/website/blog.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Blog</title>
-    <meta name="harper-update-version" content="2026-04-28-blog" />
+    <meta name="harper-update-version" content="2026-04-28-blog-v2" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -28,6 +28,12 @@
             <div class="content-container">
                 <h1 class="hero-title">Notes from the codebase.</h1>
                 <p class="hero-lede">Short product and engineering notes from Harper. This page stays high level. The <a href="changelog.html">changelog</a> keeps the version-by-version detail.</p>
+
+                <article>
+                    <h2>April 2026 · Signed-in local workflows are now account-scoped</h2>
+                    <p>Harper still works without sign-in, but the signed-in path is now a real product mode rather than a thin auth callback. When you sign in, the local TUI session is stored in the OS credential store, the Profile screen in Settings shows the active account, and session refresh can happen automatically when a remote request hits an expired access token.</p>
+                    <p>The more important behavioral change is scope. History, Export, and Statistics now follow the signed-in account instead of mixing account-owned sessions with unrelated local state. That makes the local client behave like a user-aware workspace while preserving unsigned local-only use for people who do not want authentication at all.</p>
+                </article>
 
                 <article>
                     <h2>April 2026 · Local sign-in now works through Supabase</h2>

--- a/website/installation.html
+++ b/website/installation.html
@@ -74,6 +74,11 @@ SUPABASE_ALLOWED_PROVIDERS=github</code></pre>
                 </div>
                 <p>For auth commands, <code>/auth login github</code> opens the browser, Harper polls the local server for completion, and <code>/auth status</code> reports the currently stored local TUI session.</p>
                 <p>When sign-in succeeds, Harper stores the local TUI auth session in the OS credential store (macOS Keychain, Linux keyring, or Windows Credential Manager) instead of writing the active tokens to a JSON file under your home directory.</p>
+                <p>Harper also exposes the same auth state through <code>Settings -&gt; Profile</code>. When signed out, that screen offers login actions for the configured providers. When signed in, it shows the current account, plus <code>Logout</code> and <code>Refresh Session</code>.</p>
+                <p>When you are signed in, Harper scopes session data to that account. <code>History</code>, <code>Export</code>, and <code>Statistics</code> all reflect the signed-in user only. When you are not signed in, those screens continue to use local-only data.</p>
+                <p>Remote session operations refresh the TUI session automatically if the access token has expired. If refresh also fails, Harper will show the auth error directly and you will need to sign in again.</p>
+                <p>In both <code>History</code> and <code>Export</code>, press <code>D</code> or <code>Delete</code> to remove the selected session.</p>
+                <p>Empty states are explicit now: if the signed-in user has no remote sessions, <code>History</code> says so directly; if there are no exportable sessions, <code>Export</code> shows that state instead of a blank panel.</p>
 
                 <h2>File references and Tab completion</h2>
                 <p>Type <code>@</code> in the chat input to start a file or directory reference. Press <code>Tab</code> to autocomplete matching paths and keep pressing <code>Tab</code> to cycle through candidates.</p>

--- a/website/nav-updates.json
+++ b/website/nav-updates.json
@@ -2,7 +2,7 @@
   "index.html": "2026-04-28-home",
   "installation.html": "2026-04-28-install",
   "troubleshooting.html": "2026-04-28-troubleshooting",
-  "blog.html": "2026-04-28-blog",
+  "blog.html": "2026-04-28-blog-v2",
   "changelog.html": "2026-04-28-changelog",
   "server.html": "2026-04-28-server",
   "terms.html": "2026-04-28-terms",

--- a/website/server.html
+++ b/website/server.html
@@ -109,7 +109,7 @@ curl http://127.0.0.1:8081/api/sessions</code></pre>
   }'</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p>The session endpoint returns messages plus any active plan and resolved AGENTS context for that session. Session list items also include a human-readable <code>title</code> derived from the first user message when available. When Supabase auth is enabled, session list, load, and delete operations are scoped to the signed-in user.</p>
+                <p>The session endpoint returns messages plus any active plan and resolved AGENTS context for that session. Session list items also include a human-readable <code>title</code> derived from the first user message when available. When Supabase auth is enabled, session list, load, delete, export, and statistics operations are scoped to the signed-in user.</p>
 
                 <h2>Planner runtime API</h2>
                 <p>Harper exposes planner/runtime state through a pull endpoint and a server-sent events stream. Use the pull endpoint for snapshots and the SSE endpoint when a client needs to follow running jobs incrementally.</p>
@@ -178,6 +178,9 @@ open http://127.0.0.1:8081/auth/login/github</code></pre>
                 </div>
                 <p><code>/auth login github</code> starts a local flow, opens the browser, and then stores the resulting TUI session once Harper sees the completed callback. <code>/auth status</code> reports the local TUI auth state. <code>/auth logout</code> clears the local stored TUI session.</p>
                 <p>Successful TUI sign-in stores the local auth session in the system credential store (for example macOS Keychain) rather than a plain JSON token file. If you launch Harper with <code>--no-server</code>, these TUI auth commands are unavailable because the local auth callback and polling endpoints are disabled.</p>
+                <p>The same TUI session is also visible from <code>Settings -&gt; Profile</code>, which shows the signed-in account and offers <code>Logout</code> and <code>Refresh Session</code> actions.</p>
+                <p>When a remote session request returns <code>401 Unauthorized</code>, Harper automatically attempts one Supabase refresh-token exchange through the local server and retries the request once before surfacing the error.</p>
+                <p>Signed-in users see account-scoped data in <code>History</code>, <code>Export</code>, and <code>Statistics</code>. Press <code>D</code> or <code>Delete</code> in the TUI session lists to remove the selected session.</p>
 
                 <h2>Review example</h2>
                 <div class="code-wrapper">


### PR DESCRIPTION
## Changes

- tightened the signed-in TUI session flow so expired access tokens refresh automatically before remote session operations fail
- added a Profile screen under `Settings` that shows the active account and exposes login, logout, and refresh-session actions
- made signed-in `History`, `Export`, and `Statistics` consistently account-scoped while preserving unsigned local-only behavior
- added session deletion from `History` and `Export` with `D` / `Delete`
- improved TUI empty states and error messages for remote sessions, export, AGENTS, and help overlays
- enriched stored Supabase auth sessions with inferred user metadata so the TUI profile shows the same display name/provider data as `/auth/me`
- updated website docs and the blog for the signed-in local workflow and profile behavior

## Validation

- `cargo test -p harper-ui test_enter_profile_ -- --nocapture`
- `cargo check -p harper-ui`
- `cargo check -p harper-core`
- pre-push hooks: `fmt`, `clippy`, `cargo check`