### PR TITLE
[feat] plan followup state, bounded retry, cross-process plan events, and tui plan steps browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "harper-core"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "aes",
  "arboard",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "harper-sandbox"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "caps",
  "log",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "harper-ui"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/PLANNER_NEXT_STEPS.md
+++ b/PLANNER_NEXT_STEPS.md
@@ -1,188 +1,94 @@
 # Harper Planner Next Steps
 
-This file captures the next implementation steps after the current planning/runtime work.
+This file captures the remaining planner/runtime work after the current planning, job, follow-up, retry, scoped `AGENTS.md`, and cross-process delivery changes.
 
 ## Count
 
-There are **10 solid next steps** that can be implemented without changing direction.
+There are **3 real next steps** left without changing direction.
 
 ## Next Steps
 
-1. **Background job model**
-   - Introduce first-class job IDs, job records, and job lifecycle state.
-   - Separate long-running jobs from simple synchronous tool calls.
-
-2. **Job list UI**
-   - Add a panel or overlay showing running, completed, blocked, and failed jobs.
-   - Allow selecting a job to inspect its output and status history.
-
-3. **Step-to-job linkage**
-   - Explicitly attach a plan step to a spawned/running job.
-   - Keep the step `in_progress` while the linked job is active.
-
-4. **Automatic completion from job finish**
-   - Mark a linked step completed when the job succeeds and the match is high-confidence.
-   - Move the next pending step to `in_progress` when appropriate.
-
-5. **Failure-aware plan transitions**
-   - Mark runtime as `failed` or `blocked` when a job exits non-zero or approval is denied.
-   - Nudge the model to revise the plan instead of continuing blindly.
-
-6. **HTTP API plan/job events**
-   - Expose live plan/job state through API endpoints or server-sent events.
-   - Keep web clients in sync with the same runtime state as the TUI.
-   - Status: implemented with:
-     - `GET /api/sessions/{id}/plan`
-     - `GET /api/sessions/{id}/plan/stream`
-   - Current delivery model:
-     - same-process updates use in-memory broadcast for low-latency push
-     - cross-process updates use the persisted SQLite plan event journal
-   - Remaining boundary:
-     - cross-process delivery is journal-backed, not a dedicated external event bus
-
-7. **Plan editing commands in UI**
-   - Add direct UI actions for promoting, completing, or clearing steps.
-   - Make plans editable even when the model is not actively driving the session.
-
-8. **Scoped AGENTS.md resolution**
-   - Replace the current single-file append behavior with scoped lookup and merge logic.
-   - Use nested `AGENTS.md` rules per directory tree instead of only repo-root text.
-
-9. **Planner-quality orchestration**
-   - Add stronger multi-step execution policies around sequencing, retries, checkpoints, and summaries.
-   - Make the model behave more like a planner/executor instead of only a reactive chat loop.
-
-10. **Live command output polish**
+1. **Live command output polish**
    - Refine the existing command output panel and active runtime display.
-   - Add richer status summaries, truncation controls, and clearer failure surfacing.
+   - Add clearer truncation controls, richer status summaries, and better failure surfacing.
+
+2. **Legacy fallback cleanup**
+   - Reduce the remaining heuristic fallback paths where explicit command intent now exists.
+   - Prefer explicit retry/sandbox intent end to end over command-shape inference.
+
+3. **Planner follow-up history polish**
+   - Extend the current single follow-up state into richer visible history if needed.
+   - Make retry/checkpoint review easier without losing the current lightweight UI.
 
 ## Recommended Order
 
-If we implement these in sequence, this is the best order:
-
-1. Background job model
-2. Job list UI
-3. Step-to-job linkage
-4. Automatic completion from job finish
-5. Failure-aware plan transitions
-6. HTTP API plan/job events
-7. Plan editing commands in UI
-8. Scoped `AGENTS.md` resolution
-9. Planner-quality orchestration
-10. Live command output polish
+1. Live command output polish
+2. Legacy fallback cleanup
+3. Planner follow-up history polish
 
 ## Suggested Milestones
 
-### Milestone 1: Runtime jobs
-- Background job model
-- Job list UI
+### Milestone 1: Runtime polish
 - Live command output polish
 
-### Milestone 2: Plan/job coordination
-- Step-to-job linkage
-- Automatic completion from job finish
-- Failure-aware plan transitions
+### Milestone 2: Fallback cleanup
+- Reduce heuristic retry/sandbox fallback paths
+- Keep explicit intent paths as the primary contract
 
-### Milestone 3: Cross-interface support
-- HTTP API plan/job events
-- Plan editing commands in UI
-
-### Milestone 4: Planner maturity
-- Scoped `AGENTS.md` resolution
-- Planner-quality orchestration
+### Milestone 3: Follow-up history
+- Add richer checkpoint/retry review history
+- Keep active follow-up state easy to understand
 
 ## Harper `update_plan` Seeds
 
-These are ready-to-use plan payloads in Harper-style structure.
-
-### Seed 1: Runtime jobs
+### Seed 1: Runtime polish
 
 ```json
 {
-  "explanation": "Introduce first-class runtime jobs so command execution is tracked explicitly instead of only through one active command slot.",
-  "items": [
-    { "step": "Define job record schema", "status": "pending" },
-    { "step": "Persist job lifecycle state", "status": "pending" },
-    { "step": "Render job status summary", "status": "pending" },
-    { "step": "Polish command output display", "status": "pending" }
-  ]
-}
-```
-
-### Seed 2: Plan and job coordination
-
-```json
-{
-  "explanation": "Tie plan progress to actual runtime state so steps reflect real execution instead of only model intent.",
-  "items": [
-    { "step": "Link steps to jobs", "status": "pending" },
-    { "step": "Advance steps on success", "status": "pending" },
-    { "step": "Handle blocked and failed runs", "status": "pending" },
-    { "step": "Refine plan transition rules", "status": "pending" }
-  ]
-}
-```
-
-### Seed 3: Cross-interface support
-
-```json
-{
-  "explanation": "Expose plan and job runtime state consistently across TUI and HTTP clients, with the current stream path using in-process broadcast plus a persisted SQLite event journal.",
-  "items": [
-    { "step": "Add HTTP plan runtime endpoints", "status": "pending" },
-    { "step": "Stream API-side runtime events", "status": "pending" },
-    { "step": "Add UI plan editing actions", "status": "pending" },
-    { "step": "Keep clients in sync", "status": "pending" }
-  ]
-}
-```
-
-### Seed 4: Planner maturity
-
-```json
-{
-  "explanation": "Move from basic reactive execution toward a planner-quality agent with scoped repo instructions and stronger orchestration.",
-  "items": [
-    { "step": "Resolve scoped AGENTS rules", "status": "pending" },
-    { "step": "Add planner checkpoints", "status": "pending" },
-    { "step": "Improve retry and recovery", "status": "pending" },
-    { "step": "Summarize execution state cleanly", "status": "pending" }
-  ]
-}
-```
-
-### Seed 5: Live output polish
-
-```json
-{
-  "explanation": "Refine the existing live command output panel so active runtime state is easier to inspect and reason about.",
+  "explanation": "Refine planner runtime visibility now that plan/job/follow-up state and cross-process delivery are in place.",
   "items": [
     { "step": "Clarify active command status", "status": "pending" },
-    { "step": "Improve truncation behavior", "status": "pending" },
-    { "step": "Show failure summaries clearly", "status": "pending" },
-    { "step": "Add richer job selection UX", "status": "pending" }
+    { "step": "Improve output truncation", "status": "pending" },
+    { "step": "Surface failures more clearly", "status": "pending" }
+  ]
+}
+```
+
+### Seed 2: Fallback cleanup
+
+```json
+{
+  "explanation": "Reduce legacy inference paths now that explicit retry and sandbox intent are available in the core tool contract.",
+  "items": [
+    { "step": "Find heuristic-only paths", "status": "pending" },
+    { "step": "Prefer explicit intent", "status": "pending" },
+    { "step": "Keep compatibility fallback", "status": "pending" }
+  ]
+}
+```
+
+### Seed 3: Follow-up history
+
+```json
+{
+  "explanation": "Improve visibility of completed checkpoints and recovery actions after the active follow-up model is already in place.",
+  "items": [
+    { "step": "Design follow-up history view", "status": "pending" },
+    { "step": "Store checkpoint history", "status": "pending" },
+    { "step": "Render retry/checkpoint review", "status": "pending" }
   ]
 }
 ```
 
 ## Single Master Plan
 
-If you want one top-level plan instead of milestone plans, use this:
-
 ```json
 {
-  "explanation": "Finish Harper's planner/runtime system from live execution visibility through planner-quality orchestration.",
+  "explanation": "Finish the remaining planner/runtime polish after core orchestration, scoped AGENTS resolution, retry handling, and cross-process delivery are in place.",
   "items": [
-    { "step": "Introduce job model", "status": "pending" },
-    { "step": "Build job list UI", "status": "pending" },
-    { "step": "Link steps to jobs", "status": "pending" },
-    { "step": "Auto-advance on job finish", "status": "pending" },
-    { "step": "Handle blocked and failed states", "status": "pending" },
-    { "step": "Expose runtime over HTTP", "status": "pending" },
-    { "step": "Add UI plan editing", "status": "pending" },
-    { "step": "Resolve scoped AGENTS rules", "status": "pending" },
-    { "step": "Improve planner orchestration", "status": "pending" },
-    { "step": "Polish live command output", "status": "pending" }
+    { "step": "Polish live command output", "status": "pending" },
+    { "step": "Reduce legacy fallback paths", "status": "pending" },
+    { "step": "Improve follow-up history UX", "status": "pending" }
   ]
 }
 ```

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -133,12 +133,40 @@ No silent fallback occurs.
 
 ---
 
+## `[exec_policy]`
+
+Execution approval, sandbox presets, and bounded retry behavior for `run_command`.
+
+| Key                      | Type             | Default          | Description |
+| ------------------------ | ---------------- | ---------------- | ----------- |
+| `approval_profile`       | string           | `allow_listed`   | `strict`, `allow_listed`, or `allow_all` |
+| `sandbox_profile`        | string           | `disabled`       | `disabled`, `workspace`, or `networked_workspace` |
+| `retry_max_attempts`     | integer          | `1`              | Max automatic retries for retry-safe failures |
+| `retry_network_commands` | array of strings | `["curl","wget"]`| Network command classes eligible for bounded retry |
+| `retry_write_commands`   | array of strings | `["mkdir","touch"]` | Write command classes eligible for bounded retry |
+
+### `[exec_policy.sandbox]`
+
+| Key              | Type             | Default | Description |
+| ---------------- | ---------------- | ------- | ----------- |
+| `allowed_dirs`   | array of strings | `[]`    | Readable roots inside the sandbox |
+| `writable_dirs`  | array of strings | `[]`    | Writable roots inside the sandbox |
+| `network_access` | bool             | profile | Whether sandboxed commands may reach the network |
+| `readonly_home`  | bool             | profile | Whether `$HOME` is mounted read-only |
+
+### Notes
+
+- `allow_listed` still prompts when a command declares network access or writes outside configured writable roots.
+- Retry behavior remains conservative: Harper uses declared intent plus configured command classes, not blind command replay.
+
+---
+
 ## Minimal Example
 
 ```toml
 [provider]
 name = "openai"
-model = "gpt-4.1"
+model = "gpt-5.5"
 
 [execution]
 require_approval = true

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -21,6 +21,31 @@ mkdir -p config
 cp config/local.example.toml config/local.toml
 ```
 
+## Execution Policy
+
+Harper separates command approval policy from sandbox policy under `[exec_policy]`. The same fields are also available in the TUI under `Settings -> Execution Policy`.
+
+```toml
+[exec_policy]
+approval_profile = "allow_listed"   # strict | allow_listed | allow_all
+sandbox_profile = "workspace"       # disabled | workspace | networked_workspace
+retry_max_attempts = 1
+retry_network_commands = ["curl", "wget"]
+retry_write_commands = ["mkdir", "touch"]
+
+[exec_policy.sandbox]
+allowed_dirs = ["."]
+writable_dirs = ["./tmp", "./build"]
+```
+
+- `approval_profile` controls when Harper asks before running commands.
+- `sandbox_profile` controls the default sandbox boundary.
+- `retry_max_attempts` controls bounded automatic retries for retry-safe failures.
+- `allowed_dirs` are readable roots.
+- `writable_dirs` are writable roots.
+
+Under `allow_listed`, Harper still asks for approval when a command declares network access or writes outside configured writable roots, even if the command itself is allowlisted.
+
 ## API Configuration
 
 ### Setting Up OpenAI
@@ -56,9 +81,9 @@ You can specify which models to use for different tasks:
 
 ```toml
 [models]
-default = "gpt-4"
-code = "gpt-4"
-chat = "gpt-3.5-turbo"
+default = "gpt-5.5"
+code = "gpt-5.5"
+chat = "gpt-5.5"
 ```
 
 ### Model Parameters
@@ -120,7 +145,7 @@ You can also configure Harper using environment variables:
 ```bash
 export HARPER_API_KEY="your-api-key"
 export HARPER_PROVIDER="OpenAI"
-export HARPER_MODEL="gpt-4"
+export HARPER_MODEL="gpt-5.5"
 export HARPER_DEBUG="false"
 ```
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -58,7 +58,7 @@ This guide helps you resolve common issues you might encounter while using Harpe
 **Symptom**: Responses take a long time to appear.
 
 **Solutions**:
-1. Try a faster model (e.g., gpt-3.5-turbo instead of gpt-4)
+1. Try a smaller or faster configured model instead of `gpt-5.5`
 2. Reduce max_tokens setting
 3. Check your network latency
 4. Close other bandwidth-intensive applications

--- a/lib/harper-core/src/agent/chat.rs
+++ b/lib/harper-core/src/agent/chat.rs
@@ -256,6 +256,9 @@ impl<'a> ChatService<'a> {
                 blocked_commands: None,
                 sandbox_profile: None,
                 sandbox: None,
+                retry_max_attempts: None,
+                retry_network_commands: None,
+                retry_write_commands: None,
             },
             approver: None,
             runtime_events: None,
@@ -1023,8 +1026,61 @@ impl<'a> ChatService<'a> {
         });
 
         if has_active_plan {
+            if let Some(followup) = existing_plan
+                .as_ref()
+                .and_then(|plan| plan.runtime.as_ref())
+                .and_then(|runtime| runtime.followup.as_ref())
+            {
+                match followup {
+                    crate::core::plan::PlanFollowup::RetryOrReplan {
+                        step,
+                        command,
+                        retry_count,
+                    } => {
+                        let command = command.as_deref().unwrap_or(step.as_str());
+                        if *retry_count <= 1 {
+                            return Ok(Some(format!(
+                                "This multi-step task hit a failure at '{}' while running '{}'. Retry once if the issue looks transient; otherwise call update_plan to revise the remaining steps before more tool work.",
+                                step, command
+                            )));
+                        }
+                        return Ok(Some(format!(
+                            "This multi-step task has already failed {} times at '{}' while running '{}'. Do not keep retrying blindly; call update_plan to revise the plan before more tool work.",
+                            retry_count, step, command
+                        )));
+                    }
+                    crate::core::plan::PlanFollowup::Checkpoint { step, next_step } => {
+                        let next_clause = next_step
+                            .as_deref()
+                            .map(|next_step| {
+                                format!(
+                                    " Continue with '{}' only after a short checkpoint summary.",
+                                    next_step
+                                )
+                            })
+                            .unwrap_or_else(|| {
+                                " If the task is done, confirm completion instead of repeating the plan."
+                                    .to_string()
+                            });
+                        return Ok(Some(format!(
+                            "This multi-step task has an open checkpoint on '{}'. Briefly summarize what changed before more tool work.{}",
+                            step, next_clause
+                        )));
+                    }
+                }
+            }
+            if let Some(blocked_step) = existing_plan.as_ref().and_then(|plan| {
+                plan.items
+                    .iter()
+                    .find(|item| matches!(item.status, crate::core::plan::PlanStepStatus::Blocked))
+            }) {
+                return Ok(Some(format!(
+                    "This multi-step task is currently blocked at '{}'. Before more tool work, call update_plan to explain the blocker, retry, or revise the remaining steps.",
+                    blocked_step.step
+                )));
+            }
             return Ok(Some(
-                "This is an active multi-step task. Refresh the plan with update_plan if the steps or statuses have changed before continuing."
+                "This is an active multi-step task. Keep the plan current with update_plan, and add a brief checkpoint summary whenever a step finishes or the next step changes."
                     .to_string(),
             ));
         }
@@ -1672,6 +1728,16 @@ impl AuditParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::{ApiConfig, ApiProvider};
+
+    fn test_config() -> ApiConfig {
+        ApiConfig {
+            provider: ApiProvider::OpenAI,
+            api_key: "test-key".to_string(),
+            base_url: "https://api.openai.com/v1/chat/completions".to_string(),
+            model_name: "gpt-5.5".to_string(),
+        }
+    }
 
     #[test]
     fn parse_audit_no_args() {
@@ -1743,6 +1809,103 @@ mod tests {
         ));
         assert!(!ChatService::request_needs_plan("run git status"));
         assert!(!ChatService::request_needs_plan("fix typo"));
+    }
+
+    #[test]
+    fn plan_prompt_mentions_blocked_step_when_plan_is_blocked() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "blocked-plan-session",
+            &crate::core::plan::PlanState {
+                explanation: Some("blocked".to_string()),
+                items: vec![crate::core::plan::PlanItem {
+                    step: "Fix failing migration".to_string(),
+                    status: crate::core::plan::PlanStepStatus::Blocked,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let chat = ChatService::new(
+            &conn,
+            &config,
+            None,
+            None,
+            Some("blocked-plan-session".to_string()),
+            HashMap::new(),
+            exec_policy,
+        );
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: "fix the migration and then update the docs".to_string(),
+        }];
+
+        let prompt = chat
+            .plan_prompt_for_request(&history, "blocked-plan-session")
+            .expect("plan prompt")
+            .expect("prompt present");
+
+        assert!(prompt.contains("blocked at 'Fix failing migration'"));
+        assert!(prompt.contains("call update_plan"));
+    }
+
+    #[test]
+    fn plan_prompt_mentions_retry_limit_when_followup_requires_replan() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "retry-plan-session",
+            &crate::core::plan::PlanState {
+                explanation: Some("retry".to_string()),
+                items: vec![crate::core::plan::PlanItem {
+                    step: "Patch handler".to_string(),
+                    status: crate::core::plan::PlanStepStatus::Blocked,
+                    job_id: None,
+                }],
+                runtime: Some(crate::core::plan::PlanRuntime {
+                    followup: Some(crate::core::plan::PlanFollowup::RetryOrReplan {
+                        step: "Patch handler".to_string(),
+                        command: Some("cargo test".to_string()),
+                        retry_count: 2,
+                    }),
+                    ..Default::default()
+                }),
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let chat = ChatService::new(
+            &conn,
+            &config,
+            None,
+            None,
+            Some("retry-plan-session".to_string()),
+            HashMap::new(),
+            exec_policy,
+        );
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: "fix the handler and then rerun the tests".to_string(),
+        }];
+
+        let prompt = chat
+            .plan_prompt_for_request(&history, "retry-plan-session")
+            .expect("plan prompt")
+            .expect("prompt present");
+
+        assert!(prompt.contains("already failed 2 times"));
+        assert!(prompt.contains("Do not keep retrying blindly"));
     }
 
     #[test]

--- a/lib/harper-core/src/agent/prompt.rs
+++ b/lib/harper-core/src/agent/prompt.rs
@@ -98,6 +98,7 @@ Core Tools:
 - search_replace(args: {\"path\": \"src/main.rs\", \"old_string\": \"old\", \"new_string\": \"new\"})
 - run_command(args: {\"command\": \"git status\"})
 - run_command(args: {\"command\": \"cp ./src.txt ./build/out.txt\", \"declared_read_paths\": [\"./src.txt\"], \"declared_write_paths\": [\"./build/out.txt\"]})
+- run_command(args: {\"command\": \"curl -fsSL http://127.0.0.1:8081/health\", \"requires_network\": true, \"retry_policy\": \"safe\"})
 - todo(args: {\"action\": \"add|list|remove|clear\", \"description\": \"...\", \"index\": 1})
 - update_plan(args: {\"explanation\": \"optional context\", \"items\": [{\"step\": \"Inspect files\", \"status\": \"in_progress\"}]})
 - list_changed_files(args: {\"ext\": \"rs\", \"tracked_only\": true, \"since\": \"HEAD~1\"})

--- a/lib/harper-core/src/core/agents.rs
+++ b/lib/harper-core/src/core/agents.rs
@@ -165,13 +165,45 @@ fn normalize_target(base_dir: &Path, target: &Path) -> HarperResult<PathBuf> {
         base_dir.join(target)
     };
 
-    joined.canonicalize().map_err(|err| {
+    if joined.exists() {
+        return joined.canonicalize().map_err(|err| {
+            HarperError::Io(format!(
+                "Failed to resolve target path '{}': {}",
+                joined.display(),
+                err
+            ))
+        });
+    }
+
+    let mut existing_ancestor = joined.as_path();
+    let mut missing_suffix = Vec::new();
+    while !existing_ancestor.exists() {
+        let Some(name) = existing_ancestor.file_name().map(|name| name.to_owned()) else {
+            return Err(HarperError::Io(format!(
+                "Failed to resolve target path '{}': no existing ancestor found",
+                joined.display()
+            )));
+        };
+        missing_suffix.push(name);
+        existing_ancestor = existing_ancestor.parent().ok_or_else(|| {
+            HarperError::Io(format!(
+                "Failed to resolve target path '{}': no existing ancestor found",
+                joined.display()
+            ))
+        })?;
+    }
+
+    let mut resolved = existing_ancestor.canonicalize().map_err(|err| {
         HarperError::Io(format!(
             "Failed to resolve target path '{}': {}",
-            joined.display(),
+            existing_ancestor.display(),
             err
         ))
-    })
+    })?;
+    for component in missing_suffix.into_iter().rev() {
+        resolved.push(component);
+    }
+    Ok(resolved)
 }
 
 fn find_repo_root(start_dir: &Path) -> HarperResult<PathBuf> {
@@ -488,6 +520,42 @@ mod tests {
         assert!(rendered.contains("root rules"));
         assert!(rendered.contains("a rules"));
         assert!(!rendered.contains("b rules"));
+    }
+
+    #[test]
+    fn resolves_agents_for_nonexistent_target_using_existing_ancestors() {
+        let temp = TempDir::new().expect("temp dir");
+        let repo = temp.path().join("repo");
+        let nested = repo.join("src/feature");
+        fs::create_dir_all(&nested).expect("mkdirs");
+        fs::create_dir(repo.join(".git")).expect("git dir");
+        write_file(&repo.join("AGENTS.md"), "root rules");
+        write_file(&repo.join("src/AGENTS.md"), "src rules");
+        write_file(&nested.join("AGENTS.md"), "feature rules");
+        let repo = repo.canonicalize().expect("canonical repo");
+
+        let nonexistent = nested.join("new_file.rs");
+        let resolved = resolve_agents_for_targets(&repo, [nonexistent.as_path()]).expect("resolve");
+
+        let paths: Vec<String> = resolved
+            .sources
+            .iter()
+            .map(|source| {
+                source
+                    .path
+                    .strip_prefix(&repo)
+                    .expect("strip")
+                    .components()
+                    .map(|component| component.as_os_str().to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+                    .join("/")
+            })
+            .collect();
+
+        assert_eq!(
+            paths,
+            vec!["AGENTS.md", "src/AGENTS.md", "src/feature/AGENTS.md"]
+        );
     }
 
     #[test]

--- a/lib/harper-core/src/core/llm_client.rs
+++ b/lib/harper-core/src/core/llm_client.rs
@@ -175,6 +175,11 @@ pub async fn call_llm(
                                 "requires_network": {
                                     "type": "boolean",
                                     "description": "Set true if the command needs network access"
+                                },
+                                "retry_policy": {
+                                    "type": "string",
+                                    "enum": ["never", "safe"],
+                                    "description": "Optional explicit retry policy for transient-safe commands"
                                 }
                             },
                             "required": ["command"]

--- a/lib/harper-core/src/core/plan.rs
+++ b/lib/harper-core/src/core/plan.rs
@@ -56,6 +56,20 @@ pub struct PlanJobRecord {
     pub has_error_output: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PlanFollowup {
+    Checkpoint {
+        step: String,
+        next_step: Option<String>,
+    },
+    RetryOrReplan {
+        step: String,
+        command: Option<String>,
+        retry_count: u32,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlanRuntime {
     #[serde(default)]
@@ -68,6 +82,8 @@ pub struct PlanRuntime {
     pub active_job_id: Option<String>,
     #[serde(default)]
     pub jobs: Vec<PlanJobRecord>,
+    #[serde(default)]
+    pub followup: Option<PlanFollowup>,
 }
 
 impl PlanRuntime {
@@ -76,7 +92,10 @@ impl PlanRuntime {
     }
 
     pub fn is_empty(&self) -> bool {
-        !self.has_active_state() && self.active_job_id.is_none() && self.jobs.is_empty()
+        !self.has_active_state()
+            && self.active_job_id.is_none()
+            && self.jobs.is_empty()
+            && self.followup.is_none()
     }
 
     pub fn set_active_tool_state(
@@ -111,6 +130,7 @@ impl PlanRuntime {
             output_preview: None,
             has_error_output: false,
         });
+        self.followup = None;
         job_id
     }
 
@@ -183,6 +203,38 @@ impl PlanRuntime {
         self.clear_active_state();
     }
 
+    pub fn set_checkpoint_followup(&mut self, step: impl Into<String>, next_step: Option<String>) {
+        self.followup = Some(PlanFollowup::Checkpoint {
+            step: step.into(),
+            next_step,
+        });
+    }
+
+    pub fn set_retry_or_replan_followup(
+        &mut self,
+        step: impl Into<String>,
+        command: Option<String>,
+    ) {
+        let step = step.into();
+        let retry_count = match self.followup.as_ref() {
+            Some(PlanFollowup::RetryOrReplan {
+                step: existing_step,
+                retry_count,
+                ..
+            }) if existing_step == &step => retry_count.saturating_add(1),
+            _ => 1,
+        };
+        self.followup = Some(PlanFollowup::RetryOrReplan {
+            step,
+            command,
+            retry_count,
+        });
+    }
+
+    pub fn clear_followup(&mut self) {
+        self.followup = None;
+    }
+
     pub fn clear_active_state(&mut self) {
         self.active_tool = None;
         self.active_command = None;
@@ -225,7 +277,7 @@ pub struct PlanState {
 
 #[cfg(test)]
 mod tests {
-    use super::{PlanJobStatus, PlanRuntime};
+    use super::{PlanFollowup, PlanJobStatus, PlanRuntime};
 
     #[test]
     fn runtime_deserializes_legacy_shape_with_empty_jobs() {
@@ -263,5 +315,22 @@ mod tests {
         assert!(runtime.active_job_id.is_none());
         assert!(!runtime.has_active_state());
         assert_eq!(runtime.jobs[0].status, PlanJobStatus::Succeeded);
+    }
+
+    #[test]
+    fn runtime_retry_followup_counts_repeated_failures() {
+        let mut runtime = PlanRuntime::default();
+
+        runtime.set_retry_or_replan_followup("Patch handler", Some("cargo test".to_string()));
+        runtime.set_retry_or_replan_followup("Patch handler", Some("cargo test".to_string()));
+
+        assert_eq!(
+            runtime.followup,
+            Some(PlanFollowup::RetryOrReplan {
+                step: "Patch handler".to_string(),
+                command: Some("cargo test".to_string()),
+                retry_count: 2,
+            })
+        );
     }
 }

--- a/lib/harper-core/src/core/plan_events.rs
+++ b/lib/harper-core/src/core/plan_events.rs
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 use crate::core::plan::PlanState;
+use ring::digest::{digest, SHA256};
+use std::collections::HashSet;
+use std::fs;
+use std::net::UdpSocket;
+use std::path::PathBuf;
+use std::sync::Mutex;
 use std::sync::OnceLock;
 use tokio::sync::broadcast;
 
@@ -20,10 +26,11 @@ use tokio::sync::broadcast;
 pub struct PlanUpdateEvent {
     pub event_id: i64,
     pub session_id: String,
-    pub plan: PlanState,
+    pub plan: Option<PlanState>,
 }
 
 static PLAN_UPDATES: OnceLock<broadcast::Sender<PlanUpdateEvent>> = OnceLock::new();
+static PLAN_EVENT_LISTENERS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 fn sender() -> &'static broadcast::Sender<PlanUpdateEvent> {
     PLAN_UPDATES.get_or_init(|| {
@@ -36,7 +43,7 @@ pub fn subscribe() -> broadcast::Receiver<PlanUpdateEvent> {
     sender().subscribe()
 }
 
-pub fn notify(event_id: i64, session_id: &str, plan: PlanState) {
+pub fn notify(event_id: i64, session_id: &str, plan: Option<PlanState>) {
     let _ = sender().send(PlanUpdateEvent {
         event_id,
         session_id: session_id.to_string(),
@@ -44,21 +51,222 @@ pub fn notify(event_id: i64, session_id: &str, plan: PlanState) {
     });
 }
 
+fn listener_registry() -> &'static Mutex<HashSet<String>> {
+    PLAN_EVENT_LISTENERS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn registry_dir(db_key: &str) -> PathBuf {
+    let digest = digest(&SHA256, db_key.as_bytes());
+    let hex = digest
+        .as_ref()
+        .iter()
+        .take(8)
+        .map(|byte| format!("{:02x}", byte))
+        .collect::<String>();
+    std::env::temp_dir().join("hp-plan").join(hex)
+}
+
+fn listener_registry_path(db_key: &str, port: u16) -> PathBuf {
+    registry_dir(db_key).join(format!("{}.port", port))
+}
+
+fn signal_file_path(db_key: &str) -> PathBuf {
+    registry_dir(db_key).join("signal")
+}
+
+fn parse_signal_payload(payload: &str) -> Option<(i64, String)> {
+    let (event_id, session_id) = payload.trim().split_once('\t')?;
+    let event_id = event_id.parse::<i64>().ok()?;
+    Some((event_id, session_id.to_string()))
+}
+
+pub fn ensure_cross_process_listener(db_key: &str) -> bool {
+    let mut started = listener_registry()
+        .lock()
+        .expect("plan event listener registry lock");
+    if !started.insert(db_key.to_string()) {
+        return true;
+    }
+    drop(started);
+
+    let dir = registry_dir(db_key);
+    if fs::create_dir_all(&dir).is_err() {
+        let mut started = listener_registry()
+            .lock()
+            .expect("plan event listener registry lock");
+        started.remove(db_key);
+        return false;
+    }
+
+    let signal_path = signal_file_path(db_key);
+    std::thread::spawn(move || {
+        let mut last_seen_event_id: Option<i64> = None;
+        loop {
+            if let Ok(payload) = fs::read_to_string(&signal_path) {
+                if let Some((event_id, session_id)) = parse_signal_payload(&payload) {
+                    if Some(event_id) > last_seen_event_id {
+                        last_seen_event_id = Some(event_id);
+                        notify(event_id, &session_id, None);
+                    }
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    });
+
+    let Ok(socket) = UdpSocket::bind(("127.0.0.1", 0)) else {
+        return true;
+    };
+    let Ok(address) = socket.local_addr() else {
+        return true;
+    };
+    let registry_path = listener_registry_path(db_key, address.port());
+    let _ = fs::write(&registry_path, address.port().to_string());
+    std::thread::spawn(move || {
+        let mut buf = [0_u8; 1024];
+        while let Ok(size) = socket.recv(&mut buf) {
+            let Ok(payload) = std::str::from_utf8(&buf[..size]) else {
+                continue;
+            };
+            let Some((event_id, session_id)) = parse_signal_payload(payload) else {
+                continue;
+            };
+            notify(event_id, &session_id, None);
+        }
+        let _ = fs::remove_file(&registry_path);
+    });
+    true
+}
+
+pub fn notify_cross_process(db_key: &str, event_id: i64, session_id: &str) {
+    let dir = registry_dir(db_key);
+    let signal_path = signal_file_path(db_key);
+    let payload = format!("{}\t{}", event_id, session_id);
+    let _ = fs::create_dir_all(&dir);
+    let _ = fs::write(&signal_path, &payload);
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return;
+    };
+    let Ok(sender) = UdpSocket::bind(("127.0.0.1", 0)) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("port") {
+            continue;
+        }
+        let Ok(port_text) = fs::read_to_string(&path) else {
+            let _ = fs::remove_file(path);
+            continue;
+        };
+        let Ok(port) = port_text.trim().parse::<u16>() else {
+            let _ = fs::remove_file(path);
+            continue;
+        };
+        if sender
+            .send_to(payload.as_bytes(), ("127.0.0.1", port))
+            .is_err()
+        {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{notify, subscribe};
+    use super::{
+        ensure_cross_process_listener, listener_registry_path, notify, notify_cross_process,
+        parse_signal_payload, signal_file_path, subscribe,
+    };
     use crate::core::plan::PlanState;
+    use std::fs;
+    use std::net::UdpSocket;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_test_db_key(prefix: &str) -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        format!("{}-{}-{}", prefix, std::process::id(), nanos)
+    }
 
     #[tokio::test]
     async fn broadcasts_plan_updates() {
         let mut rx = subscribe();
         let plan = PlanState::default();
 
-        notify(42, "session-a", plan.clone());
+        notify(42, "session-a", Some(plan.clone()));
 
         let event = rx.recv().await.expect("event");
         assert_eq!(event.event_id, 42);
         assert_eq!(event.session_id, "session-a");
-        assert_eq!(event.plan, plan);
+        assert_eq!(event.plan, Some(plan));
+    }
+
+    #[test]
+    fn cross_process_notifier_sends_socket_payload() {
+        let db_key = unique_test_db_key("plan-event-test");
+        let socket = match UdpSocket::bind(("127.0.0.1", 0)) {
+            Ok(socket) => socket,
+            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+                return;
+            }
+            Err(err) => panic!("bind test listener: {}", err),
+        };
+        let port = socket.local_addr().expect("listener address").port();
+        let path = listener_registry_path(&db_key, port);
+        fs::create_dir_all(path.parent().expect("registry dir")).expect("create notifier dir");
+        fs::write(&path, port.to_string()).expect("write notifier port");
+
+        notify_cross_process(&db_key, 7, "session-z");
+
+        let mut buf = [0_u8; 256];
+        let size = socket.recv(&mut buf).expect("receive notifier payload");
+        let payload = std::str::from_utf8(&buf[..size]).expect("utf8 payload");
+        assert_eq!(payload, "7\tsession-z");
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn cross_process_listener_rebroadcasts_updates_to_subscribers() {
+        let db_key = unique_test_db_key("plan-listener-test");
+        assert!(ensure_cross_process_listener(&db_key));
+        let mut rx = subscribe();
+
+        notify_cross_process(&db_key, 9, "session-b");
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let event = rx.recv().await.expect("cross-process event");
+                if event.event_id == 9 && event.session_id == "session-b" {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("timeout waiting for cross-process event");
+        assert_eq!(event.event_id, 9);
+        assert_eq!(event.session_id, "session-b");
+        assert_eq!(event.plan, None);
+    }
+
+    #[test]
+    fn parse_signal_payload_reads_event_and_session() {
+        let parsed = parse_signal_payload("41\tsession-y\n").expect("payload");
+        assert_eq!(parsed.0, 41);
+        assert_eq!(parsed.1, "session-y");
+    }
+
+    #[test]
+    fn notify_cross_process_writes_signal_file() {
+        let db_key = unique_test_db_key("plan-signal-file-test");
+
+        notify_cross_process(&db_key, 11, "session-c");
+
+        let signal_path = signal_file_path(&db_key);
+        let payload = fs::read_to_string(signal_path).expect("signal payload");
+        assert_eq!(payload, "11\tsession-c");
     }
 }

--- a/lib/harper-core/src/lib.rs
+++ b/lib/harper-core/src/lib.rs
@@ -76,7 +76,7 @@ mod tests {
             provider: ApiProvider::OpenAI,
             api_key: "test-key".to_string(),
             base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-            model_name: "gpt-4".to_string(),
+            model_name: "gpt-5.5".to_string(),
         }
     }
 
@@ -100,13 +100,13 @@ mod tests {
             provider: ApiProvider::OpenAI,
             api_key: "test-key".to_string(),
             base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-            model_name: "gpt-4".to_string(),
+            model_name: "gpt-5.5".to_string(),
         };
 
         assert!(matches!(config.provider, ApiProvider::OpenAI));
         assert_eq!(config.api_key, "test-key");
         assert!(config.base_url.contains("openai.com"));
-        assert_eq!(config.model_name, "gpt-4");
+        assert_eq!(config.model_name, "gpt-5.5");
     }
 
     #[test]
@@ -163,12 +163,12 @@ mod tests {
         let chat_service = ChatService::new_test(&conn, &config);
 
         let prompt = chat_service.build_system_prompt(false).await;
-        assert!(prompt.contains("gpt-4"));
+        assert!(prompt.contains("gpt-5.5"));
         assert!(prompt.contains("run_command"));
         assert!(!prompt.contains("SEARCH:"));
 
         let prompt = chat_service.build_system_prompt(true).await;
-        assert!(prompt.contains("gpt-4"));
+        assert!(prompt.contains("gpt-5.5"));
         assert!(prompt.contains("run_command"));
         assert!(prompt.contains("SEARCH:"));
         Ok(())

--- a/lib/harper-core/src/memory/storage/mod.rs
+++ b/lib/harper-core/src/memory/storage/mod.rs
@@ -321,8 +321,41 @@ pub fn save_plan_state(conn: &Connection, session_id: &str, plan: &PlanState) ->
     )?;
     save_plan_runtime(conn, session_id, plan.runtime.as_ref())?;
     let event_id = insert_plan_event(conn, session_id)?;
-    crate::core::plan_events::notify(event_id, session_id, plan.clone());
+    crate::core::plan_events::notify(event_id, session_id, Some(plan.clone()));
+    if let Some(db_key) = database_key(conn) {
+        crate::core::plan_events::notify_cross_process(&db_key, event_id, session_id);
+    }
     Ok(())
+}
+
+pub fn delete_plan_state(conn: &Connection, session_id: &str) -> HarperResult<()> {
+    conn.execute(
+        "DELETE FROM session_plans WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    conn.execute(
+        "DELETE FROM session_plan_runtime WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    let event_id = insert_plan_event(conn, session_id)?;
+    crate::core::plan_events::notify(event_id, session_id, None);
+    if let Some(db_key) = database_key(conn) {
+        crate::core::plan_events::notify_cross_process(&db_key, event_id, session_id);
+    }
+    Ok(())
+}
+
+fn database_key(conn: &Connection) -> Option<String> {
+    let mut stmt = conn.prepare("PRAGMA database_list").ok()?;
+    let mut rows = stmt.query([]).ok()?;
+    while let Ok(Some(row)) = rows.next() {
+        let name: String = row.get(1).ok()?;
+        let path: String = row.get(2).ok()?;
+        if name == "main" && !path.trim().is_empty() {
+            return Some(path);
+        }
+    }
+    None
 }
 
 fn insert_plan_event(conn: &Connection, session_id: &str) -> HarperResult<i64> {

--- a/lib/harper-core/src/runtime/config.rs
+++ b/lib/harper-core/src/runtime/config.rs
@@ -106,6 +106,9 @@ pub struct ExecPolicyConfig {
     pub blocked_commands: Option<Vec<String>>,
     pub sandbox_profile: Option<SandboxProfile>,
     pub sandbox: Option<SandboxConfig>,
+    pub retry_max_attempts: Option<u32>,
+    pub retry_network_commands: Option<Vec<String>>,
+    pub retry_write_commands: Option<Vec<String>>,
 }
 
 impl Default for ExecPolicyConfig {
@@ -123,6 +126,9 @@ impl Default for ExecPolicyConfig {
                 readonly_home: Some(false),
                 max_execution_time_secs: None,
             }),
+            retry_max_attempts: Some(1),
+            retry_network_commands: Some(vec!["curl".to_string(), "wget".to_string()]),
+            retry_write_commands: Some(vec!["mkdir".to_string(), "touch".to_string()]),
         }
     }
 }
@@ -536,6 +542,24 @@ impl ExecPolicyConfig {
 
         effective
     }
+
+    pub fn effective_retry_max_attempts(&self) -> u32 {
+        self.retry_max_attempts.unwrap_or(1)
+    }
+
+    pub fn retries_network_command(&self, command: &str) -> bool {
+        self.retry_network_commands
+            .as_ref()
+            .map(|commands| commands.iter().any(|configured| configured == command))
+            .unwrap_or_else(|| matches!(command, "curl" | "wget"))
+    }
+
+    pub fn retries_write_command(&self, command: &str) -> bool {
+        self.retry_write_commands
+            .as_ref()
+            .map(|commands| commands.iter().any(|configured| configured == command))
+            .unwrap_or_else(|| matches!(command, "mkdir" | "touch"))
+    }
 }
 
 impl CustomCommandsConfig {
@@ -744,6 +768,9 @@ mod tests {
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Workspace),
             sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
 
         let sandbox = config.effective_sandbox_config();
@@ -770,6 +797,9 @@ mod tests {
                 readonly_home: None,
                 max_execution_time_secs: Some(5),
             }),
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
 
         let sandbox = config.effective_sandbox_config();

--- a/lib/harper-core/src/server/mod.rs
+++ b/lib/harper-core/src/server/mod.rs
@@ -707,51 +707,95 @@ pub async fn get_session_plan_stream(
     let initial_json =
         serde_json::to_string(&initial_payload).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let last_event_id = load_latest_plan_event_id(&state, &session_id)?;
+    let has_push_listener = database_key_from_state(&state)
+        .map(|db_key| plan_events::ensure_cross_process_listener(&db_key))
+        .unwrap_or(false);
 
     let receiver = plan_events::subscribe();
     let stream = stream::unfold(
-        (state.clone(), receiver, session_id, user, last_event_id),
-        |(state, mut receiver, session_id, user, mut last_event_id)| async move {
+        (
+            state.clone(),
+            receiver,
+            session_id,
+            user,
+            last_event_id,
+            has_push_listener,
+        ),
+        |(state, mut receiver, session_id, user, mut last_event_id, has_push_listener)| async move {
             loop {
-                let sleep = tokio::time::sleep(Duration::from_millis(500));
-                tokio::pin!(sleep);
-
-                tokio::select! {
-                    recv = receiver.recv() => {
-                        match recv {
-                            Ok(update) if update.session_id == session_id => {
-                                last_event_id = Some(update.event_id);
-                                let next_json = match serde_json::to_string(&update.plan) {
-                                    Ok(json) => json,
-                                    Err(_) => return None,
-                                };
-                                let event = Event::default().event("plan").data(next_json);
-                                return Some((Ok(event), (state, receiver, session_id, user, last_event_id)));
-                            }
-                            Ok(_) => continue,
-                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
-                        }
+                let recv_result = if has_push_listener {
+                    receiver.recv().await
+                } else {
+                    let sleep = tokio::time::sleep(Duration::from_millis(500));
+                    tokio::pin!(sleep);
+                    tokio::select! {
+                        recv = receiver.recv() => recv,
+                        _ = &mut sleep => Err(tokio::sync::broadcast::error::RecvError::Lagged(0)),
                     }
-                    _ = &mut sleep => {
+                };
+
+                match recv_result {
+                    Ok(update) if update.session_id == session_id => {
+                        last_event_id = Some(update.event_id);
+                        let plan = match update.plan {
+                            Some(plan) => serde_json::json!(Some(plan)),
+                            None => {
+                                match load_session_plan_value(&state, &session_id, user.as_ref()) {
+                                    Ok(plan) => plan,
+                                    Err(_) => return None,
+                                }
+                            }
+                        };
+                        let next_json = match serde_json::to_string(&plan) {
+                            Ok(json) => json,
+                            Err(_) => return None,
+                        };
+                        let event = Event::default().event("plan").data(next_json);
+                        return Some((
+                            Ok(event),
+                            (
+                                state,
+                                receiver,
+                                session_id,
+                                user,
+                                last_event_id,
+                                has_push_listener,
+                            ),
+                        ));
+                    }
+                    Ok(_) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
                         let latest_event_id = match load_latest_plan_event_id(&state, &session_id) {
                             Ok(event_id) => event_id,
                             Err(_) => return None,
                         };
                         if latest_event_id.is_some() && latest_event_id > last_event_id {
-                            let plan = match load_session_plan_value(&state, &session_id, user.as_ref()) {
-                                Ok(plan) => plan,
-                                Err(_) => return None,
-                            };
+                            let plan =
+                                match load_session_plan_value(&state, &session_id, user.as_ref()) {
+                                    Ok(plan) => plan,
+                                    Err(_) => return None,
+                                };
                             let next_json = match serde_json::to_string(&plan) {
                                 Ok(json) => json,
                                 Err(_) => return None,
                             };
                             last_event_id = latest_event_id;
                             let event = Event::default().event("plan").data(next_json);
-                            return Some((Ok(event), (state, receiver, session_id, user, last_event_id)));
+                            return Some((
+                                Ok(event),
+                                (
+                                    state,
+                                    receiver,
+                                    session_id,
+                                    user,
+                                    last_event_id,
+                                    has_push_listener,
+                                ),
+                            ));
                         }
+                        continue;
                     }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
                 }
             }
         },
@@ -775,6 +819,23 @@ fn load_latest_plan_event_id(
         .expect("Failed to lock database connection");
     crate::memory::storage::load_latest_plan_event_id(&conn, session_id)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn database_key_from_state(state: &ServerState) -> Option<String> {
+    let conn = state
+        .conn
+        .lock()
+        .expect("Failed to lock database connection");
+    let mut stmt = conn.prepare("PRAGMA database_list").ok()?;
+    let mut rows = stmt.query([]).ok()?;
+    while let Ok(Some(row)) = rows.next() {
+        let name: String = row.get(1).ok()?;
+        let path: String = row.get(2).ok()?;
+        if name == "main" && !path.trim().is_empty() {
+            return Some(path);
+        }
+    }
+    None
 }
 
 pub async fn delete_session(
@@ -2110,7 +2171,7 @@ mod tests {
                 provider: ApiProvider::OpenAI,
                 api_key: "test-key".to_string(),
                 base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-                model_name: "gpt-4".to_string(),
+                model_name: "gpt-5.5".to_string(),
             },
             client: Client::new(),
             exec_policy: crate::runtime::config::ExecPolicyConfig::default(),
@@ -2145,7 +2206,7 @@ mod tests {
                 provider: ApiProvider::OpenAI,
                 api_key: "test-key".to_string(),
                 base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-                model_name: "gpt-4".to_string(),
+                model_name: "gpt-5.5".to_string(),
             },
             client: Client::new(),
             exec_policy: ExecPolicyConfig::default(),
@@ -2255,6 +2316,7 @@ mod tests {
                             output_preview: Some("echo hi".to_string()),
                             has_error_output: false,
                         }],
+                        followup: None,
                     }),
                     updated_at: None,
                 },
@@ -2307,6 +2369,7 @@ mod tests {
                             output_preview: Some("echo hi".to_string()),
                             has_error_output: false,
                         }],
+                        followup: None,
                     }),
                     updated_at: None,
                 },
@@ -2358,6 +2421,7 @@ mod tests {
                             output_preview: Some("echo hi".to_string()),
                             has_error_output: false,
                         }],
+                        followup: None,
                     }),
                     updated_at: None,
                 },

--- a/lib/harper-core/src/tools/mod.rs
+++ b/lib/harper-core/src/tools/mod.rs
@@ -68,6 +68,12 @@ pub struct ToolService<'a> {
     runtime_events: Option<Arc<dyn RuntimeEventSink>>,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct PlanSyncOutcome {
+    completed_step: Option<String>,
+    next_step: Option<String>,
+}
+
 impl<'a> ToolService<'a> {
     fn parse_run_command_sandbox_intent(args: &serde_json::Value) -> shell::CommandSandboxIntent {
         shell::CommandSandboxIntent {
@@ -91,6 +97,15 @@ impl<'a> ToolService<'a> {
                 .get("requires_network")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false),
+            retry_policy: args
+                .get("retry_policy")
+                .and_then(|v| v.as_str())
+                .and_then(|value| {
+                    serde_json::from_value::<shell::CommandRetryPolicy>(serde_json::Value::String(
+                        value.to_string(),
+                    ))
+                    .ok()
+                }),
         }
     }
 
@@ -742,7 +757,7 @@ impl<'a> ToolService<'a> {
         tool_output: &str,
     ) -> Result<String, HarperError> {
         self.emit_activity_update(Some("thinking".to_string()));
-        self.sync_plan_after_tool(tool_call_json)?;
+        let plan_sync_outcome = self.sync_plan_after_tool(tool_call_json)?;
         // Create a new history vector by cloning the existing one
         let mut new_history = history.to_vec();
 
@@ -767,7 +782,7 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
             tool_output
         );
         if !Self::is_update_plan_call(tool_call_json) {
-            if let Some(plan_instruction) = self.plan_followup_instruction()? {
+            if let Some(plan_instruction) = self.plan_followup_instruction(&plan_sync_outcome)? {
                 system_message.push_str("\n5. ");
                 system_message.push_str(&plan_instruction);
             }
@@ -828,67 +843,74 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
         Ok(())
     }
 
-    fn sync_plan_after_tool(&self, tool_call_json: &str) -> HarperResult<()> {
+    fn sync_plan_after_tool(&self, tool_call_json: &str) -> HarperResult<PlanSyncOutcome> {
         let Some(session_id) = self.session_id else {
-            return Ok(());
+            return Ok(PlanSyncOutcome::default());
         };
         let Some(mut plan) = crate::memory::storage::load_plan_state(self.conn, session_id)? else {
-            return Ok(());
+            return Ok(PlanSyncOutcome::default());
         };
         let Some(current_index) = plan
             .items
             .iter()
             .position(|item| matches!(item.status, crate::core::plan::PlanStepStatus::InProgress))
         else {
-            return Ok(());
+            return Ok(PlanSyncOutcome::default());
         };
 
         let tool_name = Self::tool_name_from_call(tool_call_json);
         let Some(tool_name) = tool_name else {
-            return Ok(());
+            return Ok(PlanSyncOutcome::default());
         };
         if !Self::is_safe_auto_advance_tool(&tool_name) {
-            if let Some(runtime) = plan.runtime.as_mut() {
-                runtime.clear_active_state();
-                if runtime.is_empty() {
-                    plan.runtime = None;
-                }
-                crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
-            }
-            return Ok(());
+            let mut runtime = plan.runtime.take().unwrap_or_default();
+            runtime.clear_active_state();
+            let current_step = plan.items[current_index].step.clone();
+            runtime.set_checkpoint_followup(current_step, None);
+            plan.runtime = (!runtime.is_empty()).then_some(runtime);
+            crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
+            return Ok(PlanSyncOutcome::default());
         }
 
         let step_text = plan.items[current_index].step.to_ascii_lowercase();
         if !Self::step_matches_safe_tool(&step_text, &tool_name) {
-            if let Some(runtime) = plan.runtime.as_mut() {
-                runtime.clear_active_state();
-                if runtime.is_empty() {
-                    plan.runtime = None;
-                }
-                crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
-            }
-            return Ok(());
+            let mut runtime = plan.runtime.take().unwrap_or_default();
+            runtime.clear_active_state();
+            let current_step = plan.items[current_index].step.clone();
+            runtime.set_checkpoint_followup(current_step, None);
+            plan.runtime = (!runtime.is_empty()).then_some(runtime);
+            crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
+            return Ok(PlanSyncOutcome::default());
         }
 
+        let completed_step = plan.items[current_index].step.clone();
         plan.items[current_index].status = crate::core::plan::PlanStepStatus::Completed;
-        if let Some(next_pending) = plan
+        let next_step = if let Some(next_pending) = plan
             .items
             .iter_mut()
             .find(|item| matches!(item.status, crate::core::plan::PlanStepStatus::Pending))
         {
+            let next_step = next_pending.step.clone();
             next_pending.status = crate::core::plan::PlanStepStatus::InProgress;
-        }
-        if let Some(runtime) = plan.runtime.as_mut() {
-            runtime.clear_active_state();
-            if runtime.is_empty() {
-                plan.runtime = None;
-            }
-        }
+            Some(next_step)
+        } else {
+            None
+        };
+        let mut runtime = plan.runtime.take().unwrap_or_default();
+        runtime.clear_active_state();
+        runtime.set_checkpoint_followup(completed_step.clone(), next_step.clone());
+        plan.runtime = (!runtime.is_empty()).then_some(runtime);
         crate::memory::storage::save_plan_state(self.conn, session_id, &plan)?;
-        Ok(())
+        Ok(PlanSyncOutcome {
+            completed_step: Some(completed_step),
+            next_step,
+        })
     }
 
-    fn plan_followup_instruction(&self) -> HarperResult<Option<String>> {
+    fn plan_followup_instruction(
+        &self,
+        sync_outcome: &PlanSyncOutcome,
+    ) -> HarperResult<Option<String>> {
         let Some(session_id) = self.session_id else {
             return Ok(None);
         };
@@ -904,6 +926,76 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
             .any(|item| !matches!(item.status, crate::core::plan::PlanStepStatus::Completed));
         if !has_remaining {
             return Ok(None);
+        }
+
+        if let Some(followup) = plan
+            .runtime
+            .as_ref()
+            .and_then(|runtime| runtime.followup.as_ref())
+        {
+            match followup {
+                crate::core::plan::PlanFollowup::RetryOrReplan {
+                    step,
+                    command,
+                    retry_count,
+                } => {
+                    let command = command.as_deref().unwrap_or(step.as_str());
+                    if *retry_count <= 1 {
+                        return Ok(Some(format!(
+                            "The current plan step '{}' just failed while running '{}'. Retry once if the issue looks transient; otherwise call update_plan to revise the remaining work.",
+                            step, command
+                        )));
+                    }
+                    return Ok(Some(format!(
+                        "The current plan step '{}' has already failed {} times while running '{}'. Do not keep retrying blindly; call update_plan to revise or de-scope the remaining work.",
+                        step, retry_count, command
+                    )));
+                }
+                crate::core::plan::PlanFollowup::Checkpoint { step, next_step } => {
+                    let next_clause = next_step
+                        .as_deref()
+                        .map(|next_step| {
+                            format!(
+                                " Continue with '{}' only after summarizing what changed.",
+                                next_step
+                            )
+                        })
+                        .unwrap_or_else(|| {
+                            " If that closed the task, confirm completion instead of repeating the plan."
+                                .to_string()
+                        });
+                    return Ok(Some(format!(
+                        "Plan checkpoint: '{}' advanced. Briefly summarize what changed before continuing.{}",
+                        step, next_clause
+                    )));
+                }
+            }
+        }
+
+        if let Some(blocked_step) = plan
+            .items
+            .iter()
+            .find(|item| matches!(item.status, crate::core::plan::PlanStepStatus::Blocked))
+        {
+            return Ok(Some(format!(
+                "A session plan is blocked at step '{}'. Before more tool work, call update_plan to explain the blocker, retry, or revise the remaining steps.",
+                blocked_step.step
+            )));
+        }
+
+        if let Some(completed_step) = sync_outcome.completed_step.as_deref() {
+            let next_clause = sync_outcome
+                .next_step
+                .as_deref()
+                .map(|step| format!(" Continue with '{}' once the checkpoint is clear.", step))
+                .unwrap_or_else(|| {
+                    " If that closed the task, confirm completion instead of repeating the plan."
+                        .to_string()
+                });
+            return Ok(Some(format!(
+                "Plan checkpoint: '{}' just completed. Briefly summarize what changed before continuing.{}",
+                completed_step, next_clause
+            )));
         }
 
         Ok(Some(
@@ -1065,7 +1157,7 @@ fn extract_target_paths_from_json(
 
 #[cfg(test)]
 mod tests {
-    use super::ToolService;
+    use super::{PlanSyncOutcome, ToolService};
     use crate::core::plan::{PlanItem, PlanState, PlanStepStatus};
     use crate::core::{ApiConfig, ApiProvider};
     use crate::runtime::config::ExecPolicyConfig;
@@ -1078,7 +1170,7 @@ mod tests {
             provider: ApiProvider::OpenAI,
             api_key: "test-key".to_string(),
             base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-            model_name: "gpt-4".to_string(),
+            model_name: "gpt-5.5".to_string(),
         }
     }
 
@@ -1179,6 +1271,54 @@ mod tests {
     }
 
     #[test]
+    fn sync_plan_after_tool_returns_checkpoint_summary_state() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "checkpoint-session",
+            &PlanState {
+                explanation: Some("Testing checkpoint".to_string()),
+                items: vec![
+                    PlanItem {
+                        step: "Inspect server file".to_string(),
+                        status: PlanStepStatus::InProgress,
+                        job_id: None,
+                    },
+                    PlanItem {
+                        step: "Patch handler".to_string(),
+                        status: PlanStepStatus::Pending,
+                        job_id: None,
+                    },
+                ],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let service = ToolService::new(
+            &conn,
+            &config,
+            &exec_policy,
+            None,
+            Some("checkpoint-session"),
+        );
+
+        let outcome = service
+            .sync_plan_after_tool(r#"{"tool":"read_file","args":{"path":"src/server.rs"}}"#)
+            .expect("sync plan after tool");
+
+        assert_eq!(
+            outcome.completed_step.as_deref(),
+            Some("Inspect server file")
+        );
+        assert_eq!(outcome.next_step.as_deref(), Some("Patch handler"));
+    }
+
+    #[test]
     fn sync_plan_after_tool_does_not_complete_write_step() {
         let conn = Connection::open_in_memory().expect("in-memory db");
         crate::memory::storage::init_db(&conn).expect("init db");
@@ -1216,6 +1356,193 @@ mod tests {
             .expect("load plan")
             .expect("plan present");
         assert_eq!(plan.items[0].status, PlanStepStatus::InProgress);
+        assert!(matches!(
+            plan.runtime.as_ref().and_then(|runtime| runtime.followup.as_ref()),
+            Some(crate::core::plan::PlanFollowup::Checkpoint {
+                step,
+                next_step: None
+            }) if step == "Patch handler"
+        ));
+    }
+
+    #[test]
+    fn plan_followup_instruction_prioritizes_blocked_steps() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "blocked-followup-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Retry the failing command".to_string(),
+                    status: PlanStepStatus::Blocked,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let service = ToolService::new(
+            &conn,
+            &config,
+            &exec_policy,
+            None,
+            Some("blocked-followup-session"),
+        );
+
+        let instruction = service
+            .plan_followup_instruction(&PlanSyncOutcome::default())
+            .expect("followup")
+            .expect("instruction present");
+
+        assert!(instruction.contains("blocked at step 'Retry the failing command'"));
+        assert!(instruction.contains("call update_plan"));
+    }
+
+    #[test]
+    fn plan_followup_instruction_uses_checkpoint_summary_for_completed_step() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "checkpoint-followup-session",
+            &PlanState {
+                explanation: None,
+                items: vec![
+                    PlanItem {
+                        step: "Inspect server file".to_string(),
+                        status: PlanStepStatus::Completed,
+                        job_id: None,
+                    },
+                    PlanItem {
+                        step: "Patch handler".to_string(),
+                        status: PlanStepStatus::InProgress,
+                        job_id: None,
+                    },
+                ],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let service = ToolService::new(
+            &conn,
+            &config,
+            &exec_policy,
+            None,
+            Some("checkpoint-followup-session"),
+        );
+
+        let instruction = service
+            .plan_followup_instruction(&PlanSyncOutcome {
+                completed_step: Some("Inspect server file".to_string()),
+                next_step: Some("Patch handler".to_string()),
+            })
+            .expect("followup")
+            .expect("instruction present");
+
+        assert!(instruction.contains("Plan checkpoint: 'Inspect server file' just completed."));
+        assert!(instruction.contains("Continue with 'Patch handler'"));
+    }
+
+    #[test]
+    fn plan_followup_instruction_requests_retry_once_for_first_failure() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "retry-followup-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Run migration".to_string(),
+                    status: PlanStepStatus::Blocked,
+                    job_id: None,
+                }],
+                runtime: Some(crate::core::plan::PlanRuntime {
+                    followup: Some(crate::core::plan::PlanFollowup::RetryOrReplan {
+                        step: "Run migration".to_string(),
+                        command: Some("cargo test".to_string()),
+                        retry_count: 1,
+                    }),
+                    ..Default::default()
+                }),
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let service = ToolService::new(
+            &conn,
+            &config,
+            &exec_policy,
+            None,
+            Some("retry-followup-session"),
+        );
+
+        let instruction = service
+            .plan_followup_instruction(&PlanSyncOutcome::default())
+            .expect("followup")
+            .expect("instruction present");
+
+        assert!(instruction.contains("Retry once if the issue looks transient"));
+        assert!(instruction.contains("Run migration"));
+    }
+
+    #[test]
+    fn plan_followup_instruction_stops_repeated_retries() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "retry-limit-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Run migration".to_string(),
+                    status: PlanStepStatus::Blocked,
+                    job_id: None,
+                }],
+                runtime: Some(crate::core::plan::PlanRuntime {
+                    followup: Some(crate::core::plan::PlanFollowup::RetryOrReplan {
+                        step: "Run migration".to_string(),
+                        command: Some("cargo test".to_string()),
+                        retry_count: 2,
+                    }),
+                    ..Default::default()
+                }),
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let service = ToolService::new(
+            &conn,
+            &config,
+            &exec_policy,
+            None,
+            Some("retry-limit-session"),
+        );
+
+        let instruction = service
+            .plan_followup_instruction(&PlanSyncOutcome::default())
+            .expect("followup")
+            .expect("instruction present");
+
+        assert!(instruction.contains("Do not keep retrying blindly"));
+        assert!(instruction.contains("already failed 2 times"));
     }
 
     #[test]
@@ -1238,7 +1565,8 @@ mod tests {
             "command": "cp ./src.txt ./build/out.txt",
             "declared_read_paths": ["./src.txt"],
             "declared_write_paths": ["./build/out.txt"],
-            "requires_network": true
+            "requires_network": true,
+            "retry_policy": "safe"
         }));
 
         assert_eq!(intent.declared_read_paths, vec![PathBuf::from("./src.txt")]);
@@ -1247,5 +1575,9 @@ mod tests {
             vec![PathBuf::from("./build/out.txt")]
         );
         assert!(intent.requires_network);
+        assert_eq!(
+            intent.retry_policy,
+            Some(crate::tools::shell::CommandRetryPolicy::Safe)
+        );
     }
 }

--- a/lib/harper-core/src/tools/plan.rs
+++ b/lib/harper-core/src/tools/plan.rs
@@ -150,6 +150,28 @@ pub fn update_active_plan_job(
     })
 }
 
+pub fn record_active_plan_retry_followup(
+    conn: &Connection,
+    session_id: &str,
+    command: Option<String>,
+) -> HarperResult<()> {
+    let Some(mut plan) = crate::memory::storage::load_plan_state(conn, session_id)? else {
+        return Ok(());
+    };
+    let Some(step) = plan
+        .items
+        .iter()
+        .find(|item| matches!(item.status, PlanStepStatus::InProgress))
+        .map(|item| item.step.clone())
+    else {
+        return Ok(());
+    };
+    let mut runtime = plan.runtime.unwrap_or_default();
+    runtime.set_retry_or_replan_followup(step, command);
+    plan.runtime = (!runtime.is_empty()).then_some(runtime);
+    crate::memory::storage::save_plan_state(conn, session_id, &plan)
+}
+
 pub fn finish_active_plan_job(
     conn: &Connection,
     session_id: &str,
@@ -181,20 +203,41 @@ pub fn finish_active_plan_job_with_output(
             .iter()
             .position(|item| item.job_id.as_deref() == Some(active_job_id.as_str()))
         {
+            let step_text = plan.items[item_index].step.clone();
+            let job_command = runtime
+                .jobs
+                .iter()
+                .rev()
+                .find(|job| job.job_id == active_job_id)
+                .and_then(|job| job.command.clone())
+                .or_else(|| {
+                    runtime
+                        .jobs
+                        .iter()
+                        .rev()
+                        .find(|job| job.job_id == active_job_id)
+                        .map(|job| job.tool.clone())
+                });
             plan.items[item_index].job_id = None;
             match status {
                 PlanJobStatus::Succeeded => {
                     plan.items[item_index].status = PlanStepStatus::Completed;
-                    if let Some(next_pending) = plan
+                    let next_step = if let Some(next_pending) = plan
                         .items
                         .iter_mut()
                         .find(|item| matches!(item.status, PlanStepStatus::Pending))
                     {
+                        let next_step = next_pending.step.clone();
                         next_pending.status = PlanStepStatus::InProgress;
-                    }
+                        Some(next_step)
+                    } else {
+                        None
+                    };
+                    runtime.set_checkpoint_followup(step_text, next_step);
                 }
                 PlanJobStatus::Blocked | PlanJobStatus::Failed => {
                     plan.items[item_index].status = PlanStepStatus::Blocked;
+                    runtime.set_retry_or_replan_followup(step_text, job_command);
                 }
                 PlanJobStatus::WaitingApproval | PlanJobStatus::Running => {}
             }
@@ -220,6 +263,109 @@ pub fn append_active_plan_job_output(
     update_plan_runtime(conn, session_id, |runtime| {
         runtime.append_active_job_output(chunk, is_error);
     })
+}
+
+pub fn set_plan_step_status(
+    conn: &Connection,
+    session_id: &str,
+    step_index: usize,
+    status: PlanStepStatus,
+) -> HarperResult<()> {
+    let Some(mut plan) = crate::memory::storage::load_plan_state(conn, session_id)? else {
+        return Ok(());
+    };
+    if step_index >= plan.items.len() {
+        return Err(HarperError::Validation(format!(
+            "plan step index {} is out of bounds",
+            step_index
+        )));
+    }
+
+    if matches!(status, PlanStepStatus::InProgress) {
+        for (index, item) in plan.items.iter_mut().enumerate() {
+            if index != step_index && matches!(item.status, PlanStepStatus::InProgress) {
+                item.status = PlanStepStatus::Pending;
+                item.job_id = None;
+            }
+        }
+    }
+
+    let item = &mut plan.items[step_index];
+    item.status = status;
+    item.job_id = None;
+
+    crate::memory::storage::save_plan_state(conn, session_id, &plan)
+}
+
+pub fn clear_plan_state(conn: &Connection, session_id: &str) -> HarperResult<()> {
+    crate::memory::storage::delete_plan_state(conn, session_id)
+}
+
+pub fn clear_plan_followup(conn: &Connection, session_id: &str) -> HarperResult<()> {
+    let Some(mut plan) = crate::memory::storage::load_plan_state(conn, session_id)? else {
+        return Ok(());
+    };
+    let Some(runtime) = plan.runtime.as_mut() else {
+        return Ok(());
+    };
+    runtime.clear_followup();
+    if runtime.is_empty() {
+        plan.runtime = None;
+    }
+    crate::memory::storage::save_plan_state(conn, session_id, &plan)
+}
+
+pub fn replan_blocked_step(
+    conn: &Connection,
+    session_id: &str,
+    step_index: usize,
+) -> HarperResult<()> {
+    let Some(mut plan) = crate::memory::storage::load_plan_state(conn, session_id)? else {
+        return Ok(());
+    };
+    if step_index >= plan.items.len() {
+        return Err(HarperError::Validation(format!(
+            "plan step index {} is out of bounds",
+            step_index
+        )));
+    }
+
+    let original_step = plan.items[step_index].step.clone();
+    for item in &mut plan.items {
+        if matches!(item.status, PlanStepStatus::InProgress) {
+            item.status = PlanStepStatus::Pending;
+            item.job_id = None;
+        }
+    }
+
+    plan.items[step_index] = PlanItem {
+        step: format!("Revise approach for blocked step: {}", original_step),
+        status: PlanStepStatus::InProgress,
+        job_id: None,
+    };
+    plan.items.insert(
+        step_index + 1,
+        PlanItem {
+            step: format!("Validate revised approach for: {}", original_step),
+            status: PlanStepStatus::Pending,
+            job_id: None,
+        },
+    );
+
+    let note = format!("Planner replan generated after blocker: {}", original_step);
+    plan.explanation = match plan.explanation.take() {
+        Some(existing) if !existing.trim().is_empty() => Some(format!("{} {}", existing, note)),
+        _ => Some(note),
+    };
+    if let Some(runtime) = plan.runtime.as_mut() {
+        runtime.clear_followup();
+        runtime.clear_active_state();
+        if runtime.is_empty() {
+            plan.runtime = None;
+        }
+    }
+
+    crate::memory::storage::save_plan_state(conn, session_id, &plan)
 }
 
 fn update_plan_runtime<F>(conn: &Connection, session_id: &str, mutator: F) -> HarperResult<()>
@@ -257,8 +403,9 @@ fn parse_status(value: Option<&serde_json::Value>) -> HarperResult<PlanStepStatu
 #[cfg(test)]
 mod tests {
     use super::{
-        append_active_plan_job_output, finish_active_plan_job, finish_active_plan_job_with_output,
-        start_plan_job,
+        append_active_plan_job_output, clear_plan_followup, clear_plan_state,
+        finish_active_plan_job, finish_active_plan_job_with_output, replan_blocked_step,
+        set_plan_step_status, start_plan_job,
     };
     use crate::core::plan::{PlanItem, PlanJobStatus, PlanState, PlanStepStatus};
     use rusqlite::Connection;
@@ -353,6 +500,10 @@ mod tests {
             .runtime
             .as_ref()
             .is_some_and(|rt| rt.active_job_id.is_none()));
+        assert!(matches!(
+            plan.runtime.as_ref().and_then(|rt| rt.followup.as_ref()),
+            Some(crate::core::plan::PlanFollowup::Checkpoint { .. })
+        ));
     }
 
     #[test]
@@ -391,6 +542,10 @@ mod tests {
             .expect("plan present");
         assert_eq!(plan.items[0].status, PlanStepStatus::Blocked);
         assert!(plan.items[0].job_id.is_none());
+        assert!(matches!(
+            plan.runtime.as_ref().and_then(|rt| rt.followup.as_ref()),
+            Some(crate::core::plan::PlanFollowup::RetryOrReplan { retry_count: 1, .. })
+        ));
     }
 
     #[test]
@@ -483,5 +638,153 @@ mod tests {
         assert_eq!(job.output_transcript, "line one\nline two\n");
         assert_eq!(job.output_preview.as_deref(), Some("line one\nline two"));
         assert!(job.has_error_output);
+    }
+
+    #[test]
+    fn set_plan_step_status_promotes_selected_step_to_in_progress() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-edit-session",
+            &PlanState {
+                explanation: None,
+                items: vec![
+                    PlanItem {
+                        step: "First".to_string(),
+                        status: PlanStepStatus::InProgress,
+                        job_id: Some("job-1".to_string()),
+                    },
+                    PlanItem {
+                        step: "Second".to_string(),
+                        status: PlanStepStatus::Pending,
+                        job_id: None,
+                    },
+                ],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        set_plan_step_status(&conn, "plan-edit-session", 1, PlanStepStatus::InProgress)
+            .expect("set status");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-edit-session")
+            .expect("load plan")
+            .expect("plan exists");
+        assert_eq!(plan.items[0].status, PlanStepStatus::Pending);
+        assert_eq!(plan.items[0].job_id, None);
+        assert_eq!(plan.items[1].status, PlanStepStatus::InProgress);
+    }
+
+    #[test]
+    fn clear_plan_state_removes_saved_plan() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-clear-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "First".to_string(),
+                    status: PlanStepStatus::Pending,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        clear_plan_state(&conn, "plan-clear-session").expect("clear plan");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-clear-session")
+            .expect("load plan");
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn clear_plan_followup_keeps_plan_items() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-followup-clear-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Inspect".to_string(),
+                    status: PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: Some({
+                    let mut runtime = crate::core::plan::PlanRuntime::default();
+                    runtime.set_checkpoint_followup("Inspect", Some("Patch".to_string()));
+                    runtime
+                }),
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        clear_plan_followup(&conn, "plan-followup-clear-session").expect("clear followup");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-followup-clear-session")
+            .expect("load plan")
+            .expect("plan present");
+        assert_eq!(plan.items.len(), 1);
+        assert!(plan
+            .runtime
+            .as_ref()
+            .is_none_or(|runtime| runtime.followup.is_none()));
+    }
+
+    #[test]
+    fn replan_blocked_step_rewrites_plan_deterministically() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "plan-replan-session",
+            &PlanState {
+                explanation: Some("Original plan".to_string()),
+                items: vec![PlanItem {
+                    step: "Patch failing handler".to_string(),
+                    status: PlanStepStatus::Blocked,
+                    job_id: None,
+                }],
+                runtime: Some({
+                    let mut runtime = crate::core::plan::PlanRuntime::default();
+                    runtime.set_retry_or_replan_followup(
+                        "Patch failing handler",
+                        Some("cargo test".to_string()),
+                    );
+                    runtime
+                }),
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        replan_blocked_step(&conn, "plan-replan-session", 0).expect("replan step");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "plan-replan-session")
+            .expect("load plan")
+            .expect("plan present");
+        assert_eq!(plan.items.len(), 2);
+        assert_eq!(plan.items[0].status, PlanStepStatus::InProgress);
+        assert!(plan.items[0]
+            .step
+            .contains("Revise approach for blocked step: Patch failing handler"));
+        assert_eq!(plan.items[1].status, PlanStepStatus::Pending);
+        assert!(plan.items[1]
+            .step
+            .contains("Validate revised approach for: Patch failing handler"));
+        assert!(plan
+            .runtime
+            .as_ref()
+            .is_none_or(|runtime| runtime.followup.is_none()));
     }
 }

--- a/lib/harper-core/src/tools/shell.rs
+++ b/lib/harper-core/src/tools/shell.rs
@@ -47,6 +47,25 @@ pub struct CommandSandboxIntent {
     pub declared_read_paths: Vec<PathBuf>,
     pub declared_write_paths: Vec<PathBuf>,
     pub requires_network: bool,
+    pub retry_policy: Option<CommandRetryPolicy>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandRetryPolicy {
+    Never,
+    Safe,
+}
+
+struct CommandAttemptResult {
+    output_text: String,
+    success: bool,
+    exit_code: Option<i32>,
+    duration_ms: i64,
+    stdout_preview: Option<String>,
+    stderr_preview: Option<String>,
+    output_preview: Option<String>,
+    has_error_output: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -58,6 +77,8 @@ struct RunCommandPayload {
     declared_write_paths: Vec<PathBuf>,
     #[serde(default)]
     requires_network: bool,
+    #[serde(default)]
+    retry_policy: Option<CommandRetryPolicy>,
 }
 
 fn parse_run_command_response(
@@ -83,6 +104,7 @@ fn parse_run_command_response(
                 declared_read_paths: parsed.declared_read_paths,
                 declared_write_paths: parsed.declared_write_paths,
                 requires_network: parsed.requires_network,
+                retry_policy: parsed.retry_policy,
             }),
         ));
     }
@@ -142,17 +164,18 @@ fn build_sandbox_request(
 
     let working_dir = std::env::current_dir().map_err(|e| HarperError::Io(e.to_string()))?;
     let rest_args: Vec<&str> = rest.iter().map(String::as_str).collect();
-    let (declared_read_paths, declared_write_paths, requires_network) = if let Some(intent) = intent
-    {
-        (
-            intent.declared_read_paths.clone(),
-            intent.declared_write_paths.clone(),
-            intent.requires_network,
-        )
-    } else {
-        let (reads, writes) = infer_path_intent(command, &rest_args);
-        (reads, writes, looks_like_network_command(command))
-    };
+    let (declared_read_paths, declared_write_paths, requires_network, _retry_policy) =
+        if let Some(intent) = intent {
+            (
+                intent.declared_read_paths.clone(),
+                intent.declared_write_paths.clone(),
+                intent.requires_network,
+                intent.retry_policy.clone(),
+            )
+        } else {
+            let (reads, writes) = infer_path_intent(command, &rest_args);
+            (reads, writes, looks_like_network_command(command), None)
+        };
 
     Ok(SandboxRequest {
         command: command.clone(),
@@ -444,6 +467,264 @@ fn approval_required_for_command(
     }
 }
 
+fn autonomous_retry_safe(
+    exec_policy: &ExecPolicyConfig,
+    command_str: &str,
+    requires_approval: bool,
+    intent: Option<&CommandSandboxIntent>,
+) -> bool {
+    if requires_approval {
+        return false;
+    }
+    let Some(intent) = intent else {
+        return true;
+    };
+    if let Some(policy) = intent.retry_policy.as_ref() {
+        return matches!(policy, CommandRetryPolicy::Safe);
+    }
+    let command = parsing::parse_quoted_args(command_str)
+        .ok()
+        .and_then(|args| args.first().cloned())
+        .map(|command| command_basename(&command).to_string())
+        .unwrap_or_else(|| command_basename(command_str).to_string());
+    let has_writes = !intent.declared_write_paths.is_empty();
+
+    if intent.requires_network {
+        return !has_writes && exec_policy.retries_network_command(&command);
+    }
+    if has_writes {
+        return writes_within_configured_writable_dirs(exec_policy, intent)
+            && exec_policy.retries_write_command(&command);
+    }
+    true
+}
+
+async fn execute_sandboxed_once(
+    sandbox: &Sandbox,
+    request: SandboxRequest,
+    runtime_events: Option<&Arc<dyn RuntimeEventSink>>,
+    audit_ctx: Option<&CommandAuditContext<'_>>,
+    command_str: &str,
+) -> crate::core::error::HarperResult<CommandAttemptResult> {
+    let (stream_tx, mut stream_rx) = mpsc::unbounded_channel::<(String, bool)>();
+    let runtime_events_clone = runtime_events.cloned();
+    let session_id_owned = audit_ctx
+        .and_then(|ctx| ctx.session_id)
+        .map(ToString::to_string);
+    let command_owned = command_str.to_string();
+    let stream_forwarder = tokio::spawn(async move {
+        while let Some((chunk, is_error)) = stream_rx.recv().await {
+            emit_command_output(
+                runtime_events_clone.as_ref(),
+                session_id_owned.as_deref(),
+                &command_owned,
+                chunk,
+                is_error,
+                false,
+            )
+            .await;
+        }
+    });
+    let start = Instant::now();
+    let result = sandbox
+        .execute_request_streaming(request, move |chunk, is_error| {
+            let _ = stream_tx.send((chunk, is_error));
+        })
+        .await?;
+    stream_forwarder
+        .await
+        .map_err(|e| HarperError::Command(format!("Sandbox output forwarding failed: {}", e)))?;
+    let duration_ms = start.elapsed().as_millis() as i64;
+    let exit_code = result.output.status.code();
+    let stdout_preview = bytes_to_preview(&result.output.stdout);
+    let stderr_preview = bytes_to_preview(&result.output.stderr);
+    let stdout_text = String::from_utf8_lossy(&result.output.stdout).into_owned();
+    let stderr_text = String::from_utf8_lossy(&result.output.stderr).into_owned();
+    let output_preview = if result.output.status.success() {
+        preview_text(&stdout_text)
+    } else if !stderr_text.trim().is_empty() {
+        preview_text(&stderr_text)
+    } else {
+        preview_text(&stdout_text)
+    };
+    let has_error_output = !result.output.status.success() || !stderr_text.trim().is_empty();
+
+    emit_command_output(
+        runtime_events,
+        audit_ctx.and_then(|ctx| ctx.session_id),
+        command_str,
+        String::new(),
+        false,
+        true,
+    )
+    .await;
+
+    Ok(CommandAttemptResult {
+        output_text: if result.output.status.success() {
+            stdout_text
+        } else {
+            stderr_text
+        },
+        success: result.output.status.success(),
+        exit_code,
+        duration_ms,
+        stdout_preview,
+        stderr_preview,
+        output_preview,
+        has_error_output,
+    })
+}
+
+async fn execute_direct_once(
+    command_str: &str,
+    runtime_events: Option<&Arc<dyn RuntimeEventSink>>,
+    audit_ctx: Option<&CommandAuditContext<'_>>,
+) -> crate::core::error::HarperResult<CommandAttemptResult> {
+    let start = Instant::now();
+    let mut child = TokioCommand::new("sh")
+        .arg("-c")
+        .arg(command_str)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| HarperError::Command(format!("Failed to execute command: {}", e)))?;
+
+    let mut stdout_task = None;
+    if let Some(stdout) = child.stdout.take() {
+        let runtime_events = runtime_events.cloned();
+        let session_id = audit_ctx.and_then(|ctx| ctx.session_id).map(str::to_string);
+        let db_path = audit_ctx.and_then(|ctx| database_path(ctx.conn));
+        let command = command_str.to_string();
+        stdout_task = Some(tokio::spawn(async move {
+            let live_conn = db_path
+                .as_deref()
+                .and_then(|path| crate::memory::storage::create_connection(path).ok());
+            let mut lines = BufReader::new(stdout).lines();
+            let mut collected = String::new();
+            while let Ok(Some(line)) = lines.next_line().await {
+                collected.push_str(&line);
+                collected.push('\n');
+                if let (Some(conn), Some(session_id)) = (&live_conn, session_id.as_deref()) {
+                    let _ = crate::tools::plan::append_active_plan_job_output(
+                        conn,
+                        session_id,
+                        &format!("{}\n", line),
+                        false,
+                    );
+                    if let Some(sink) = runtime_events.as_ref() {
+                        let plan = crate::memory::storage::load_plan_state(conn, session_id)
+                            .ok()
+                            .flatten();
+                        let _ = sink.plan_updated(session_id, plan).await;
+                    }
+                }
+                emit_command_output(
+                    runtime_events.as_ref(),
+                    session_id.as_deref(),
+                    &command,
+                    format!("{}\n", line),
+                    false,
+                    false,
+                )
+                .await;
+            }
+            collected
+        }));
+    }
+
+    let mut stderr_task = None;
+    if let Some(stderr) = child.stderr.take() {
+        let runtime_events = runtime_events.cloned();
+        let session_id = audit_ctx.and_then(|ctx| ctx.session_id).map(str::to_string);
+        let db_path = audit_ctx.and_then(|ctx| database_path(ctx.conn));
+        let command = command_str.to_string();
+        stderr_task = Some(tokio::spawn(async move {
+            let live_conn = db_path
+                .as_deref()
+                .and_then(|path| crate::memory::storage::create_connection(path).ok());
+            let mut lines = BufReader::new(stderr).lines();
+            let mut collected = String::new();
+            while let Ok(Some(line)) = lines.next_line().await {
+                collected.push_str(&line);
+                collected.push('\n');
+                if let (Some(conn), Some(session_id)) = (&live_conn, session_id.as_deref()) {
+                    let _ = crate::tools::plan::append_active_plan_job_output(
+                        conn,
+                        session_id,
+                        &format!("{}\n", line),
+                        true,
+                    );
+                    if let Some(sink) = runtime_events.as_ref() {
+                        let plan = crate::memory::storage::load_plan_state(conn, session_id)
+                            .ok()
+                            .flatten();
+                        let _ = sink.plan_updated(session_id, plan).await;
+                    }
+                }
+                emit_command_output(
+                    runtime_events.as_ref(),
+                    session_id.as_deref(),
+                    &command,
+                    format!("{}\n", line),
+                    true,
+                    false,
+                )
+                .await;
+            }
+            collected
+        }));
+    }
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| HarperError::Command(format!("Failed to wait for command: {}", e)))?;
+    let duration_ms = start.elapsed().as_millis() as i64;
+    let stdout_text = match stdout_task {
+        Some(task) => task.await.unwrap_or_default(),
+        None => String::new(),
+    };
+    let stderr_text = match stderr_task {
+        Some(task) => task.await.unwrap_or_default(),
+        None => String::new(),
+    };
+    emit_command_output(
+        runtime_events,
+        audit_ctx.and_then(|ctx| ctx.session_id),
+        command_str,
+        String::new(),
+        false,
+        true,
+    )
+    .await;
+    let exit_code = status.code();
+    let stdout_preview = bytes_to_preview(stdout_text.as_bytes());
+    let stderr_preview = bytes_to_preview(stderr_text.as_bytes());
+    let output_preview = if status.success() {
+        preview_text(&stdout_text)
+    } else if !stderr_text.trim().is_empty() {
+        preview_text(&stderr_text)
+    } else {
+        preview_text(&stdout_text)
+    };
+    let has_error_output = !status.success() || !stderr_text.trim().is_empty();
+
+    Ok(CommandAttemptResult {
+        output_text: if status.success() {
+            stdout_text
+        } else {
+            stderr_text
+        },
+        success: status.success(),
+        exit_code,
+        duration_ms,
+        stdout_preview,
+        stderr_preview,
+        output_preview,
+        has_error_output,
+    })
+}
+
 /// Execute a shell command with safety checks
 pub async fn execute_command(
     response: &str,
@@ -658,319 +939,125 @@ pub async fn execute_command(
             Some(format!("running command: {}", command_str)),
         )
         .await;
-        let _ = crate::tools::plan::update_active_plan_job(ctx.0, ctx.1, PlanJobStatus::Running)
-            .or_else(|_| {
-                crate::tools::plan::start_plan_job(
-                    ctx.0,
-                    ctx.1,
-                    "run_command",
-                    Some(command_str.to_string()),
-                    PlanJobStatus::Running,
-                )
-            });
+        let has_active_job = crate::memory::storage::load_plan_state(ctx.0, ctx.1)
+            .ok()
+            .flatten()
+            .and_then(|plan| plan.runtime)
+            .and_then(|runtime| runtime.active_job_id)
+            .is_some();
+        let _ = if has_active_job {
+            crate::tools::plan::update_active_plan_job(ctx.0, ctx.1, PlanJobStatus::Running)
+        } else {
+            crate::tools::plan::start_plan_job(
+                ctx.0,
+                ctx.1,
+                "run_command",
+                Some(command_str.to_string()),
+                PlanJobStatus::Running,
+            )
+        };
         emit_plan_update(runtime_events.as_ref(), ctx.0, ctx.1).await;
     }
 
-    if let Some(sandbox_config) = configured_sandbox(exec_policy).filter(|config| config.enabled) {
-        let request = build_sandbox_request(command_str, resolved_intent.as_ref())?;
-        let sandbox = Sandbox::new(sandbox_config);
-        let (stream_tx, mut stream_rx) = mpsc::unbounded_channel::<(String, bool)>();
-        let runtime_events_clone = runtime_events.clone();
-        let session_id_owned = audit_ctx
-            .and_then(|ctx| ctx.session_id)
-            .map(ToString::to_string);
-        let command_owned = command_str.to_string();
-        let stream_forwarder = tokio::spawn(async move {
-            while let Some((chunk, is_error)) = stream_rx.recv().await {
-                emit_command_output(
-                    runtime_events_clone.as_ref(),
-                    session_id_owned.as_deref(),
-                    &command_owned,
-                    chunk,
-                    is_error,
-                    false,
-                )
-                .await;
+    let retry_safe = autonomous_retry_safe(
+        exec_policy,
+        command_str,
+        requires_approval,
+        resolved_intent.as_ref(),
+    );
+    let sandbox = configured_sandbox(exec_policy)
+        .filter(|config| config.enabled)
+        .map(Sandbox::new);
+    let mut attempt = 0;
+    loop {
+        let attempt_result = if let Some(sandbox) = sandbox.as_ref() {
+            let request = build_sandbox_request(command_str, resolved_intent.as_ref())?;
+            execute_sandboxed_once(
+                sandbox,
+                request,
+                runtime_events.as_ref(),
+                audit_ctx,
+                command_str,
+            )
+            .await?
+        } else {
+            execute_direct_once(command_str, runtime_events.as_ref(), audit_ctx).await?
+        };
+
+        if attempt_result.success
+            || !retry_safe
+            || attempt >= exec_policy.effective_retry_max_attempts()
+        {
+            maybe_log_command(
+                audit_ctx,
+                command_str,
+                if attempt_result.success {
+                    "succeeded"
+                } else {
+                    "failed"
+                },
+                requires_approval,
+                approved,
+                attempt_result.exit_code,
+                Some(attempt_result.duration_ms),
+                attempt_result.stdout_preview,
+                attempt_result.stderr_preview,
+                (!attempt_result.success)
+                    .then_some("Command exited with non-zero status".to_string()),
+            );
+
+            if let Some(ctx) =
+                audit_ctx.and_then(|ctx| ctx.session_id.map(|session_id| (ctx.conn, session_id)))
+            {
+                let _ = crate::tools::plan::finish_active_plan_job_with_output(
+                    ctx.0,
+                    ctx.1,
+                    if attempt_result.success {
+                        PlanJobStatus::Succeeded
+                    } else {
+                        PlanJobStatus::Failed
+                    },
+                    attempt_result.output_preview,
+                    attempt_result.has_error_output,
+                );
+                emit_plan_update(runtime_events.as_ref(), ctx.0, ctx.1).await;
             }
-        });
-        let start = Instant::now();
-        let result = sandbox
-            .execute_request_streaming(request, move |chunk, is_error| {
-                let _ = stream_tx.send((chunk, is_error));
-            })
-            .await?;
-        stream_forwarder.await.map_err(|e| {
-            HarperError::Command(format!("Sandbox output forwarding failed: {}", e))
-        })?;
-        let duration_ms = start.elapsed().as_millis() as i64;
-        let exit_code = result.output.status.code();
-        let stdout_preview = bytes_to_preview(&result.output.stdout);
-        let stderr_preview = bytes_to_preview(&result.output.stderr);
-        let stdout_text = String::from_utf8_lossy(&result.output.stdout).into_owned();
-        let stderr_text = String::from_utf8_lossy(&result.output.stderr).into_owned();
-        let output_preview = if result.output.status.success() {
-            preview_text(&stdout_text)
-        } else if !stderr_text.trim().is_empty() {
-            preview_text(&stderr_text)
-        } else {
-            preview_text(&stdout_text)
-        };
-        let has_error_output = !result.output.status.success() || !stderr_text.trim().is_empty();
 
-        emit_command_output(
-            runtime_events.as_ref(),
-            audit_ctx.and_then(|ctx| ctx.session_id),
+            return Ok(attempt_result.output_text);
+        }
+
+        maybe_log_command(
+            audit_ctx,
             command_str,
-            String::new(),
-            false,
-            true,
-        )
-        .await;
-
-        let output_text = if result.output.status.success() {
-            maybe_log_command(
-                audit_ctx,
-                command_str,
-                "succeeded",
-                requires_approval,
-                approved,
-                exit_code,
-                Some(duration_ms),
-                stdout_preview,
-                stderr_preview,
-                None,
-            );
-            stdout_text
-        } else {
-            maybe_log_command(
-                audit_ctx,
-                command_str,
-                "failed",
-                requires_approval,
-                approved,
-                exit_code,
-                Some(duration_ms),
-                stdout_preview,
-                stderr_preview,
-                Some("Command exited with non-zero status".to_string()),
-            );
-            stderr_text
-        };
-
+            "retrying",
+            requires_approval,
+            approved,
+            attempt_result.exit_code,
+            Some(attempt_result.duration_ms),
+            attempt_result.stdout_preview.clone(),
+            attempt_result.stderr_preview.clone(),
+            Some("Autonomous retry scheduled after first failure".to_string()),
+        );
         if let Some(ctx) =
             audit_ctx.and_then(|ctx| ctx.session_id.map(|session_id| (ctx.conn, session_id)))
         {
-            let _ = crate::tools::plan::finish_active_plan_job_with_output(
+            let _ = crate::tools::plan::record_active_plan_retry_followup(
                 ctx.0,
                 ctx.1,
-                if result.output.status.success() {
-                    PlanJobStatus::Succeeded
-                } else {
-                    PlanJobStatus::Failed
-                },
-                output_preview,
-                has_error_output,
+                Some(command_str.to_string()),
             );
+            let _ =
+                crate::tools::plan::update_active_plan_job(ctx.0, ctx.1, PlanJobStatus::Running);
             emit_plan_update(runtime_events.as_ref(), ctx.0, ctx.1).await;
         }
-
-        return Ok(output_text);
+        emit_activity_update(
+            runtime_events.as_ref(),
+            audit_ctx.and_then(|ctx| ctx.session_id),
+            Some(format!("retrying command: {}", command_str)),
+        )
+        .await;
+        attempt += 1;
     }
-
-    let start = Instant::now();
-    let mut child = TokioCommand::new("sh")
-        .arg("-c")
-        .arg(command_str)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| {
-            let err_msg = format!("Failed to execute command: {}", e);
-            maybe_log_command(
-                audit_ctx,
-                command_str,
-                "error",
-                requires_approval,
-                approved,
-                None,
-                None,
-                None,
-                None,
-                Some(err_msg.clone()),
-            );
-            HarperError::Command(err_msg)
-        })?;
-
-    let mut stdout_task = None;
-    if let Some(stdout) = child.stdout.take() {
-        let runtime_events = runtime_events.clone();
-        let session_id = audit_ctx.and_then(|ctx| ctx.session_id).map(str::to_string);
-        let db_path = audit_ctx.and_then(|ctx| database_path(ctx.conn));
-        let command = command_str.to_string();
-        stdout_task = Some(tokio::spawn(async move {
-            let live_conn = db_path
-                .as_deref()
-                .and_then(|path| crate::memory::storage::create_connection(path).ok());
-            let mut lines = BufReader::new(stdout).lines();
-            let mut collected = String::new();
-            while let Ok(Some(line)) = lines.next_line().await {
-                collected.push_str(&line);
-                collected.push('\n');
-                if let (Some(conn), Some(session_id)) = (&live_conn, session_id.as_deref()) {
-                    let _ = crate::tools::plan::append_active_plan_job_output(
-                        conn,
-                        session_id,
-                        &format!("{}\n", line),
-                        false,
-                    );
-                    if let Some(sink) = runtime_events.as_ref() {
-                        let plan = crate::memory::storage::load_plan_state(conn, session_id)
-                            .ok()
-                            .flatten();
-                        let _ = sink.plan_updated(session_id, plan).await;
-                    }
-                }
-                emit_command_output(
-                    runtime_events.as_ref(),
-                    session_id.as_deref(),
-                    &command,
-                    format!("{}\n", line),
-                    false,
-                    false,
-                )
-                .await;
-            }
-            collected
-        }));
-    }
-
-    let mut stderr_task = None;
-    if let Some(stderr) = child.stderr.take() {
-        let runtime_events = runtime_events.clone();
-        let session_id = audit_ctx.and_then(|ctx| ctx.session_id).map(str::to_string);
-        let db_path = audit_ctx.and_then(|ctx| database_path(ctx.conn));
-        let command = command_str.to_string();
-        stderr_task = Some(tokio::spawn(async move {
-            let live_conn = db_path
-                .as_deref()
-                .and_then(|path| crate::memory::storage::create_connection(path).ok());
-            let mut lines = BufReader::new(stderr).lines();
-            let mut collected = String::new();
-            while let Ok(Some(line)) = lines.next_line().await {
-                collected.push_str(&line);
-                collected.push('\n');
-                if let (Some(conn), Some(session_id)) = (&live_conn, session_id.as_deref()) {
-                    let _ = crate::tools::plan::append_active_plan_job_output(
-                        conn,
-                        session_id,
-                        &format!("{}\n", line),
-                        true,
-                    );
-                    if let Some(sink) = runtime_events.as_ref() {
-                        let plan = crate::memory::storage::load_plan_state(conn, session_id)
-                            .ok()
-                            .flatten();
-                        let _ = sink.plan_updated(session_id, plan).await;
-                    }
-                }
-                emit_command_output(
-                    runtime_events.as_ref(),
-                    session_id.as_deref(),
-                    &command,
-                    format!("{}\n", line),
-                    true,
-                    false,
-                )
-                .await;
-            }
-            collected
-        }));
-    }
-
-    let status = child.wait().await.map_err(|e| {
-        let err_msg = format!("Failed to wait for command: {}", e);
-        HarperError::Command(err_msg)
-    })?;
-    let duration_ms = start.elapsed().as_millis() as i64;
-    let stdout_text = match stdout_task {
-        Some(task) => task.await.unwrap_or_default(),
-        None => String::new(),
-    };
-    let stderr_text = match stderr_task {
-        Some(task) => task.await.unwrap_or_default(),
-        None => String::new(),
-    };
-    emit_command_output(
-        runtime_events.as_ref(),
-        audit_ctx.and_then(|ctx| ctx.session_id),
-        command_str,
-        String::new(),
-        false,
-        true,
-    )
-    .await;
-    let exit_code = status.code();
-    let stdout_preview = bytes_to_preview(stdout_text.as_bytes());
-    let stderr_preview = bytes_to_preview(stderr_text.as_bytes());
-    let output_preview = if status.success() {
-        preview_text(&stdout_text)
-    } else if !stderr_text.trim().is_empty() {
-        preview_text(&stderr_text)
-    } else {
-        preview_text(&stdout_text)
-    };
-    let has_error_output = !status.success() || !stderr_text.trim().is_empty();
-
-    let result = if status.success() {
-        let out = stdout_text;
-        maybe_log_command(
-            audit_ctx,
-            command_str,
-            "succeeded",
-            requires_approval,
-            approved,
-            exit_code,
-            Some(duration_ms),
-            stdout_preview,
-            stderr_preview,
-            None,
-        );
-        out
-    } else {
-        let err_output = stderr_text;
-        maybe_log_command(
-            audit_ctx,
-            command_str,
-            "failed",
-            requires_approval,
-            approved,
-            exit_code,
-            Some(duration_ms),
-            stdout_preview,
-            stderr_preview,
-            Some("Command exited with non-zero status".to_string()),
-        );
-        err_output
-    };
-
-    if let Some(ctx) =
-        audit_ctx.and_then(|ctx| ctx.session_id.map(|session_id| (ctx.conn, session_id)))
-    {
-        let _ = crate::tools::plan::finish_active_plan_job_with_output(
-            ctx.0,
-            ctx.1,
-            if status.success() {
-                PlanJobStatus::Succeeded
-            } else {
-                PlanJobStatus::Failed
-            },
-            output_preview,
-            has_error_output,
-        );
-        emit_plan_update(runtime_events.as_ref(), ctx.0, ctx.1).await;
-    }
-
-    Ok(result)
 }
 
 async fn emit_plan_update(
@@ -1048,13 +1135,25 @@ fn bytes_to_preview(bytes: &[u8]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        approval_required_for_command, build_sandbox_request, configured_sandbox,
-        infer_path_intent, looks_like_network_command, parse_run_command_response,
-        CommandSandboxIntent,
+        approval_required_for_command, autonomous_retry_safe, build_sandbox_request,
+        configured_sandbox, execute_command, infer_path_intent, looks_like_network_command,
+        parse_run_command_response, CommandAuditContext, CommandRetryPolicy, CommandSandboxIntent,
     };
+    use crate::core::plan::{PlanFollowup, PlanItem, PlanState, PlanStepStatus};
+    use crate::core::{ApiConfig, ApiProvider};
     use crate::runtime::config::{
         ApprovalProfile, ExecPolicyConfig, SandboxConfig as RuntimeSandboxConfig, SandboxProfile,
     };
+    use rusqlite::Connection;
+
+    fn test_config() -> ApiConfig {
+        ApiConfig {
+            provider: ApiProvider::OpenAI,
+            api_key: "test-key".to_string(),
+            base_url: "https://api.openai.com/v1/chat/completions".to_string(),
+            model_name: "gpt-5.5".to_string(),
+        }
+    }
 
     #[test]
     fn build_sandbox_request_extracts_command_args_and_declared_paths() {
@@ -1093,6 +1192,7 @@ mod tests {
             declared_read_paths: vec![std::path::PathBuf::from("./input.txt")],
             declared_write_paths: vec![std::path::PathBuf::from("./out.txt")],
             requires_network: true,
+            retry_policy: Some(CommandRetryPolicy::Safe),
         };
         let request =
             build_sandbox_request("cat ./ignored.txt", Some(&intent)).expect("sandbox request");
@@ -1105,7 +1205,7 @@ mod tests {
     #[test]
     fn parse_run_command_response_reads_enhanced_bracket_payload() {
         let (command, intent) = parse_run_command_response(
-            r#"[RUN_COMMAND {"command":"cp ./src.txt ./out.txt","declared_read_paths":["./src.txt"],"declared_write_paths":["./out.txt"],"requires_network":true}]"#,
+            r#"[RUN_COMMAND {"command":"cp ./src.txt ./out.txt","declared_read_paths":["./src.txt"],"declared_write_paths":["./out.txt"],"requires_network":true,"retry_policy":"safe"}]"#,
             None,
         )
         .expect("parse run command");
@@ -1121,6 +1221,7 @@ mod tests {
             vec![std::path::PathBuf::from("./out.txt")]
         );
         assert!(intent.requires_network);
+        assert_eq!(intent.retry_policy, Some(CommandRetryPolicy::Safe));
     }
 
     #[test]
@@ -1129,6 +1230,7 @@ mod tests {
             declared_read_paths: vec![std::path::PathBuf::from("./input.txt")],
             declared_write_paths: vec![],
             requires_network: false,
+            retry_policy: Some(CommandRetryPolicy::Never),
         };
         let (command, intent) =
             parse_run_command_response("[RUN_COMMAND cat ./input.txt]", Some(&fallback))
@@ -1228,6 +1330,9 @@ mod tests {
                 readonly_home: Some(true),
                 max_execution_time_secs: Some(15),
             }),
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
 
         let sandbox = configured_sandbox(&exec_policy).expect("sandbox config");
@@ -1252,6 +1357,9 @@ mod tests {
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
             sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
         assert!(!approval_required_for_command(
             &exec_policy,
@@ -1268,6 +1376,9 @@ mod tests {
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
             sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
         assert!(approval_required_for_command(
             &exec_policy,
@@ -1284,6 +1395,9 @@ mod tests {
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
             sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
         assert!(!approval_required_for_command(
             &exec_policy,
@@ -1308,11 +1422,15 @@ mod tests {
                 readonly_home: Some(true),
                 max_execution_time_secs: Some(30),
             }),
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
         let intent = CommandSandboxIntent {
             declared_read_paths: vec![std::path::PathBuf::from("./src.txt")],
             declared_write_paths: vec![std::path::PathBuf::from("./out.txt")],
             requires_network: false,
+            retry_policy: None,
         };
         assert!(approval_required_for_command(
             &exec_policy,
@@ -1336,11 +1454,15 @@ mod tests {
                 readonly_home: Some(true),
                 max_execution_time_secs: Some(30),
             }),
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
         let intent = CommandSandboxIntent {
             declared_read_paths: vec![std::path::PathBuf::from("./src.txt")],
             declared_write_paths: vec![std::path::PathBuf::from("./safe/out.txt")],
             requires_network: false,
+            retry_policy: None,
         };
         assert!(!approval_required_for_command(
             &exec_policy,
@@ -1357,16 +1479,176 @@ mod tests {
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
             sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
         let intent = CommandSandboxIntent {
             declared_read_paths: vec![],
             declared_write_paths: vec![],
             requires_network: true,
+            retry_policy: None,
         };
         assert!(approval_required_for_command(
             &exec_policy,
             "curl https://example.com",
             Some(&intent)
+        ));
+    }
+
+    #[test]
+    fn autonomous_retry_safe_allows_non_network_readonly_commands() {
+        let exec_policy = ExecPolicyConfig::default();
+        let intent = CommandSandboxIntent {
+            declared_read_paths: vec![std::path::PathBuf::from("./input.txt")],
+            declared_write_paths: vec![],
+            requires_network: false,
+            retry_policy: None,
+        };
+        assert!(autonomous_retry_safe(
+            &exec_policy,
+            "cat ./input.txt",
+            false,
+            Some(&intent)
+        ));
+        assert!(!autonomous_retry_safe(
+            &exec_policy,
+            "cp ./input.txt ./out.txt",
+            false,
+            Some(&CommandSandboxIntent {
+                declared_write_paths: vec![std::path::PathBuf::from("./out.txt")],
+                ..intent.clone()
+            })
+        ));
+    }
+
+    #[test]
+    fn autonomous_retry_safe_allows_known_network_and_write_commands() {
+        let exec_policy = ExecPolicyConfig {
+            sandbox: Some(crate::runtime::config::SandboxConfig {
+                enabled: None,
+                allowed_dirs: None,
+                writable_dirs: Some(vec![".".to_string()]),
+                network_access: None,
+                readonly_home: None,
+                max_execution_time_secs: None,
+            }),
+            ..Default::default()
+        };
+
+        assert!(autonomous_retry_safe(
+            &exec_policy,
+            "curl https://example.com",
+            false,
+            Some(&CommandSandboxIntent {
+                requires_network: true,
+                ..Default::default()
+            })
+        ));
+        assert!(autonomous_retry_safe(
+            &exec_policy,
+            "mkdir ./build",
+            false,
+            Some(&CommandSandboxIntent {
+                declared_write_paths: vec![std::path::PathBuf::from("./build")],
+                ..Default::default()
+            })
+        ));
+        assert!(!autonomous_retry_safe(
+            &exec_policy,
+            "tar -xf archive.tar ./dst",
+            false,
+            Some(&CommandSandboxIntent {
+                declared_write_paths: vec![std::path::PathBuf::from("./dst")],
+                ..Default::default()
+            })
+        ));
+    }
+
+    #[test]
+    fn autonomous_retry_safe_honors_explicit_retry_policy() {
+        let exec_policy = ExecPolicyConfig::default();
+        assert!(autonomous_retry_safe(
+            &exec_policy,
+            "custom-tool ./input",
+            false,
+            Some(&CommandSandboxIntent {
+                declared_read_paths: vec![],
+                declared_write_paths: vec![std::path::PathBuf::from("./out.txt")],
+                requires_network: true,
+                retry_policy: Some(CommandRetryPolicy::Safe),
+            })
+        ));
+        assert!(!autonomous_retry_safe(
+            &exec_policy,
+            "cat ./input",
+            false,
+            Some(&CommandSandboxIntent {
+                declared_read_paths: vec![std::path::PathBuf::from("./input.txt")],
+                declared_write_paths: vec![],
+                requires_network: false,
+                retry_policy: Some(CommandRetryPolicy::Never),
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn execute_command_retries_once_for_retry_safe_failure() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "retry-safe-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Check failing command".to_string(),
+                    status: PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        let exec_policy = ExecPolicyConfig {
+            approval_profile: Some(ApprovalProfile::AllowAll),
+            allowed_commands: None,
+            blocked_commands: None,
+            sandbox_profile: Some(SandboxProfile::Disabled),
+            sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
+        };
+        let audit_ctx = CommandAuditContext {
+            conn: &conn,
+            session_id: Some("retry-safe-session"),
+            source: "test",
+        };
+
+        let _ = execute_command(
+            "[RUN_COMMAND false]",
+            &test_config(),
+            &exec_policy,
+            None,
+            Some(&audit_ctx),
+            None,
+            None,
+        )
+        .await
+        .expect("command execution should return stderr text");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "retry-safe-session")
+            .expect("load plan")
+            .expect("plan present");
+        assert_eq!(plan.items[0].status, PlanStepStatus::Blocked);
+        assert!(matches!(
+            plan.runtime
+                .as_ref()
+                .and_then(|runtime| runtime.followup.as_ref()),
+            Some(PlanFollowup::RetryOrReplan { retry_count: 2, .. })
         ));
     }
 }

--- a/lib/harper-sandbox/BUILD
+++ b/lib/harper-sandbox/BUILD
@@ -11,5 +11,7 @@ rust_library(
 rust_test(
     name = "harper_sandbox_test",
     crate = ":harper_sandbox",
-    deps = all_crate_deps(normal_dev = True),
+    deps = all_crate_deps(normal_dev = True) + [
+        "@crates//:tempfile",
+    ],
 )

--- a/lib/harper-ui/src/interfaces/ui/app.rs
+++ b/lib/harper-ui/src/interfaces/ui/app.rs
@@ -45,6 +45,7 @@ pub struct ReviewState {
 pub enum NavigationFocus {
     Messages,
     Review,
+    PlanSteps,
     PlanJobs,
     Agents,
 }
@@ -58,6 +59,8 @@ pub struct ChatState {
     pub active_agents: Option<ResolvedAgents>,
     pub active_review: Option<ReviewState>,
     pub review_selected: usize,
+    pub plan_step_selected: usize,
+    pub plan_steps_expanded: bool,
     pub plan_job_selected: usize,
     pub plan_jobs_expanded: bool,
     pub plan_job_output_scroll: usize,
@@ -206,6 +209,8 @@ pub async fn gather_sidebar_entries_async(messages: &[Message]) -> Vec<String> {
 impl ChatState {
     pub fn refresh_plan_state(&mut self) {
         if let Some(plan) = &self.active_plan {
+            let max_steps = plan.items.len().saturating_sub(1);
+            self.plan_step_selected = self.plan_step_selected.min(max_steps);
             let max_jobs = plan
                 .runtime
                 .as_ref()
@@ -213,6 +218,8 @@ impl ChatState {
                 .unwrap_or(0);
             self.plan_job_selected = self.plan_job_selected.min(max_jobs);
         } else {
+            self.plan_step_selected = 0;
+            self.plan_steps_expanded = false;
             self.plan_job_selected = 0;
             self.plan_jobs_expanded = false;
             self.plan_job_output_scroll = 0;
@@ -236,6 +243,10 @@ impl ChatState {
             .active_review
             .as_ref()
             .is_some_and(|review| !review.findings.is_empty());
+        let has_steps = self
+            .active_plan
+            .as_ref()
+            .is_some_and(|plan| !plan.items.is_empty());
         let has_jobs = self
             .active_plan
             .as_ref()
@@ -249,6 +260,7 @@ impl ChatState {
 
         self.navigation_focus = match self.navigation_focus {
             NavigationFocus::Review if has_review => NavigationFocus::Review,
+            NavigationFocus::PlanSteps if has_steps => NavigationFocus::PlanSteps,
             NavigationFocus::PlanJobs if has_jobs => NavigationFocus::PlanJobs,
             NavigationFocus::Agents if has_agents => NavigationFocus::Agents,
             _ => NavigationFocus::Messages,
@@ -259,6 +271,7 @@ impl ChatState {
         match self.navigation_focus {
             NavigationFocus::Messages => "messages",
             NavigationFocus::Review => "findings",
+            NavigationFocus::PlanSteps => "plan",
             NavigationFocus::PlanJobs => "jobs",
             NavigationFocus::Agents => "agents",
         }
@@ -361,6 +374,7 @@ pub struct TuiApp {
     pub auth_last_poll_at: Option<Instant>,
     pub approval_profile: ApprovalProfile,
     pub sandbox_profile: SandboxProfile,
+    pub retry_max_attempts: u32,
     pub allowed_commands: Vec<String>,
     pub blocked_commands: Vec<String>,
     pub execution_policy_editor: Option<ExecutionPolicyEditorState>,
@@ -384,6 +398,7 @@ impl Default for TuiApp {
             auth_last_poll_at: None,
             approval_profile: ApprovalProfile::AllowListed,
             sandbox_profile: SandboxProfile::Disabled,
+            retry_max_attempts: 1,
             allowed_commands: Vec::new(),
             blocked_commands: Vec::new(),
             execution_policy_editor: None,
@@ -418,7 +433,7 @@ impl TuiApp {
     }
 
     pub fn execution_policy_row_count(&self) -> usize {
-        5
+        6
     }
 
     pub fn set_error_message(&mut self, content: String) {
@@ -524,6 +539,14 @@ impl TuiApp {
                             }
                         }
                     }
+                    NavigationFocus::PlanSteps => {
+                        if let Some(plan) = &chat_state.active_plan {
+                            if !plan.items.is_empty() {
+                                chat_state.plan_step_selected =
+                                    (chat_state.plan_step_selected + 1).min(plan.items.len() - 1);
+                            }
+                        }
+                    }
                     NavigationFocus::PlanJobs => {
                         if chat_state.plan_jobs_expanded {
                             chat_state.plan_job_output_scroll =
@@ -587,6 +610,10 @@ impl TuiApp {
                 match chat_state.navigation_focus {
                     NavigationFocus::Review => {
                         chat_state.review_selected = chat_state.review_selected.saturating_sub(1);
+                    }
+                    NavigationFocus::PlanSteps => {
+                        chat_state.plan_step_selected =
+                            chat_state.plan_step_selected.saturating_sub(1);
                     }
                     NavigationFocus::PlanJobs => {
                         if chat_state.plan_jobs_expanded {

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use arboard::{Clipboard, ImageData};
-use crossterm::event::{Event, KeyCode, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use harper_core;
+use harper_core::PlanStepStatus;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -22,7 +23,7 @@ use uuid::Uuid;
 
 // Keyboard shortcut constants
 const HELP_MESSAGE: &str =
-    "G:Help | Tab:Complete | Esc:Back | ↑↓:Navigate | Y/V:Prev/Next | Enter:Select/Approve | T:Send | L/→:Preview | D/Delete:Remove Session | X:Exit | W:Web | B:Sidebar | A:Agents | F:Findings | P:Jobs | M:Msgs | C:ID";
+    "G:Help | Tab:Complete | Esc:Back | ↑↓:Navigate | Y/V:Prev/Next | Enter:Select/Approve | T:Send | L/→:Preview | D/Delete:Remove Session | X:Exit | W:Web | B:Sidebar | A:Agents | F:Findings | Ctrl+S:Plan | R:Retry | U:Replan | K:Ack | P:Jobs | M:Msgs | C:ID";
 
 use super::app::{
     AppState, ChatState, ExecutionPolicyEditorState, ExecutionPolicyListField, NavigationFocus,
@@ -47,6 +48,26 @@ pub enum EventResult {
         provider: String,
     },
     SaveExecutionPolicy,
+    SetPlanStepStatus {
+        session_id: String,
+        step_index: usize,
+        status: PlanStepStatus,
+    },
+    ClearPlan {
+        session_id: String,
+    },
+    RetryPlanFollowup {
+        session_id: String,
+        command: String,
+    },
+    RequestPlanReplan {
+        session_id: String,
+        step_index: usize,
+        step: String,
+    },
+    ClearPlanFollowup {
+        session_id: String,
+    },
     DeleteSession {
         session_id: String,
         remote: bool,
@@ -70,6 +91,8 @@ pub(crate) fn create_chat_state(
         active_agents,
         active_review: None,
         review_selected: 0,
+        plan_step_selected: 0,
+        plan_steps_expanded: false,
         plan_job_selected: 0,
         plan_jobs_expanded: false,
         plan_job_output_scroll: 0,
@@ -139,6 +162,97 @@ fn start_execution_policy_editor(app: &mut TuiApp, field: ExecutionPolicyListFie
         ExecutionPolicyListField::BlockedCommands => app.blocked_commands.join(", "),
     };
     app.execution_policy_editor = Some(ExecutionPolicyEditorState { field, input });
+}
+
+fn handle_plan_step_action(key: KeyEvent, app: &mut TuiApp) -> Option<EventResult> {
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        return None;
+    }
+    let AppState::Chat(chat_state) = &mut app.state else {
+        return None;
+    };
+    if !matches!(chat_state.navigation_focus, NavigationFocus::PlanSteps) {
+        return None;
+    }
+    let Some(plan) = &chat_state.active_plan else {
+        app.set_status_message("No active plan".to_string());
+        return Some(EventResult::Continue);
+    };
+    if plan.items.is_empty() {
+        app.set_status_message("No active plan".to_string());
+        return Some(EventResult::Continue);
+    }
+
+    let session_id = chat_state.session_id.clone();
+    let step_index = chat_state.plan_step_selected.min(plan.items.len() - 1);
+    match key.code {
+        KeyCode::Char('c') => Some(EventResult::SetPlanStepStatus {
+            session_id,
+            step_index,
+            status: PlanStepStatus::Completed,
+        }),
+        KeyCode::Char('i') => Some(EventResult::SetPlanStepStatus {
+            session_id,
+            step_index,
+            status: PlanStepStatus::InProgress,
+        }),
+        KeyCode::Char('b') => Some(EventResult::SetPlanStepStatus {
+            session_id,
+            step_index,
+            status: PlanStepStatus::Blocked,
+        }),
+        KeyCode::Char('r') => plan
+            .runtime
+            .as_ref()
+            .and_then(|runtime| runtime.followup.as_ref())
+            .and_then(|followup| match followup {
+                harper_core::core::plan::PlanFollowup::RetryOrReplan {
+                    command: Some(command),
+                    ..
+                } => Some(EventResult::RetryPlanFollowup {
+                    session_id,
+                    command: command.clone(),
+                }),
+                _ => None,
+            })
+            .or_else(|| {
+                app.set_status_message("No retryable planner command".to_string());
+                Some(EventResult::Continue)
+            }),
+        KeyCode::Char('u') => plan
+            .runtime
+            .as_ref()
+            .and_then(|runtime| runtime.followup.as_ref())
+            .and_then(|followup| match followup {
+                harper_core::core::plan::PlanFollowup::RetryOrReplan { step, .. } => {
+                    Some(EventResult::RequestPlanReplan {
+                        session_id,
+                        step_index,
+                        step: step.clone(),
+                    })
+                }
+                _ => None,
+            })
+            .or_else(|| {
+                app.set_status_message("No planner retry followup to replan".to_string());
+                Some(EventResult::Continue)
+            }),
+        KeyCode::Char('k') => {
+            if plan
+                .runtime
+                .as_ref()
+                .and_then(|runtime| runtime.followup.as_ref())
+                .is_some()
+            {
+                Some(EventResult::ClearPlanFollowup { session_id })
+            } else {
+                app.set_status_message("No planner followup to acknowledge".to_string());
+                Some(EventResult::Continue)
+            }
+        }
+        KeyCode::Char('x') => Some(EventResult::ClearPlan { session_id }),
+        _ => None,
+    }
 }
 
 pub fn handle_event(
@@ -228,6 +342,10 @@ pub fn handle_event(
                     }
                     _ => return EventResult::Continue,
                 }
+            }
+
+            if let Some(result) = handle_plan_step_action(key, app) {
+                return result;
             }
 
             // Handle Ctrl shortcuts first
@@ -429,6 +547,38 @@ pub fn handle_event(
                         app.next();
                         return EventResult::Continue;
                     }
+                    KeyCode::Char('s') => {
+                        let mut status_message = None;
+                        if let AppState::Chat(chat_state) = &mut app.state {
+                            if chat_state
+                                .active_plan
+                                .as_ref()
+                                .is_some_and(|plan| !plan.items.is_empty())
+                            {
+                                if !chat_state.plan_steps_expanded {
+                                    chat_state.plan_steps_expanded = true;
+                                    chat_state.set_navigation_focus(NavigationFocus::PlanSteps);
+                                    status_message = Some("Plan browser expanded".to_string());
+                                } else if matches!(
+                                    chat_state.navigation_focus,
+                                    NavigationFocus::PlanSteps
+                                ) {
+                                    chat_state.plan_steps_expanded = false;
+                                    chat_state.set_navigation_focus(NavigationFocus::Messages);
+                                    status_message = Some("Plan browser closed".to_string());
+                                } else {
+                                    chat_state.set_navigation_focus(NavigationFocus::PlanSteps);
+                                    status_message = Some("Focus on plan steps".to_string());
+                                }
+                            } else {
+                                status_message = Some("No active plan".to_string());
+                            }
+                        }
+                        if let Some(message) = status_message {
+                            app.set_status_message(message);
+                        }
+                        return EventResult::Continue;
+                    }
                     _ => {}
                 }
             }
@@ -463,6 +613,10 @@ pub fn handle_event(
                             chat_state.plan_job_output_scroll = 0;
                             chat_state.set_navigation_focus(NavigationFocus::Messages);
                             app.set_status_message("Planner jobs browser closed".to_string());
+                        } else if chat_state.plan_steps_expanded {
+                            chat_state.plan_steps_expanded = false;
+                            chat_state.set_navigation_focus(NavigationFocus::Messages);
+                            app.set_status_message("Plan browser closed".to_string());
                         } else {
                             app.state = AppState::Menu(0);
                         }
@@ -643,9 +797,12 @@ fn handle_enter(app: &mut TuiApp, session_service: &SessionService) -> EventResu
             1 => {
                 app.sandbox_profile = settings::next_sandbox_profile(app.sandbox_profile);
             }
-            2 => start_execution_policy_editor(app, ExecutionPolicyListField::AllowedCommands),
-            3 => start_execution_policy_editor(app, ExecutionPolicyListField::BlockedCommands),
-            4 => return EventResult::SaveExecutionPolicy,
+            2 => {
+                app.retry_max_attempts = settings::next_retry_max_attempts(app.retry_max_attempts);
+            }
+            3 => start_execution_policy_editor(app, ExecutionPolicyListField::AllowedCommands),
+            4 => start_execution_policy_editor(app, ExecutionPolicyListField::BlockedCommands),
+            5 => return EventResult::SaveExecutionPolicy,
             _ => {}
         },
         AppState::ViewSession(session_id, _, _) => {
@@ -1215,7 +1372,7 @@ mod tests {
     #[test]
     fn test_enter_execution_policy_save_returns_async_event() {
         let mut app = TuiApp::new();
-        app.state = AppState::ExecutionPolicy(4);
+        app.state = AppState::ExecutionPolicy(5);
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         harper_core::memory::storage::init_db(&conn).unwrap();
         let session_service = SessionService::new(&conn);
@@ -1232,7 +1389,7 @@ mod tests {
     fn test_enter_execution_policy_allowed_commands_opens_editor() {
         let mut app = TuiApp::new();
         app.allowed_commands = vec!["git".to_string()];
-        app.state = AppState::ExecutionPolicy(2);
+        app.state = AppState::ExecutionPolicy(3);
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         harper_core::memory::storage::init_db(&conn).unwrap();
         let session_service = SessionService::new(&conn);
@@ -1249,7 +1406,7 @@ mod tests {
     #[test]
     fn test_execution_policy_editor_commits_command_list() {
         let mut app = TuiApp::new();
-        app.state = AppState::ExecutionPolicy(2);
+        app.state = AppState::ExecutionPolicy(3);
         app.execution_policy_editor = Some(super::ExecutionPolicyEditorState {
             field: super::ExecutionPolicyListField::AllowedCommands,
             input: "git, ls, cargo".to_string(),
@@ -1266,6 +1423,218 @@ mod tests {
         assert!(matches!(result, EventResult::Continue));
         assert_eq!(app.allowed_commands, vec!["git", "ls", "cargo"]);
         assert!(app.execution_policy_editor.is_none());
+    }
+
+    #[test]
+    fn test_enter_execution_policy_retry_attempts_cycles_value() {
+        let mut app = TuiApp::new();
+        app.retry_max_attempts = 1;
+        app.state = AppState::ExecutionPolicy(2);
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Enter.into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(result, EventResult::Continue));
+        assert_eq!(app.retry_max_attempts, 2);
+    }
+
+    #[test]
+    fn ctrl_s_opens_plan_steps_browser() {
+        let mut app = TuiApp::new();
+        app.state = AppState::Chat(Box::new(create_chat_state(
+            "session".to_string(),
+            vec![],
+            Some(harper_core::PlanState {
+                explanation: None,
+                items: vec![harper_core::PlanItem {
+                    step: "First".to_string(),
+                    status: harper_core::PlanStepStatus::Pending,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            }),
+            None,
+        )));
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL)),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(result, EventResult::Continue));
+        let AppState::Chat(chat_state) = &app.state else {
+            panic!("expected chat state");
+        };
+        assert!(chat_state.plan_steps_expanded);
+        assert!(matches!(
+            chat_state.navigation_focus,
+            NavigationFocus::PlanSteps
+        ));
+    }
+
+    #[test]
+    fn plan_steps_focus_complete_shortcut_returns_status_update() {
+        let mut app = TuiApp::new();
+        let mut chat_state = create_chat_state(
+            "session".to_string(),
+            vec![],
+            Some(harper_core::PlanState {
+                explanation: None,
+                items: vec![harper_core::PlanItem {
+                    step: "First".to_string(),
+                    status: harper_core::PlanStepStatus::Pending,
+                    job_id: None,
+                }],
+                runtime: None,
+                updated_at: None,
+            }),
+            None,
+        );
+        chat_state.plan_steps_expanded = true;
+        chat_state.set_navigation_focus(NavigationFocus::PlanSteps);
+        app.state = AppState::Chat(Box::new(chat_state));
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Char('c').into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(
+            result,
+            EventResult::SetPlanStepStatus {
+                step_index: 0,
+                status: harper_core::PlanStepStatus::Completed,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn plan_steps_focus_retry_shortcut_returns_retry_event() {
+        let mut app = TuiApp::new();
+        let mut runtime = harper_core::core::plan::PlanRuntime::default();
+        runtime
+            .set_retry_or_replan_followup("Retry failing command", Some("cargo test".to_string()));
+        let mut chat_state = create_chat_state(
+            "session".to_string(),
+            vec![],
+            Some(harper_core::PlanState {
+                explanation: None,
+                items: vec![harper_core::PlanItem {
+                    step: "Retry failing command".to_string(),
+                    status: harper_core::PlanStepStatus::Blocked,
+                    job_id: None,
+                }],
+                runtime: Some(runtime),
+                updated_at: None,
+            }),
+            None,
+        );
+        chat_state.plan_steps_expanded = true;
+        chat_state.set_navigation_focus(NavigationFocus::PlanSteps);
+        app.state = AppState::Chat(Box::new(chat_state));
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Char('r').into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(
+            result,
+            EventResult::RetryPlanFollowup {
+                command,
+                ..
+            } if command == "cargo test"
+        ));
+    }
+
+    #[test]
+    fn plan_steps_focus_ack_shortcut_returns_followup_clear() {
+        let mut app = TuiApp::new();
+        let mut runtime = harper_core::core::plan::PlanRuntime::default();
+        runtime.set_checkpoint_followup("Inspect output", Some("Patch".to_string()));
+        let mut chat_state = create_chat_state(
+            "session".to_string(),
+            vec![],
+            Some(harper_core::PlanState {
+                explanation: None,
+                items: vec![harper_core::PlanItem {
+                    step: "Inspect output".to_string(),
+                    status: harper_core::PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: Some(runtime),
+                updated_at: None,
+            }),
+            None,
+        );
+        chat_state.plan_steps_expanded = true;
+        chat_state.set_navigation_focus(NavigationFocus::PlanSteps);
+        app.state = AppState::Chat(Box::new(chat_state));
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Char('k').into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(result, EventResult::ClearPlanFollowup { .. }));
+    }
+
+    #[test]
+    fn plan_steps_focus_replan_shortcut_returns_structured_event() {
+        let mut app = TuiApp::new();
+        let mut runtime = harper_core::core::plan::PlanRuntime::default();
+        runtime
+            .set_retry_or_replan_followup("Retry failing command", Some("cargo test".to_string()));
+        let mut chat_state = create_chat_state(
+            "session".to_string(),
+            vec![],
+            Some(harper_core::PlanState {
+                explanation: None,
+                items: vec![harper_core::PlanItem {
+                    step: "Retry failing command".to_string(),
+                    status: harper_core::PlanStepStatus::Blocked,
+                    job_id: None,
+                }],
+                runtime: Some(runtime),
+                updated_at: None,
+            }),
+            None,
+        );
+        chat_state.plan_steps_expanded = true;
+        chat_state.set_navigation_focus(NavigationFocus::PlanSteps);
+        app.state = AppState::Chat(Box::new(chat_state));
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        harper_core::memory::storage::init_db(&conn).unwrap();
+        let session_service = SessionService::new(&conn);
+
+        let result = handle_event(
+            Event::Key(KeyCode::Char('u').into()),
+            &mut app,
+            &session_service,
+        );
+        assert!(matches!(
+            result,
+            EventResult::RequestPlanReplan { step_index: 0, step, .. } if step == "Retry failing command"
+        ));
     }
 
     #[test]

--- a/lib/harper-ui/src/interfaces/ui/settings.rs
+++ b/lib/harper-ui/src/interfaces/ui/settings.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 pub fn save_execution_policy_settings(
     approval: ApprovalProfile,
     sandbox: SandboxProfile,
+    retry_max_attempts: u32,
     allowed_commands: &[String],
     blocked_commands: &[String],
 ) -> io::Result<()> {
@@ -29,6 +30,7 @@ pub fn save_execution_policy_settings(
         &existing,
         approval,
         sandbox,
+        retry_max_attempts,
         allowed_commands,
         blocked_commands,
     );
@@ -39,11 +41,13 @@ fn upsert_exec_policy_settings(
     input: &str,
     approval: ApprovalProfile,
     sandbox: SandboxProfile,
+    retry_max_attempts: u32,
     allowed_commands: &[String],
     blocked_commands: &[String],
 ) -> String {
     let approval_line = format!("approval_profile = \"{}\"", approval_profile_name(approval));
     let sandbox_line = format!("sandbox_profile = \"{}\"", sandbox_profile_name(sandbox));
+    let retry_line = format!("retry_max_attempts = {}", retry_max_attempts);
     let allowed_line = format!(
         "allowed_commands = {}",
         serde_json::to_string(allowed_commands).unwrap_or_else(|_| "[]".to_string())
@@ -72,6 +76,7 @@ fn upsert_exec_policy_settings(
                     let trimmed = line.trim_start();
                     !(trimmed.starts_with("approval_profile")
                         || trimmed.starts_with("sandbox_profile")
+                        || trimmed.starts_with("retry_max_attempts")
                         || trimmed.starts_with("allowed_commands")
                         || trimmed.starts_with("blocked_commands"))
                 })
@@ -79,6 +84,7 @@ fn upsert_exec_policy_settings(
                 .collect();
             section_body.insert(0, blocked_line);
             section_body.insert(0, allowed_line);
+            section_body.insert(0, retry_line);
             section_body.insert(0, sandbox_line);
             section_body.insert(0, approval_line);
 
@@ -91,6 +97,7 @@ fn upsert_exec_policy_settings(
             lines.push("[exec_policy]".to_string());
             lines.push(approval_line);
             lines.push(sandbox_line);
+            lines.push(retry_line);
             lines.push(allowed_line);
             lines.push(blocked_line);
         }
@@ -135,11 +142,15 @@ pub fn next_sandbox_profile(profile: SandboxProfile) -> SandboxProfile {
     }
 }
 
+pub fn next_retry_max_attempts(value: u32) -> u32 {
+    (value + 1) % 4
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        approval_profile_name, next_approval_profile, next_sandbox_profile, sandbox_profile_name,
-        upsert_exec_policy_settings,
+        approval_profile_name, next_approval_profile, next_retry_max_attempts,
+        next_sandbox_profile, sandbox_profile_name, upsert_exec_policy_settings,
     };
     use harper_core::{ApprovalProfile, SandboxProfile};
 
@@ -149,12 +160,14 @@ mod tests {
             "",
             ApprovalProfile::AllowListed,
             SandboxProfile::Workspace,
+            2,
             &["git".to_string()],
             &["rm".to_string()],
         );
         assert!(output.contains("[exec_policy]"));
         assert!(output.contains("approval_profile = \"allow_listed\""));
         assert!(output.contains("sandbox_profile = \"workspace\""));
+        assert!(output.contains("retry_max_attempts = 2"));
         assert!(output.contains("allowed_commands = [\"git\"]"));
         assert!(output.contains("blocked_commands = [\"rm\"]"));
     }
@@ -166,11 +179,13 @@ mod tests {
             input,
             ApprovalProfile::AllowAll,
             SandboxProfile::NetworkedWorkspace,
+            3,
             &["ls".to_string()],
             &["sudo".to_string()],
         );
         assert!(output.contains("approval_profile = \"allow_all\""));
         assert!(output.contains("sandbox_profile = \"networked_workspace\""));
+        assert!(output.contains("retry_max_attempts = 3"));
         assert!(output.contains("allowed_commands = [\"ls\"]"));
         assert!(output.contains("blocked_commands = [\"sudo\"]"));
         assert!(!output.contains("approval_profile = \"strict\""));
@@ -198,5 +213,7 @@ mod tests {
             next_sandbox_profile(SandboxProfile::Workspace),
             SandboxProfile::NetworkedWorkspace
         );
+        assert_eq!(next_retry_max_attempts(0), 1);
+        assert_eq!(next_retry_max_attempts(3), 0);
     }
 }

--- a/lib/harper-ui/src/interfaces/ui/tui.rs
+++ b/lib/harper-ui/src/interfaces/ui/tui.rs
@@ -163,6 +163,10 @@ enum WorkerMsg {
         web_search: bool,
         auth_user_id: Option<String>,
     },
+    RetryPlanCommand {
+        command: String,
+        session_id: String,
+    },
 }
 
 /// Messages sent from the background chat worker to the UI
@@ -225,6 +229,7 @@ pub async fn run_tui(
     app.auth_server_base_url = server_base_url.clone();
     app.approval_profile = exec_policy.effective_approval_profile();
     app.sandbox_profile = exec_policy.effective_sandbox_profile();
+    app.retry_max_attempts = exec_policy.effective_retry_max_attempts();
     app.allowed_commands = exec_policy.allowed_commands.clone().unwrap_or_default();
     app.blocked_commands = exec_policy.blocked_commands.clone().unwrap_or_default();
     let auth_client = reqwest::Client::new();
@@ -348,6 +353,38 @@ pub async fn run_tui(
                             Err(e) => {
                                 let _ = ui_tx_clone.send(UiUpdate::Error(e.to_string())).await;
                             }
+                        }
+                    }
+                    WorkerMsg::RetryPlanCommand {
+                        command,
+                        session_id,
+                    } => {
+                        let exec_policy = worker_exec_policy
+                            .lock()
+                            .expect("worker exec policy lock")
+                            .clone();
+                        let audit_ctx = harper_core::tools::shell::CommandAuditContext {
+                            conn: &worker_conn,
+                            session_id: Some(&session_id),
+                            source: "ui_plan_retry",
+                        };
+                        let response = format!(
+                            r#"[RUN_COMMAND {{"command":{}}}]"#,
+                            serde_json::to_string(&command)
+                                .expect("serialize retry command payload")
+                        );
+                        let result = harper_core::tools::shell::execute_command(
+                            &response,
+                            &worker_api_config,
+                            &exec_policy,
+                            None,
+                            Some(&audit_ctx),
+                            Some(approver.clone()),
+                            Some(runtime_events.clone()),
+                        )
+                        .await;
+                        if let Err(err) = result {
+                            let _ = ui_tx_clone.send(UiUpdate::Error(err.to_string())).await;
                         }
                     }
                 }
@@ -676,6 +713,7 @@ pub async fn run_tui(
                             match settings::save_execution_policy_settings(
                                 app.approval_profile,
                                 app.sandbox_profile,
+                                app.retry_max_attempts,
                                 &app.allowed_commands,
                                 &app.blocked_commands,
                             ) {
@@ -695,6 +733,7 @@ pub async fn run_tui(
                                         } else {
                                             Some(app.blocked_commands.clone())
                                         };
+                                        policy.retry_max_attempts = Some(app.retry_max_attempts);
                                     }
                                     app.set_status_message(
                                         "Saved execution policy to config/local.toml".to_string(),
@@ -704,6 +743,140 @@ pub async fn run_tui(
                                     "Failed to save execution policy: {}",
                                     err
                                 )),
+                            }
+                        }
+                        EventResult::SetPlanStepStatus {
+                            session_id,
+                            step_index,
+                            status,
+                        } => {
+                            match harper_core::tools::plan::set_plan_step_status(
+                                conn,
+                                &session_id,
+                                step_index,
+                                status,
+                            ) {
+                                Ok(()) => {
+                                    if let AppState::Chat(chat_state) = &mut app.state {
+                                        if chat_state.session_id == session_id {
+                                            match harper_core::memory::storage::load_plan_state(
+                                                conn,
+                                                &session_id,
+                                            ) {
+                                                Ok(plan) => {
+                                                    chat_state.active_plan = plan;
+                                                    chat_state.refresh_plan_state();
+                                                }
+                                                Err(err) => app.set_error_message(format!(
+                                                    "Failed to reload plan: {}",
+                                                    err
+                                                )),
+                                            }
+                                        }
+                                    }
+                                    app.set_status_message("Plan step updated".to_string());
+                                }
+                                Err(err) => app
+                                    .set_error_message(format!("Failed to update plan step: {}", err)),
+                            }
+                        }
+                        EventResult::ClearPlan { session_id } => {
+                            match harper_core::tools::plan::clear_plan_state(conn, &session_id) {
+                                Ok(()) => {
+                                    if let AppState::Chat(chat_state) = &mut app.state {
+                                        if chat_state.session_id == session_id {
+                                            chat_state.active_plan = None;
+                                            chat_state.refresh_plan_state();
+                                        }
+                                    }
+                                    app.set_status_message("Plan cleared".to_string());
+                                }
+                                Err(err) => {
+                                    app.set_error_message(format!("Failed to clear plan: {}", err))
+                                }
+                            }
+                        }
+                        EventResult::RetryPlanFollowup {
+                            session_id,
+                            command,
+                        } => {
+                            if let AppState::Chat(chat_state) = &mut app.state {
+                                if chat_state.session_id == session_id {
+                                    chat_state.command_output = None;
+                                }
+                            }
+                            app.set_activity_status(Some(format!("retrying: {}", command)));
+                            let _ = worker_tx
+                                .send(WorkerMsg::RetryPlanCommand {
+                                    command,
+                                    session_id,
+                                })
+                                .await;
+                        }
+                        EventResult::ClearPlanFollowup { session_id } => {
+                            match harper_core::tools::plan::clear_plan_followup(conn, &session_id) {
+                                Ok(()) => {
+                                    if let AppState::Chat(chat_state) = &mut app.state {
+                                        if chat_state.session_id == session_id {
+                                            match harper_core::memory::storage::load_plan_state(
+                                                conn,
+                                                &session_id,
+                                            ) {
+                                                Ok(plan) => {
+                                                    chat_state.active_plan = plan;
+                                                    chat_state.refresh_plan_state();
+                                                }
+                                                Err(err) => app.set_error_message(format!(
+                                                    "Failed to reload plan: {}",
+                                                    err
+                                                )),
+                                            }
+                                        }
+                                    }
+                                    app.set_status_message("Planner followup cleared".to_string());
+                                }
+                                Err(err) => app.set_error_message(format!(
+                                    "Failed to clear planner followup: {}",
+                                    err
+                                )),
+                            }
+                        }
+                        EventResult::RequestPlanReplan {
+                            session_id,
+                            step_index,
+                            step,
+                        } => {
+                            match harper_core::tools::plan::replan_blocked_step(
+                                conn,
+                                &session_id,
+                                step_index,
+                            ) {
+                                Ok(()) => {
+                                    if let AppState::Chat(chat_state) = &mut app.state {
+                                        if chat_state.session_id == session_id {
+                                            match harper_core::memory::storage::load_plan_state(
+                                                conn,
+                                                &session_id,
+                                            ) {
+                                                Ok(plan) => {
+                                                    chat_state.active_plan = plan;
+                                                    chat_state.refresh_plan_state();
+                                                }
+                                                Err(err) => app.set_error_message(format!(
+                                                    "Failed to reload plan: {}",
+                                                    err
+                                                )),
+                                            }
+                                        }
+                                    }
+                                    app.set_status_message(format!(
+                                        "Planner replan created for: {}",
+                                        step
+                                    ));
+                                }
+                                Err(err) => {
+                                    app.set_error_message(format!("Failed to replan step: {}", err))
+                                }
                             }
                         }
                         EventResult::StartProfileLogin { provider } => {

--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -21,7 +21,7 @@ use super::app::{
 };
 use super::settings;
 use super::theme::Theme;
-use harper_core::core::plan::{PlanJobRecord, PlanJobStatus};
+use harper_core::core::plan::{PlanFollowup, PlanJobRecord, PlanJobStatus};
 use harper_core::{PlanRuntime, PlanState, PlanStepStatus, ResolvedAgents};
 
 // Refined shortcuts for a cleaner footer
@@ -296,11 +296,18 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                     draw_plan_panel(
                         frame,
                         plan,
+                        chat_state.plan_step_selected,
                         chat_state.plan_job_selected,
-                        matches!(
-                            chat_state.navigation_focus,
-                            super::app::NavigationFocus::PlanJobs
-                        ),
+                        PlanPanelFocus {
+                            focused_steps: matches!(
+                                chat_state.navigation_focus,
+                                super::app::NavigationFocus::PlanSteps
+                            ),
+                            focused_jobs: matches!(
+                                chat_state.navigation_focus,
+                                super::app::NavigationFocus::PlanJobs
+                            ),
+                        },
                         theme,
                         chunks[next_panel_index],
                     );
@@ -378,6 +385,9 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
     }
 
     if let AppState::Chat(chat_state) = &app.state {
+        if chat_state.plan_steps_expanded {
+            draw_plan_steps_browser(frame, chat_state, theme);
+        }
         if chat_state.plan_jobs_expanded {
             draw_plan_jobs_browser(frame, chat_state, theme);
         }
@@ -626,6 +636,9 @@ fn plan_panel_height(plan: &PlanState) -> u16 {
         lines += 1;
     }
     if let Some(runtime) = &plan.runtime {
+        if runtime.followup.is_some() {
+            lines += 2;
+        }
         lines += runtime.jobs.len().min(3);
         if runtime.jobs.len() > 3 {
             lines += 1;
@@ -765,8 +778,9 @@ fn draw_review_panel(
 fn draw_plan_panel(
     frame: &mut Frame,
     plan: &PlanState,
+    selected_step: usize,
     selected_job: usize,
-    focused: bool,
+    focus: PlanPanelFocus,
     theme: &Theme,
     area: Rect,
 ) {
@@ -786,7 +800,13 @@ fn draw_plan_panel(
         ));
     }
     if let Some(runtime) = &plan.runtime {
-        lines.extend(plan_job_lines(runtime, selected_job, focused, theme));
+        lines.extend(plan_followup_lines(runtime, theme));
+        lines.extend(plan_job_lines(
+            runtime,
+            selected_job,
+            focus.focused_jobs,
+            theme,
+        ));
         if let Some(selected) = runtime
             .jobs
             .get(selected_job.min(runtime.jobs.len().saturating_sub(1)))
@@ -819,17 +839,32 @@ fn draw_plan_panel(
         }
     }
 
-    for item in plan.items.iter().take(4) {
+    let step_window_start = selected_step
+        .saturating_sub(1)
+        .min(plan.items.len().saturating_sub(4));
+    let step_window_end = (step_window_start + 4).min(plan.items.len());
+    for (offset, item) in plan.items[step_window_start..step_window_end]
+        .iter()
+        .enumerate()
+    {
+        let is_selected = focus.focused_steps && step_window_start + offset == selected_step;
         let (marker, color) = match item.status {
             PlanStepStatus::Pending => ("○", theme.muted),
             PlanStepStatus::InProgress => ("◐", theme.accent),
             PlanStepStatus::Completed => ("●", theme.output),
             PlanStepStatus::Blocked => ("■", Color::Rgb(245, 158, 11)),
         };
+        let text_style = if is_selected {
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.foreground)
+        };
         lines.push(Line::from(vec![
             Span::styled(marker, Style::default().fg(color)),
             Span::raw(" "),
-            Span::styled(item.step.as_str(), Style::default().fg(theme.foreground)),
+            Span::styled(item.step.as_str(), text_style),
         ]));
     }
 
@@ -840,10 +875,12 @@ fn draw_plan_panel(
         ));
     }
 
-    let title = if focused {
-        " Plan (focused • Y/V or ↑/↓) "
+    let title = if focus.focused_steps {
+        " Plan (Ctrl+S • C complete • I in-progress • B blocked • R retry • U replan • K ack • X clear) "
+    } else if focus.focused_jobs {
+        " Plan (jobs focused • Y/V or ↑/↓) "
     } else {
-        " Plan (Ctrl+P jobs) "
+        " Plan (Ctrl+S steps • P jobs) "
     };
     let block = Block::default()
         .title(title)
@@ -852,6 +889,12 @@ fn draw_plan_panel(
         .padding(Padding::horizontal(1));
     let widget = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
     frame.render_widget(widget, area);
+}
+
+#[derive(Clone, Copy)]
+struct PlanPanelFocus {
+    focused_steps: bool,
+    focused_jobs: bool,
 }
 
 fn agents_panel_height(agents: &ResolvedAgents, expanded: bool) -> u16 {
@@ -1005,6 +1048,45 @@ fn format_plan_runtime(runtime: &PlanRuntime) -> String {
         .or(runtime.active_tool.as_deref())
         .unwrap_or("task");
     format!("{}: {}", status, target)
+}
+
+fn plan_followup_lines(runtime: &PlanRuntime, theme: &Theme) -> Vec<Line<'static>> {
+    let Some(followup) = runtime.followup.as_ref() else {
+        return vec![];
+    };
+
+    match followup {
+        PlanFollowup::Checkpoint { step, next_step } => {
+            let mut lines = vec![Line::styled(
+                format!("checkpoint: {}", truncate_chat_summary(step, 72)),
+                theme.muted_style().add_modifier(Modifier::ITALIC),
+            )];
+            if let Some(next_step) = next_step {
+                lines.push(Line::styled(
+                    format!("  next: {}", truncate_chat_summary(next_step, 72)),
+                    theme.muted_style(),
+                ));
+            }
+            lines
+        }
+        PlanFollowup::RetryOrReplan {
+            step,
+            command,
+            retry_count,
+        } => vec![
+            Line::styled(
+                format!("retry {}: {}", retry_count, truncate_chat_summary(step, 72)),
+                Style::default().fg(Color::Rgb(245, 158, 11)),
+            ),
+            Line::styled(
+                format!(
+                    "  command: {}",
+                    truncate_chat_summary(command.as_deref().unwrap_or(step), 72)
+                ),
+                theme.muted_style(),
+            ),
+        ],
+    }
 }
 
 fn plan_job_lines(
@@ -1516,6 +1598,7 @@ fn draw_execution_policy(
             "Sandbox Profile: {}",
             settings::sandbox_profile_name(app.sandbox_profile)
         ),
+        format!("Retry Attempts: {}", app.retry_max_attempts),
         format!("Allowed Commands: {allowed}"),
         format!("Blocked Commands: {blocked}"),
         "Save and Apply".to_string(),
@@ -1552,6 +1635,10 @@ fn draw_execution_policy(
             "Allowed/blocked command lists are comma-separated and refine the selected approval profile.",
             theme.muted_style(),
         ),
+        Line::styled(
+            "Retry attempts bound autonomous retry before the planner stops and requires replanning.",
+            theme.muted_style(),
+        ),
     ])
     .block(Block::default().padding(Padding::uniform(1)))
     .wrap(Wrap { trim: true });
@@ -1564,7 +1651,7 @@ fn draw_execution_policy(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(9),
+            Constraint::Length(11),
             Constraint::Min(8),
             Constraint::Length(editor_height),
         ])
@@ -1883,6 +1970,165 @@ fn draw_plan_jobs_browser(frame: &mut Frame, chat_state: &super::app::ChatState,
     frame.render_widget(detail, chunks[2]);
 }
 
+fn draw_plan_steps_browser(frame: &mut Frame, chat_state: &super::app::ChatState, theme: &Theme) {
+    let Some(plan) = &chat_state.active_plan else {
+        return;
+    };
+    if plan.items.is_empty() {
+        return;
+    }
+
+    let selected_index = chat_state
+        .plan_step_selected
+        .min(plan.items.len().saturating_sub(1));
+    let overlay_area = centered_rect(80, 70, frame.area());
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(4),
+        ])
+        .split(overlay_area);
+
+    frame.render_widget(Clear, overlay_area);
+
+    let title = Paragraph::new(
+        "Plan Steps • Esc close • Y/V select • C complete • I in-progress • B blocked • R retry • U replan • K ack • X clear",
+    )
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.muted_style())
+            .style(Style::default().bg(theme.background)),
+    )
+    .style(Style::default().fg(theme.foreground));
+    frame.render_widget(title, chunks[0]);
+
+    let items: Vec<ListItem> = plan
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let (marker, color) = match item.status {
+                PlanStepStatus::Pending => ("○", theme.muted),
+                PlanStepStatus::InProgress => ("◐", theme.accent),
+                PlanStepStatus::Completed => ("●", theme.output),
+                PlanStepStatus::Blocked => ("■", Color::Rgb(245, 158, 11)),
+            };
+            let text_style = if index == selected_index {
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.foreground)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(marker, Style::default().fg(color)),
+                Span::raw(" "),
+                Span::styled(item.step.clone(), text_style),
+            ]))
+        })
+        .collect();
+    frame.render_widget(
+        List::new(items).block(
+            Block::default()
+                .title(" Steps ")
+                .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+                .border_style(theme.muted_style())
+                .style(Style::default().bg(theme.background))
+                .padding(Padding::horizontal(1)),
+        ),
+        chunks[1],
+    );
+
+    let selected = &plan.items[selected_index];
+    let detail = Paragraph::new(
+        vec![
+            Line::styled(
+                format!("status: {}", plan_step_status_label(selected.status)),
+                theme.muted_style(),
+            ),
+            Line::styled(
+                selected.step.as_str(),
+                Style::default().fg(theme.foreground),
+            ),
+        ]
+        .into_iter()
+        .chain(selected_step_followup_lines(
+            plan.runtime.as_ref(),
+            selected.step.as_str(),
+            theme,
+        ))
+        .collect::<Vec<_>>(),
+    )
+    .block(
+        Block::default()
+            .title(" Selected Step ")
+            .borders(Borders::LEFT | Borders::RIGHT | Borders::BOTTOM)
+            .border_style(theme.muted_style())
+            .style(Style::default().bg(theme.background))
+            .padding(Padding::horizontal(1)),
+    )
+    .wrap(Wrap { trim: true });
+    frame.render_widget(detail, chunks[2]);
+}
+
+fn selected_step_followup_lines(
+    runtime: Option<&PlanRuntime>,
+    step: &str,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
+    let Some(runtime) = runtime else {
+        return vec![];
+    };
+    let Some(followup) = runtime.followup.as_ref() else {
+        return vec![];
+    };
+    match followup {
+        PlanFollowup::Checkpoint {
+            step: followup_step,
+            next_step,
+        } if followup_step == step => {
+            let mut lines = vec![Line::styled("checkpoint pending", theme.muted_style())];
+            if let Some(next_step) = next_step {
+                lines.push(Line::styled(
+                    format!("next step: {}", truncate_chat_summary(next_step, 72)),
+                    theme.muted_style(),
+                ));
+            }
+            lines
+        }
+        PlanFollowup::RetryOrReplan {
+            step: followup_step,
+            command,
+            retry_count,
+        } if followup_step == step => vec![
+            Line::styled(
+                format!("retry count: {}", retry_count),
+                Style::default().fg(Color::Rgb(245, 158, 11)),
+            ),
+            Line::styled(
+                format!(
+                    "command: {}",
+                    truncate_chat_summary(command.as_deref().unwrap_or(step), 72)
+                ),
+                theme.muted_style(),
+            ),
+        ],
+        _ => vec![],
+    }
+}
+
+fn plan_step_status_label(status: PlanStepStatus) -> &'static str {
+    match status {
+        PlanStepStatus::Pending => "pending",
+        PlanStepStatus::InProgress => "in_progress",
+        PlanStepStatus::Completed => "completed",
+        PlanStepStatus::Blocked => "blocked",
+    }
+}
+
 fn plan_job_transcript_lines(job: &PlanJobRecord, theme: &Theme) -> Vec<Line<'static>> {
     let transcript = if job.output_transcript.trim().is_empty() {
         "No output recorded yet".to_string()
@@ -1960,6 +2206,7 @@ mod tests {
                         has_error_output: false,
                     },
                 ],
+                followup: None,
             }),
             updated_at: None,
         };
@@ -2012,6 +2259,7 @@ mod tests {
                     has_error_output: false,
                 },
             ],
+            followup: None,
         };
 
         let lines = plan_job_lines(&runtime, 0, true, &Theme::default());
@@ -2062,5 +2310,41 @@ mod tests {
         assert_eq!(transcript_lines[0].to_string(), "line one");
         assert_eq!(transcript_lines[2].to_string(), "line three");
         assert_eq!(placeholder_lines[0].to_string(), "No output recorded yet");
+    }
+
+    #[test]
+    fn plan_followup_lines_render_retry_metadata() {
+        let runtime = PlanRuntime {
+            followup: Some(PlanFollowup::RetryOrReplan {
+                step: "Patch handler".to_string(),
+                command: Some("cargo test".to_string()),
+                retry_count: 2,
+            }),
+            ..Default::default()
+        };
+
+        let lines = plan_followup_lines(&runtime, &Theme::default());
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].to_string().contains("retry 2: Patch handler"));
+        assert!(lines[1].to_string().contains("command: cargo test"));
+    }
+
+    #[test]
+    fn selected_step_followup_lines_render_checkpoint_metadata() {
+        let runtime = PlanRuntime {
+            followup: Some(PlanFollowup::Checkpoint {
+                step: "Inspect server file".to_string(),
+                next_step: Some("Patch handler".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        let lines =
+            selected_step_followup_lines(Some(&runtime), "Inspect server file", &Theme::default());
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].to_string().contains("checkpoint pending"));
+        assert!(lines[1].to_string().contains("next step: Patch handler"));
     }
 }

--- a/tests/command_log_test.rs
+++ b/tests/command_log_test.rs
@@ -36,7 +36,7 @@ async fn test_command_logging() {
         provider: ApiProvider::OpenAI,
         api_key: "test-key".to_string(),
         base_url: "https://api.openai.com/v1".to_string(),
-        model_name: "gpt-4".to_string(),
+        model_name: "gpt-5.5".to_string(),
     };
 
     let exec_policy = ExecPolicyConfig {
@@ -45,6 +45,9 @@ async fn test_command_logging() {
         blocked_commands: None,
         sandbox_profile: None,
         sandbox: None,
+        retry_max_attempts: None,
+        retry_network_commands: None,
+        retry_write_commands: None,
     };
 
     let output = shell::execute_command(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -340,7 +340,7 @@ fn test_api_config_creation() {
         provider: ApiProvider::OpenAI,
         api_key: "test-key".to_string(),
         base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-        model_name: "gpt-4".to_string(),
+        model_name: "gpt-5.5".to_string(),
     };
 
     assert!(matches!(config.provider, ApiProvider::OpenAI));
@@ -407,7 +407,7 @@ mod e2e_tests {
             provider: ApiProvider::OpenAI,
             api_key: "test-key".to_string(),
             base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-            model_name: "gpt-4".to_string(),
+            model_name: "gpt-5.5".to_string(),
         };
 
         // Test session creation and message handling
@@ -601,7 +601,7 @@ mod e2e_tests {
 provider = "OpenAI"
 api_key = "test-key"
 base_url = "https://api.openai.com/v1/chat/completions"
-model_name = "gpt-4"
+model_name = "gpt-5.5"
 
 [database]
 path = '{}'
@@ -884,7 +884,7 @@ Full output:
             provider: ApiProvider::OpenAI,
             api_key: "test-key".to_string(),
             base_url: "https://api.openai.com/v1/chat/completions".to_string(),
-            model_name: "gpt-4".to_string(),
+            model_name: "gpt-5.5".to_string(),
         };
 
         // Create exec policy
@@ -894,6 +894,9 @@ Full output:
             blocked_commands: None,
             sandbox_profile: None,
             sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
         };
 
         // Create custom commands

--- a/website/installation.html
+++ b/website/installation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Installation</title>
-    <meta name="harper-update-version" content="2026-04-28-install-v5" />
+    <meta name="harper-update-version" content="2026-04-28-install-v6" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -81,14 +81,23 @@ SUPABASE_ALLOWED_PROVIDERS=github</code></pre>
                 <p>Empty states are explicit now: if the signed-in user has no remote sessions, <code>History</code> says so directly; if there are no exportable sessions, <code>Export</code> shows that state instead of a blank panel.</p>
 
                 <h2>Execution Policy in Settings</h2>
-                <p>Harper now exposes execution policy selection directly in the TUI under <code>Settings -&gt; Execution Policy</code>. That screen lets you choose an approval profile, choose a sandbox profile, edit <code>allowed_commands</code> and <code>blocked_commands</code>, then save them back to <code>config/local.toml</code>.</p>
+                <p>Harper now exposes execution policy selection directly in the TUI under <code>Settings -&gt; Execution Policy</code>. That screen lets you choose an approval profile, choose a sandbox profile, tune retry attempts for retry-safe command failures, edit <code>allowed_commands</code> and <code>blocked_commands</code>, then save them back to <code>config/local.toml</code>.</p>
                 <div class="code-wrapper">
                     <pre><code>approval_profile = "allow_listed"   # strict | allow_listed | allow_all
-sandbox_profile = "disabled"        # disabled | workspace | networked_workspace</code></pre>
+sandbox_profile = "disabled"        # disabled | workspace | networked_workspace
+retry_max_attempts = 1</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <p>Approval profiles control whether commands always require approval, only allowlisted commands can run automatically, or all commands can run automatically. Under <code>allow_listed</code>, Harper still asks for approval when a command declares network access, or when it declares writes outside the configured sandbox writable roots, even if the command itself is allowlisted. Sandbox profiles control whether command execution is unsandboxed, sandboxed to the workspace, or sandboxed with workspace access plus network enabled.</p>
                 <p>The same screen also lets you edit <code>allowed_commands</code> and <code>blocked_commands</code> directly as comma-separated lists, so you do not have to hand-edit the local config for simple policy changes.</p>
+                <p><code>retry_max_attempts</code> controls bounded automatic retries for retry-safe commands. Network retries and write retries are still gated by command class and declared command intent.</p>
+                <div class="code-wrapper">
+                    <pre><code>[exec_policy]
+retry_max_attempts = 2
+retry_network_commands = ["curl", "wget"]
+retry_write_commands = ["mkdir", "touch"]</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
                 <p>If you need finer sandbox control than the named profiles provide, set explicit read/write roots in <code>config/local.toml</code>:</p>
                 <div class="code-wrapper">
                     <pre><code>[exec_policy.sandbox]

--- a/website/nav-updates.json
+++ b/website/nav-updates.json
@@ -1,10 +1,10 @@
 {
   "index.html": "2026-04-28-home",
-  "installation.html": "2026-04-28-install-v5",
+  "installation.html": "2026-04-28-install-v6",
   "troubleshooting.html": "2026-04-28-troubleshooting",
   "blog.html": "2026-04-28-blog-v3",
   "changelog.html": "2026-04-28-changelog",
-  "server.html": "2026-04-28-server-v5",
+  "server.html": "2026-04-28-server-v6",
   "terms.html": "2026-04-28-terms",
   "privacy.html": "2026-04-28-privacy"
 }

--- a/website/server.html
+++ b/website/server.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · API Server</title>
-    <meta name="harper-update-version" content="2026-04-28-server-v5" />
+    <meta name="harper-update-version" content="2026-04-28-server-v6" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -42,10 +42,19 @@ port = 8081</code></pre>
                 <div class="code-wrapper">
                     <pre><code>[exec_policy]
 approval_profile = "allow_listed"   # strict | allow_listed | allow_all
-sandbox_profile = "disabled"        # disabled | workspace | networked_workspace</code></pre>
+sandbox_profile = "disabled"        # disabled | workspace | networked_workspace
+retry_max_attempts = 1</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <p><code>allow_listed</code> preserves the existing default behavior for safe commands, but Harper still asks for approval when the command declares network access or writes outside the configured writable roots. <code>strict</code> requires approval for every command. <code>allow_all</code> skips approval checks. <code>workspace</code> enables sandboxing with workspace access and network disabled. <code>networked_workspace</code> enables the same workspace sandbox but allows network access.</p>
+                <p><code>retry_max_attempts</code> controls bounded automatic retries for retry-safe commands. You can also tune which command classes qualify:</p>
+                <div class="code-wrapper">
+                    <pre><code>[exec_policy]
+retry_network_commands = ["curl", "wget"]
+retry_write_commands = ["mkdir", "touch"]</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <p>Retries remain conservative: Harper still relies on declared command intent plus configured command classes, and it does not blindly retry networked or mutating commands outside those bounds.</p>
                 <p>For finer sandbox boundaries, add an explicit sandbox subsection:</p>
                 <div class="code-wrapper">
                     <pre><code>[exec_policy.sandbox]


### PR DESCRIPTION
## Changes

- completed planner follow-up orchestration in core with deterministic replan, bounded retry state, and checkpoint/retry follow-up tracking
- added plan-step browser edit actions and follow-up controls in the TUI, including retry, replan, acknowledge, and clear-plan flows
- upgraded planner cross-process delivery from the earlier platform-specific path to a cross-platform file-signal plus UDP fast-path notifier
- added execution-policy retry controls and explicit retry intent support for `run_command`, including docs and prompt/schema updates
- fixed related test and Bazel gaps, including sandbox test deps and planner notifier test isolation
- refreshed `PLANNER_NEXT_STEPS.md` and user-facing docs to reflect the current planner/runtime state

## Validation

- `cargo test -p harper-core cross_process_notifier_sends_socket_payload -- --nocapture`
- `cargo test -p harper-core cross_process_listener_rebroadcasts_updates_to_subscribers -- --nocapture`
- `cargo test -p harper-core server::tests::get_session_plan_stream_responds_with_sse -- --nocapture`
- `cargo test -p harper-core parse_run_command_sandbox_intent_reads_explicit_fields -- --nocapture`
- `cargo test -p harper-core parse_run_command_response_reads_enhanced_bracket_payload -- --nocapture`
- `cargo test -p harper-core autonomous_retry_safe_honors_explicit_retry_policy -- --nocapture`
- `cargo test -p harper-workspace --test command_log_test -- --nocapture`
- `cargo test -p harper-workspace --test integration -- --nocapture`
- `cargo check -p harper-core`
- `cargo check -p harper-ui`
- `bazel test //lib/harper-sandbox:harper_sandbox_test`
- `bazel test //lib/harper-core:harper_core_test --test_filter='core::plan_events::tests::notify_cross_process_writes_signal_file|core::plan_events::tests::cross_process_listener_rebroadcasts_updates_to_subscribers' --test_output=errors`
- `bazel test //...`
