### PR TITLE
[feat] refine routing and tui flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1901,6 +1901,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.6.3",
+ "syn 2.0.117",
  "sync_wrapper",
  "tempfile",
  "thiserror 2.0.18",

--- a/PLANNER_NEXT_STEPS.md
+++ b/PLANNER_NEXT_STEPS.md
@@ -1,6 +1,6 @@
 # Harper Planner Next Steps
 
-This file captures the remaining planner/runtime work after the current planning, job, follow-up, retry, scoped `AGENTS.md`, and cross-process delivery changes.
+This file captures the remaining planner/runtime work after the current planning, job, follow-up, retry, scoped `AGENTS.md`, cross-process delivery, deterministic repo routing, structured codebase helper changes, and persisted authoring-manager workflow.
 
 ## Count
 
@@ -12,9 +12,9 @@ There are **3 real next steps** left without changing direction.
    - Refine the existing command output panel and active runtime display.
    - Add clearer truncation controls, richer status summaries, and better failure surfacing.
 
-2. **Legacy fallback cleanup**
-   - Reduce the remaining heuristic fallback paths where explicit command intent now exists.
-   - Prefer explicit retry/sandbox intent end to end over command-shape inference.
+2. **Semantic authoring depth**
+   - Extend the current authoring manager beyond the lightweight semantic graph.
+   - Improve Rust symbol/type/trait resolution and richer multi-file edit planning.
 
 3. **Planner follow-up history polish**
    - Extend the current single follow-up state into richer visible history if needed.
@@ -23,7 +23,7 @@ There are **3 real next steps** left without changing direction.
 ## Recommended Order
 
 1. Live command output polish
-2. Legacy fallback cleanup
+2. Semantic authoring depth
 3. Planner follow-up history polish
 
 ## Suggested Milestones
@@ -31,9 +31,10 @@ There are **3 real next steps** left without changing direction.
 ### Milestone 1: Runtime polish
 - Live command output polish
 
-### Milestone 2: Fallback cleanup
-- Reduce heuristic retry/sandbox fallback paths
-- Keep explicit intent paths as the primary contract
+### Milestone 2: Semantic authoring depth
+- Improve compiler-backed candidate ownership
+- Deepen symbol/reference-aware repo understanding
+- Improve multi-file authoring decomposition quality
 
 ### Milestone 3: Follow-up history
 - Add richer checkpoint/retry review history
@@ -54,15 +55,15 @@ There are **3 real next steps** left without changing direction.
 }
 ```
 
-### Seed 2: Fallback cleanup
+### Seed 2: Semantic authoring depth
 
 ```json
 {
-  "explanation": "Reduce legacy inference paths now that explicit retry and sandbox intent are available in the core tool contract.",
+  "explanation": "Deepen the authoring helper so repo changes rely on grounded semantic context instead of shallow candidate matching.",
   "items": [
-    { "step": "Find heuristic-only paths", "status": "pending" },
-    { "step": "Prefer explicit intent", "status": "pending" },
-    { "step": "Keep compatibility fallback", "status": "pending" }
+    { "step": "Improve trait and type links", "status": "pending" },
+    { "step": "Strengthen multi-file decomposition", "status": "pending" },
+    { "step": "Keep authoring reasoning grounded", "status": "pending" }
   ]
 }
 ```
@@ -84,10 +85,10 @@ There are **3 real next steps** left without changing direction.
 
 ```json
 {
-  "explanation": "Finish the remaining planner/runtime polish after core orchestration, scoped AGENTS resolution, retry handling, and cross-process delivery are in place.",
+  "explanation": "Finish the remaining planner/runtime polish after core orchestration, scoped AGENTS resolution, retry handling, codebase helpers, and authoring-manager workflow are in place.",
   "items": [
     { "step": "Polish live command output", "status": "pending" },
-    { "step": "Reduce legacy fallback paths", "status": "pending" },
+    { "step": "Deepen semantic authoring context", "status": "pending" },
     { "step": "Improve follow-up history UX", "status": "pending" }
   ]
 }

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ea22c0a1b6f5766c820cd97ff0a7a9a0e3b25fb07a3fd8a269edb9262549d4e7",
+  "checksum": "4607d7e51685652eec6c0bb6e3424445468cf6984fd39629309d8da7ed1c9c06",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -11355,9 +11355,9 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "harper-core 0.14.0": {
+    "harper-core 0.15.0": {
       "name": "harper-core",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "package_url": "https://github.com/harpertoken/harper",
       "repository": null,
       "targets": [
@@ -11512,6 +11512,10 @@
               "target": "socket2"
             },
             {
+              "id": "syn 2.0.117",
+              "target": "syn"
+            },
+            {
               "id": "sync_wrapper 1.0.2",
               "target": "sync_wrapper"
             },
@@ -11581,7 +11585,7 @@
           ],
           "selects": {}
         },
-        "version": "0.14.0"
+        "version": "0.15.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11722,9 +11726,9 @@
       ],
       "license_file": null
     },
-    "harper-sandbox 0.1.3": {
+    "harper-sandbox 0.2.0": {
       "name": "harper-sandbox",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "package_url": null,
       "repository": null,
       "targets": [
@@ -11784,8 +11788,17 @@
             ]
           }
         },
+        "deps_dev": {
+          "common": [
+            {
+              "id": "tempfile 3.27.0",
+              "target": "tempfile"
+            }
+          ],
+          "selects": {}
+        },
         "edition": "2021",
-        "version": "0.1.3"
+        "version": "0.2.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11794,9 +11807,9 @@
       ],
       "license_file": null
     },
-    "harper-ui 0.13.0": {
+    "harper-ui 0.14.0": {
       "name": "harper-ui",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "package_url": "https://github.com/harpertoken/harper",
       "repository": null,
       "targets": [
@@ -11897,7 +11910,7 @@
           ],
           "selects": {}
         },
-        "version": "0.13.0"
+        "version": "0.14.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -23091,10 +23104,25 @@
         ],
         "crate_features": {
           "common": [
-            "default",
             "proc-macro"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -23790,10 +23818,25 @@
         ],
         "crate_features": {
           "common": [
-            "default",
             "proc-macro"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "default"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "default"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -30307,16 +30350,39 @@
             "clone-impls",
             "default",
             "derive",
-            "extra-traits",
-            "fold",
             "full",
             "parsing",
             "printing",
             "proc-macro",
-            "visit",
-            "visit-mut"
+            "visit"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              "extra-traits",
+              "fold",
+              "visit-mut"
+            ],
+            "aarch64-unknown-linux-gnu": [
+              "extra-traits",
+              "fold",
+              "visit-mut"
+            ],
+            "x86_64-pc-windows-msvc": [
+              "extra-traits",
+              "fold",
+              "visit-mut"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "extra-traits",
+              "fold",
+              "visit-mut"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "extra-traits",
+              "fold",
+              "visit-mut"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -41433,11 +41499,11 @@
   },
   "binary_crates": [],
   "workspace_members": {
-    "harper-core 0.14.0": "lib/harper-core",
+    "harper-core 0.15.0": "lib/harper-core",
     "harper-firmware 0.1.3": "lib/harper-firmware",
     "harper-mcp-server 0.1.2": "lib/harper-mcp-server",
-    "harper-sandbox 0.1.3": "lib/harper-sandbox",
-    "harper-ui 0.13.0": "lib/harper-ui",
+    "harper-sandbox 0.2.0": "lib/harper-sandbox",
+    "harper-ui 0.14.0": "lib/harper-ui",
     "harper-workspace 0.7.0": ""
   },
   "conditions": {
@@ -41740,6 +41806,7 @@
     "serde 1.0.228",
     "serde_json 1.0.149",
     "socket2 0.6.3",
+    "syn 2.0.117",
     "sync_wrapper 1.0.2",
     "syntect 5.3.0",
     "tempfile 3.27.0",

--- a/docs/development/AGENTS.md
+++ b/docs/development/AGENTS.md
@@ -185,6 +185,8 @@ fn check_permissions(path: &Path) -> Result<(), AgentError> {
 
 ## Validation Rules
 
+For routing, repo-aware tool use, transcript rendering, TUI command/file behavior, or authoring-manager changes, run the smoke checklist in `docs/testing/tui-routing-smoke.md`.
+
 ### File Type Restrictions
 ```rust
 const ALLOWED_EXTENSIONS: &[&str] = &[

--- a/docs/testing/tui-routing-smoke.md
+++ b/docs/testing/tui-routing-smoke.md
@@ -1,0 +1,152 @@
+# TUI Routing Smoke Test
+
+Use this checklist to verify Harper’s repo-aware routing, grounded tool use, and TUI rendering after changes to chat routing, codebase helpers, file tools, or transcript rendering.
+
+## Prerequisites
+
+- Build from the current workspace.
+- Restart Harper before testing.
+- Run the prompts in a fresh TUI session when possible.
+
+## Important Note
+
+- Restart Harper before testing.
+- Otherwise you may still be exercising an older running process instead of the current build.
+
+## Prompts
+
+### Repo identity
+
+- `can you check which repo we are working on`
+- `which branch am i on`
+- `which directory are we in`
+
+### Header and strategy UI
+
+- Type `/`
+- Press `Tab` to cycle slash completions
+- `/strategy`
+- `/strategy auto`
+- `/strategy grounded`
+- `/strategy deterministic`
+- `/strategy model`
+- Open `Settings -> Execution Policy`
+- Change visible header widgets
+- Save settings
+- Restart Harper
+
+### Direct file read
+
+- `Read Cargo.toml and tell me the package name.`
+
+### Codebase overview
+
+- `tell me the codebase`
+- `give me a quick overview of this repo`
+- `what are we working on here`
+
+### Open-ended authoring
+
+- `refactor the planner flow in this repo`
+- `change the retry rendering behavior in the tui`
+- `modify the subsystem that handles followup retry display`
+
+### Codebase search / render path
+
+- `Find where retry metadata is rendered in this repo.`
+- `where does the planner followup retry metadata get rendered`
+- `what file renders the retry count in the tui`
+
+### Git / change inspection
+
+- `Run git status and summarize it.`
+- `show git diff`
+- `check the code changes`
+
+### Simple command routing
+
+- `run the clear command`
+- `run pwd`
+- `run ls`
+- `run harper`
+- `run fmt`
+- `run check`
+- `run tests`
+
+### Simple file creation
+
+- `create a hello world txt file`
+- `create a python hello joy file`
+
+### Explicit file creation
+
+- `create hello.rs with fn main() { println!("Hi"); }`
+- `create notes.txt with hello from harper`
+- `create script.py with print("Hello from Harper")`
+
+### Explicit file modification
+
+- `modify notes.txt to hello from harper`
+
+### Follow-up creation
+
+Use this exact sequence:
+
+1. `hey can you create a python hello joy file`
+2. `please create the file`
+
+## Expected Outcomes
+
+- Repo/branch prompts bypass generic prose.
+- The chat header shows the configured widgets only.
+- The chat header shows the current working directory when `cwd` is enabled.
+- `/strategy` reports the current execution strategy and switching it updates the live chat session.
+- Header widget changes made in `Settings -> Execution Policy` persist to `config/local.toml`.
+- `Cargo.toml` prompt goes through a real file read.
+- Codebase prompts do not answer with generic grep advice.
+- Open-ended authoring prompts inspect first and should not jump straight to a bad edit target.
+- `git status` runs `git status`, not `git status and summarize it`.
+- Create/modify prompts route to real write operations.
+- Created file responses show fenced content with syntax highlighting.
+- Diff/code outputs render with syntax-aware formatting when detectable.
+
+## Pass / Fail Checklist
+
+- [ ] Repo identity prompts return grounded repo/branch data.
+- [ ] Current working directory prompt returns the concrete workspace path.
+- [ ] Typing `/` opens slash completion suggestions.
+- [ ] `Tab` cycles slash completions.
+- [ ] `/strategy` shows the current strategy and switching it changes the live session.
+- [ ] Header widget changes persist after save and restart.
+- [ ] Chat header only shows the widgets currently enabled.
+- [ ] Direct file read uses the real workspace file.
+- [ ] Codebase overview uses grounded workspace context.
+- [ ] Codebase search returns relevant repo files, not generic prose.
+- [ ] Open-ended authoring builds context/plan before first edit.
+- [ ] Git status/diff route to the correct underlying tool/command.
+- [ ] `clear`, `pwd`, and `ls` route as commands, not literal prose.
+- [ ] `run harper`, `run fmt`, `run check`, and `run tests` route as execution-layer commands.
+- [ ] Simple file creation writes real files in the workspace.
+- [ ] Explicit file creation writes the requested file/content.
+- [ ] Explicit file modification overwrites the requested file content.
+- [ ] Follow-up `please create the file` reuses the prior filename/content.
+- [ ] Created code/text renders back as fenced, highlighted output.
+
+## When To Run This
+
+Run this checklist after changes to:
+
+- `lib/harper-core/src/agent/intent.rs`
+- `lib/harper-core/src/agent/chat.rs`
+- `lib/harper-core/src/tools/filesystem.rs`
+- `lib/harper-core/src/tools/codebase_investigator.rs`
+- `lib/harper-core/src/tools/shell.rs`
+- `lib/harper-core/src/tools/plan.rs`
+- `lib/harper-core/src/core/plan.rs`
+- `lib/harper-core/src/runtime/config.rs`
+- `lib/harper-ui/src/interfaces/ui/app.rs`
+- `lib/harper-ui/src/interfaces/ui/events.rs`
+- `lib/harper-ui/src/interfaces/ui/settings.rs`
+- `lib/harper-ui/src/interfaces/ui/tui.rs`
+- `lib/harper-ui/src/interfaces/ui/widgets.rs`
+- `lib/harper-ui/src/plugins/syntax/mod.rs`

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -28,10 +28,14 @@ Harper separates command approval policy from sandbox policy under `[exec_policy
 ```toml
 [exec_policy]
 approval_profile = "allow_listed"   # strict | allow_listed | allow_all
+execution_strategy = "auto"         # auto | grounded | deterministic | model
 sandbox_profile = "workspace"       # disabled | workspace | networked_workspace
 retry_max_attempts = 1
 retry_network_commands = ["curl", "wget"]
 retry_write_commands = ["mkdir", "touch"]
+
+[ui]
+header_widgets = ["model", "cwd", "strategy"]
 
 [exec_policy.sandbox]
 allowed_dirs = ["."]
@@ -39,12 +43,39 @@ writable_dirs = ["./tmp", "./build"]
 ```
 
 - `approval_profile` controls when Harper asks before running commands.
+- `execution_strategy` controls whether Harper prefers model-first grounded behavior, deterministic execution, or no deterministic shortcuts.
 - `sandbox_profile` controls the default sandbox boundary.
 - `retry_max_attempts` controls bounded automatic retries for retry-safe failures.
+- `header_widgets` controls which status items appear in the chat header. You can edit that list from `Settings -> Execution Policy`, and saving the screen writes the selection back to `config/local.toml`.
 - `allowed_dirs` are readable roots.
 - `writable_dirs` are writable roots.
 
+Supported `header_widgets` values:
+
+- `session`
+- `plan`
+- `agents`
+- `web`
+- `auth`
+- `focus`
+- `model`
+- `cwd`
+- `strategy`
+- `approval`
+- `activity`
+
 Under `allow_listed`, Harper still asks for approval when a command declares network access or writes outside configured writable roots, even if the command itself is allowlisted.
+
+## Repo-aware routing
+
+Harper now uses deterministic routing only for high-confidence workspace intents, not as a replacement for model reasoning.
+
+- direct operational facts such as `which branch am i on` or `which repo are we working on`
+- direct file reads such as `read Cargo.toml`
+- simple create/write prompts such as `create hello.rs with ...`
+- direct command prompts such as `run git status`
+
+For broader repo questions such as `tell me the codebase` or `find where X is rendered`, Harper first gathers structured codebase context, then lets the model answer from that grounded context. Deterministic summaries remain fallback only when the model returns an empty or low-value response.
 
 ## API Configuration
 

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -54,6 +54,7 @@ walkdir = "2.5"
 tempfile = "3.10"
 harper-firmware = { path = "../harper-firmware" }
 harper-sandbox = { path = "../harper-sandbox" }
+syn = { version = "2.0", features = ["full", "visit"] }
 
 # Dependency resolution
 [dependencies.base64]

--- a/lib/harper-core/src/agent/chat.rs
+++ b/lib/harper-core/src/agent/chat.rs
@@ -21,9 +21,11 @@ use crate::agent::offline_shell::plan_offline_shell_commands;
 use crate::agent::prompt::PromptBuilder;
 use crate::core::cache::{ApiCacheKey, ApiResponseCache};
 use crate::core::error::{HarperError, HarperResult};
+use crate::core::plan::AuthoringPhase;
 use crate::core::{ApiConfig, Message};
 use crate::memory::storage::CommandLogEntry;
-use crate::runtime::config::ExecPolicyConfig;
+use crate::parsing;
+use crate::runtime::config::{ExecPolicyConfig, ExecutionStrategy};
 use crate::runtime::scheduler::{TaskPriority, TaskScheduler};
 use crate::tools::shell::CommandAuditContext;
 use crate::tools::ToolService;
@@ -50,6 +52,7 @@ enum CommandAction {
     Clear,
     Exit,
     Audit(AuditParams),
+    Strategy(Option<ExecutionStrategy>),
     Custom(String),
     Unknown(String),
 }
@@ -75,6 +78,12 @@ enum AuditApprovalFilter {
 }
 
 struct FileCompleter;
+
+#[derive(Debug, Clone)]
+struct AuthoringRequestContext {
+    prompt: String,
+    candidate_paths: HashSet<PathBuf>,
+}
 
 impl Helper for FileCompleter {}
 
@@ -193,6 +202,7 @@ pub struct ChatService<'a> {
     background_tasks: TaskScheduler<ChatBackgroundTask>,
     todo_reminder_armed: bool,
     last_audit_refresh: Option<Instant>,
+    execution_strategy: ExecutionStrategy,
 }
 
 #[allow(dead_code)]
@@ -210,6 +220,7 @@ impl<'a> ChatService<'a> {
         custom_commands: HashMap<String, String>,
         exec_policy: ExecPolicyConfig,
     ) -> Self {
+        let execution_strategy = exec_policy.effective_execution_strategy();
         Self {
             conn,
             config,
@@ -224,6 +235,7 @@ impl<'a> ChatService<'a> {
             background_tasks: TaskScheduler::new(),
             todo_reminder_armed: false,
             last_audit_refresh: None,
+            execution_strategy,
         }
     }
 
@@ -259,12 +271,14 @@ impl<'a> ChatService<'a> {
                 retry_max_attempts: None,
                 retry_network_commands: None,
                 retry_write_commands: None,
+                execution_strategy: None,
             },
             approver: None,
             runtime_events: None,
             background_tasks: TaskScheduler::new(),
             todo_reminder_armed: false,
             last_audit_refresh: None,
+            execution_strategy: ExecutionStrategy::Auto,
         }
     }
 
@@ -309,6 +323,19 @@ impl<'a> ChatService<'a> {
                     CommandAction::Audit(params) => {
                         self.format_command_audit(session_id, &params)?
                     }
+                    CommandAction::Strategy(Some(strategy)) => {
+                        self.execution_strategy = strategy;
+                        format!(
+                            "Execution strategy set to `{}`.",
+                            Self::execution_strategy_name(strategy)
+                        )
+                    }
+                    CommandAction::Strategy(None) => {
+                        format!(
+                            "Current execution strategy: `{}`.",
+                            Self::execution_strategy_name(self.execution_strategy)
+                        )
+                    }
                     CommandAction::Custom(desc) => {
                         self.add_user_message(history, session_id, &desc)?;
                         let response = self
@@ -334,15 +361,6 @@ impl<'a> ChatService<'a> {
 
         // Normal message processing
         self.add_user_message(history, session_id, &processed_msg)?;
-        if let Some(local_response) = self
-            .try_handle_deterministic_intent(&processed_msg, session_id)
-            .await?
-        {
-            self.notify_command_activity(session_id);
-            self.add_assistant_message(history, session_id, &local_response)?;
-            self.trim_history(history);
-            return Ok(());
-        }
         if let Some(local_response) = self
             .try_handle_offline_shell_proxy(&processed_msg, session_id)
             .await?
@@ -491,6 +509,9 @@ impl<'a> ChatService<'a> {
         help_text.push_str("  /exit - Exit the session\n");
         help_text.push_str("  /clear - Clear chat history\n");
         help_text.push_str("  /audit [limit] - Show recent command executions\n");
+        help_text.push_str(
+            "  /strategy [auto|grounded|deterministic|model] - Set or show execution strategy\n",
+        );
         help_text.push_str("  !command - Execute shell command directly\n");
         help_text.push_str("  @file - Reference and read files (with Tab completion)\n");
         for (cmd, desc) in &self.custom_commands {
@@ -523,6 +544,16 @@ impl<'a> ChatService<'a> {
         match name {
             "exit" => CommandAction::Exit,
             "clear" => CommandAction::Clear,
+            "strategy" => match args {
+                Some(value) => match Self::parse_execution_strategy(value) {
+                    Some(strategy) => CommandAction::Strategy(Some(strategy)),
+                    None => CommandAction::Unknown(format!(
+                        "Unknown strategy '{}'. Use: auto, grounded, deterministic, model.",
+                        value
+                    )),
+                },
+                None => CommandAction::Strategy(None),
+            },
             "audit" => match parse_audit_params(args) {
                 Ok(params) => CommandAction::Audit(params),
                 Err(err) => CommandAction::Unknown(err.to_string()),
@@ -744,6 +775,21 @@ impl<'a> ChatService<'a> {
                             }
                             continue;
                         }
+                        CommandAction::Strategy(Some(strategy)) => {
+                            self.execution_strategy = strategy;
+                            println!(
+                                "Execution strategy set to `{}`.",
+                                Self::execution_strategy_name(strategy)
+                            );
+                            continue;
+                        }
+                        CommandAction::Strategy(None) => {
+                            println!(
+                                "Current execution strategy: `{}`.",
+                                Self::execution_strategy_name(self.execution_strategy)
+                            );
+                            continue;
+                        }
                         CommandAction::Custom(desc) => {
                             println!("Custom command: {}", desc);
                             self.add_user_message(history, session_id, &desc)?;
@@ -831,18 +877,103 @@ impl<'a> ChatService<'a> {
                 content: plan_prompt,
             });
         }
-        self.emit_activity_update(session_id, Some("thinking".to_string()));
-        let mut response = self.call_llm(&client, &history_for_llm).await?;
-        let mut executed_tool_calls: HashSet<String> = HashSet::new();
-        let mut injected_agents_guidance: HashSet<String> = HashSet::new();
-        let mut last_tool_content: Option<String> = None;
-        let mut forced_tool_retry = false;
         let last_user_msg = history
             .iter()
             .rev()
             .find(|message| message.role == "user")
             .map(|message| message.content.clone())
             .unwrap_or_default();
+        let mut authoring_context = None;
+        if let Some(authoring_request_context) =
+            self.authoring_prompt_for_request(&last_user_msg).await?
+        {
+            history_for_llm.push(Message {
+                role: "system".to_string(),
+                content: authoring_request_context.prompt.clone(),
+            });
+            authoring_context = Some(authoring_request_context);
+        }
+
+        if self.execution_strategy == ExecutionStrategy::Deterministic {
+            if let Some((tool_name, tool_content)) = self
+                .try_handle_deterministic_intent(history, &last_user_msg, session_id)
+                .await?
+            {
+                return self
+                    .summarize_deterministic_tool_result(
+                        &client,
+                        &mut history_for_llm,
+                        history,
+                        session_id,
+                        &tool_name,
+                        &tool_content,
+                    )
+                    .await;
+            }
+        }
+
+        self.emit_activity_update(session_id, Some("thinking".to_string()));
+        let mut response = self.call_llm(&client, &history_for_llm).await?;
+        let mut executed_tool_calls: HashSet<String> = HashSet::new();
+        let mut injected_agents_guidance: HashSet<String> = HashSet::new();
+        let mut last_tool_content: Option<String> = None;
+        let mut forced_tool_retry = false;
+        let persisted_authoring = self
+            .prompt_id
+            .as_deref()
+            .and_then(|session_id| {
+                crate::memory::storage::load_plan_state(self.conn, session_id).ok()
+            })
+            .flatten()
+            .and_then(|plan| plan.runtime)
+            .and_then(|runtime| runtime.authoring);
+        let persisted_authoring_scope: HashSet<PathBuf> = persisted_authoring
+            .as_ref()
+            .map(|authoring| {
+                authoring
+                    .edit_scope
+                    .iter()
+                    .map(|path| Self::normalize_authoring_path(PathBuf::from(path)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut saw_authoring_inspection = persisted_authoring
+            .as_ref()
+            .and_then(|authoring| authoring.phase.as_ref())
+            .is_some_and(|phase| {
+                matches!(
+                    phase,
+                    AuthoringPhase::FilesInspected
+                        | AuthoringPhase::EditsApplied
+                        | AuthoringPhase::Validated
+                )
+            });
+        let mut saw_plan_update = persisted_authoring
+            .as_ref()
+            .and_then(|authoring| authoring.phase.as_ref())
+            .is_some_and(|phase| {
+                matches!(
+                    phase,
+                    AuthoringPhase::PlanCreated
+                        | AuthoringPhase::FilesInspected
+                        | AuthoringPhase::EditsApplied
+                        | AuthoringPhase::Validated
+                )
+            });
+        let mut inspected_paths: HashSet<PathBuf> = persisted_authoring
+            .as_ref()
+            .map(|authoring| {
+                authoring
+                    .inspected_files
+                    .iter()
+                    .map(|path| Self::normalize_authoring_path(PathBuf::from(path)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let has_structured_authoring_plan = persisted_authoring
+            .as_ref()
+            .and_then(|authoring| authoring.structured_plan.as_ref())
+            .is_some();
 
         for _ in 0..MAX_TOOL_ROUNDS {
             let clean_response = Self::sanitize_model_response(&response);
@@ -850,6 +981,29 @@ impl<'a> ChatService<'a> {
             let dedupe_key = tool_signature
                 .clone()
                 .unwrap_or_else(|| clean_response.clone());
+            if self.execution_strategy != ExecutionStrategy::Deterministic
+                && matches!(
+                    self.execution_strategy,
+                    ExecutionStrategy::Auto | ExecutionStrategy::Grounded
+                )
+                && Self::response_looks_like_generic_capability_refusal(&clean_response)
+            {
+                if let Some((tool_name, tool_content)) = self
+                    .try_handle_deterministic_intent(history, &last_user_msg, session_id)
+                    .await?
+                {
+                    return self
+                        .summarize_deterministic_tool_result(
+                            &client,
+                            &mut history_for_llm,
+                            history,
+                            session_id,
+                            &tool_name,
+                            &tool_content,
+                        )
+                        .await;
+                }
+            }
             if let Some(required_tool) =
                 Self::forced_tool_retry_target(&last_user_msg, &clean_response, forced_tool_retry)
             {
@@ -860,6 +1014,34 @@ impl<'a> ChatService<'a> {
                         "The user request requires an actual tool call. Do not answer with prose. Respond now with exactly one JSON tool call using `{}`.",
                         required_tool
                     ),
+                });
+                self.emit_activity_update(session_id, Some("thinking".to_string()));
+                response = self.call_llm(&client, &history_for_llm).await?;
+                continue;
+            }
+            let merged_candidate_paths = authoring_context
+                .as_ref()
+                .map(|ctx| {
+                    let mut merged = ctx.candidate_paths.clone();
+                    merged.extend(persisted_authoring_scope.iter().cloned());
+                    merged
+                })
+                .or_else(|| {
+                    (!persisted_authoring_scope.is_empty())
+                        .then_some(persisted_authoring_scope.clone())
+                });
+            if let Some(authoring_retry_prompt) = Self::authoring_tool_retry_prompt(
+                &last_user_msg,
+                &clean_response,
+                merged_candidate_paths.as_ref(),
+                saw_authoring_inspection,
+                saw_plan_update,
+                has_structured_authoring_plan,
+                &inspected_paths,
+            ) {
+                history_for_llm.push(Message {
+                    role: "system".to_string(),
+                    content: authoring_retry_prompt,
                 });
                 self.emit_activity_update(session_id, Some("thinking".to_string()));
                 response = self.call_llm(&client, &history_for_llm).await?;
@@ -911,6 +1093,71 @@ impl<'a> ChatService<'a> {
 
             if let Some((tool_result, tool_content)) = tool_option {
                 self.notify_command_activity(session_id);
+                if let Some(tool_name) = Self::tool_name_from_tool_call(&clean_response) {
+                    if tool_name == "update_plan" {
+                        saw_plan_update = true;
+                        if let Some(authoring_request_context) = authoring_context.as_ref() {
+                            let _ = crate::tools::plan::seed_plan_authoring_context(
+                                self.conn,
+                                session_id,
+                                &last_user_msg,
+                                authoring_request_context
+                                    .candidate_paths
+                                    .iter()
+                                    .map(|path| path.display().to_string())
+                                    .collect(),
+                            );
+                        }
+                        let _ = crate::tools::plan::mark_plan_authoring_plan_created(
+                            self.conn, session_id,
+                        );
+                    }
+                    if matches!(
+                        tool_name.as_str(),
+                        "read_file"
+                            | "codebase_investigator"
+                            | "git_diff"
+                            | "git_status"
+                            | "list_changed_files"
+                            | "grep"
+                    ) {
+                        saw_authoring_inspection = true;
+                        let inspected = ToolService::target_paths_for_tool_call(&clean_response)
+                            .into_iter()
+                            .map(Self::normalize_authoring_path)
+                            .collect::<Vec<_>>();
+                        inspected_paths.extend(inspected.iter().cloned());
+                        let _ = crate::tools::plan::mark_plan_authoring_inspection(
+                            self.conn,
+                            session_id,
+                            inspected
+                                .into_iter()
+                                .map(|path| path.display().to_string())
+                                .collect(),
+                        );
+                    }
+                    if matches!(tool_name.as_str(), "search_replace" | "write_file") {
+                        let edited = ToolService::target_paths_for_tool_call(&clean_response)
+                            .into_iter()
+                            .map(Self::normalize_authoring_path)
+                            .collect::<Vec<_>>();
+                        let _ = crate::tools::plan::mark_plan_authoring_edit_applied(
+                            self.conn,
+                            session_id,
+                            edited
+                                .into_iter()
+                                .map(|path| path.display().to_string())
+                                .collect(),
+                        );
+                    }
+                    if tool_name == "run_command"
+                        && Self::is_authoring_validation_command(&clean_response)
+                    {
+                        let _ = crate::tools::plan::mark_plan_authoring_validated(
+                            self.conn, session_id,
+                        );
+                    }
+                }
                 executed_tool_calls.insert(dedupe_key);
                 last_tool_content = Some(tool_content.clone());
                 let tool_message = Message {
@@ -926,7 +1173,22 @@ impl<'a> ChatService<'a> {
             break;
         }
 
-        Ok(response)
+        Ok(Self::finalize_assistant_response(
+            &response,
+            last_tool_content.as_deref(),
+        ))
+    }
+
+    fn finalize_assistant_response(response: &str, last_tool_content: Option<&str>) -> String {
+        if !response.trim().is_empty() {
+            return response.to_string();
+        }
+
+        if let Some(tool_content) = last_tool_content.filter(|content| !content.trim().is_empty()) {
+            return format!("Tool result:\n{}", tool_content);
+        }
+
+        "The model returned an empty response.".to_string()
     }
 
     fn agents_guidance_for_tool_call(
@@ -1125,6 +1387,71 @@ impl<'a> ChatService<'a> {
         has_action && (has_sequence || word_count >= 14)
     }
 
+    async fn authoring_prompt_for_request(
+        &self,
+        user_msg: &str,
+    ) -> Result<Option<AuthoringRequestContext>, HarperError> {
+        if !Self::request_needs_authoring_flow(user_msg) {
+            return Ok(None);
+        }
+
+        let overview = crate::tools::codebase_investigator::authoring_context(user_msg).await?;
+        Ok(Some(AuthoringRequestContext {
+            prompt: format!(
+                "This is an open-ended code authoring request. Do not answer with prose-only guidance. Use actual Harper tools to act on the repository. First inspect the grounded repo context below. If the task is multi-step, keep the task state current with update_plan before substantial edits. When the target is ambiguous, inspect the codebase before editing. Prefer this flow: understand the repo context, inspect relevant files, update_plan if needed, then use write_file/search_replace/run_command to make the change. Use the AUTHORING_CONTEXT and CANDIDATES sections to decide which files to inspect or edit first.\n\nGrounded repo context:\n{}",
+                overview
+            ),
+            candidate_paths: Self::extract_authoring_candidate_paths(&overview),
+        }))
+    }
+
+    fn request_needs_authoring_flow(user_msg: &str) -> bool {
+        let lower = user_msg.to_ascii_lowercase();
+        let has_authoring_signal = [
+            "create",
+            "make",
+            "modify",
+            "update",
+            "change",
+            "edit",
+            "refactor",
+            "implement",
+            "add",
+            "build",
+            "wire",
+        ]
+        .iter()
+        .any(|marker| lower.contains(marker));
+        if !has_authoring_signal {
+            return false;
+        }
+
+        let is_direct_deterministic_action = crate::agent::intent::route_intent(user_msg)
+            .is_some_and(|intent| {
+                matches!(
+                    intent,
+                    crate::agent::intent::DeterministicIntent::WriteFile(_)
+                        | crate::agent::intent::DeterministicIntent::ReadFile(_)
+                        | crate::agent::intent::DeterministicIntent::RunCommand(_)
+                )
+            });
+        if is_direct_deterministic_action {
+            return false;
+        }
+
+        lower.contains("repo")
+            || lower.contains("codebase")
+            || lower.contains("subsystem")
+            || lower.contains("feature")
+            || lower.contains("screen")
+            || lower.contains("tui")
+            || lower.contains("ui")
+            || lower.contains("core")
+            || lower.contains("planner")
+            || lower.contains("flow")
+            || lower.contains("behavior")
+    }
+
     fn request_requires_tool(user_msg: &str) -> Option<&'static str> {
         let lower = user_msg.to_ascii_lowercase();
         if lower.contains("git diff")
@@ -1135,6 +1462,29 @@ impl<'a> ChatService<'a> {
         }
         if lower.contains("git status") || lower.contains("status of repo") {
             return Some("git_status");
+        }
+        if (lower.contains("repo")
+            || lower.contains("repository")
+            || lower.contains("codebase")
+            || lower.contains("project"))
+            && (lower.contains("find ")
+                || lower.contains("where ")
+                || lower.contains("render")
+                || lower.contains("located")
+                || lower.contains("lives")
+                || lower.contains("defined")
+                || lower.contains("used"))
+        {
+            return Some("codebase_investigator");
+        }
+        if lower.contains("where is")
+            || lower.contains("where does")
+            || lower.contains("find where")
+            || lower.contains("find all")
+            || lower.contains("who calls")
+            || lower.contains("what renders")
+        {
+            return Some("codebase_investigator");
         }
         if (lower.contains("read ")
             || lower.contains("show ")
@@ -1155,6 +1505,9 @@ impl<'a> ChatService<'a> {
             && (lower.contains("file") || lower.contains(".rs") || lower.contains(".md"))
         {
             return Some("search_replace");
+        }
+        if Self::request_needs_authoring_flow(user_msg) {
+            return Some("codebase_investigator");
         }
         if lower.contains("run ")
             || lower.contains("execute ")
@@ -1195,6 +1548,200 @@ impl<'a> ChatService<'a> {
                 .trim()
                 .to_string()
         }
+    }
+
+    fn authoring_tool_retry_prompt(
+        user_msg: &str,
+        model_response: &str,
+        candidate_paths: Option<&HashSet<PathBuf>>,
+        saw_authoring_inspection: bool,
+        saw_plan_update: bool,
+        has_structured_authoring_plan: bool,
+        inspected_paths: &HashSet<PathBuf>,
+    ) -> Option<String> {
+        if !Self::request_needs_authoring_flow(user_msg) {
+            return None;
+        }
+        let tool_name = Self::tool_name_from_tool_call(model_response)?;
+        if !matches!(tool_name.as_str(), "search_replace" | "write_file") {
+            return None;
+        }
+        if Self::request_needs_plan(user_msg) && !saw_plan_update {
+            return Some(
+                "This is an open-ended multi-step authoring request. Before the first edit, call update_plan with concise steps and exactly one in_progress item. Do not edit any file yet.".to_string(),
+            );
+        }
+        if !has_structured_authoring_plan && Self::request_needs_plan(user_msg) {
+            return Some(
+                "Before the first edit on this open-ended authoring task, call update_plan with an authoring_plan that lists primary_files, supporting_files, planned_edits, and validation_plan. Do not edit any file yet.".to_string(),
+            );
+        }
+        if !saw_authoring_inspection {
+            let candidate_hint = candidate_paths
+                .map(Self::format_authoring_candidate_hint)
+                .unwrap_or_else(|| "Inspect the grounded repo context first.".to_string());
+            return Some(format!(
+                "Do not edit yet. This open-ended authoring request requires inspection before the first write/search_replace. First call codebase_investigator or read_file on a concrete repo file, then edit. {}",
+                candidate_hint
+            ));
+        }
+        let target_paths = ToolService::target_paths_for_tool_call(model_response);
+        if !target_paths.is_empty()
+            && !Self::authoring_targets_allowed(&target_paths, candidate_paths, inspected_paths)
+        {
+            let candidate_hint = candidate_paths
+                .map(Self::format_authoring_candidate_hint)
+                .unwrap_or_else(|| "Edit only files you inspected in this session.".to_string());
+            return Some(format!(
+                "Do not edit that path yet. For this authoring request, edits must target files from the grounded candidate set or files you already inspected. {}",
+                candidate_hint
+            ));
+        }
+        None
+    }
+
+    fn tool_name_from_tool_call(tool_call_json: &str) -> Option<String> {
+        let trimmed = tool_call_json.trim();
+        if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            if let Some(name) = json_value
+                .get("tool")
+                .and_then(|v| v.as_str())
+                .or_else(|| json_value.get("name").and_then(|v| v.as_str()))
+            {
+                return Some(name.to_string());
+            }
+            if let Some(first) = json_value.as_array().and_then(|arr| arr.first()) {
+                if let Some(name) = first
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|v| v.as_str())
+                {
+                    return Some(name.to_string());
+                }
+            }
+        }
+        let upper = trimmed.to_ascii_uppercase();
+        if upper.starts_with("[READ_FILE") {
+            Some("read_file".to_string())
+        } else if upper.starts_with("[RUN_COMMAND") {
+            Some("run_command".to_string())
+        } else if upper.starts_with("[GIT_STATUS") {
+            Some("git_status".to_string())
+        } else if upper.starts_with("[GIT_DIFF") {
+            Some("git_diff".to_string())
+        } else if upper.starts_with("[SEARCH_REPLACE") {
+            Some("search_replace".to_string())
+        } else if upper.starts_with("[WRITE_FILE") {
+            Some("write_file".to_string())
+        } else if upper.starts_with("[UPDATE_PLAN") {
+            Some("update_plan".to_string())
+        } else if upper.starts_with("[CODEBASE_INVESTIGATOR") {
+            Some("codebase_investigator".to_string())
+        } else {
+            None
+        }
+    }
+
+    fn extract_run_command_text(tool_call_json: &str) -> Option<String> {
+        let trimmed = tool_call_json.trim();
+        if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            let args = json_value
+                .get("args")
+                .or_else(|| json_value.get("arguments"))?;
+            return args
+                .get("command")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+        }
+        parsing::extract_tool_arg(trimmed, "[RUN_COMMAND").ok()
+    }
+
+    fn is_authoring_validation_command(tool_call_json: &str) -> bool {
+        let Some(command) = Self::extract_run_command_text(tool_call_json) else {
+            return false;
+        };
+        let lower = command.to_ascii_lowercase();
+        lower.contains("cargo check")
+            || lower.contains("cargo test")
+            || lower.contains("cargo fmt")
+            || lower.contains("pytest")
+            || lower.contains("npm test")
+            || lower.contains("pnpm test")
+    }
+
+    fn extract_authoring_candidate_paths(overview: &str) -> HashSet<PathBuf> {
+        overview
+            .lines()
+            .filter_map(|line| line.strip_prefix("FILE: "))
+            .map(|path| Self::normalize_authoring_path(PathBuf::from(path.trim())))
+            .collect()
+    }
+
+    fn normalize_authoring_path(path: PathBuf) -> PathBuf {
+        let path_str = path.to_string_lossy();
+        if let Some(stripped) = path_str.strip_prefix("./") {
+            PathBuf::from(stripped)
+        } else {
+            path
+        }
+    }
+
+    fn format_authoring_candidate_hint(candidate_paths: &HashSet<PathBuf>) -> String {
+        if candidate_paths.is_empty() {
+            return "Inspect a concrete repo file first.".to_string();
+        }
+        let mut candidates = candidate_paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>();
+        candidates.sort();
+        candidates.dedup();
+        format!(
+            "Inspect or edit one of these candidate files first: {}.",
+            candidates
+                .into_iter()
+                .take(4)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+
+    fn authoring_targets_allowed(
+        target_paths: &[PathBuf],
+        candidate_paths: Option<&HashSet<PathBuf>>,
+        inspected_paths: &HashSet<PathBuf>,
+    ) -> bool {
+        target_paths.iter().all(|target_path| {
+            let normalized_target = Self::normalize_authoring_path(target_path.clone());
+            let target_name = normalized_target.file_name().and_then(|name| name.to_str());
+            inspected_paths.iter().any(|allowed| {
+                let normalized_allowed = Self::normalize_authoring_path(allowed.clone());
+                normalized_allowed == normalized_target
+                    || normalized_allowed.ends_with(&normalized_target)
+                    || normalized_target.ends_with(&normalized_allowed)
+                    || target_name
+                        .zip(
+                            normalized_allowed
+                                .file_name()
+                                .and_then(|name| name.to_str()),
+                        )
+                        .is_some_and(|(target, allowed)| target == allowed)
+            }) || candidate_paths.is_some_and(|candidates| {
+                candidates.iter().any(|allowed| {
+                    let normalized_allowed = Self::normalize_authoring_path(allowed.clone());
+                    normalized_allowed == normalized_target
+                        || normalized_allowed.ends_with(&normalized_target)
+                        || normalized_target.ends_with(&normalized_allowed)
+                        || target_name
+                            .zip(
+                                normalized_allowed
+                                    .file_name()
+                                    .and_then(|name| name.to_str()),
+                            )
+                            .is_some_and(|(target, allowed)| target == allowed)
+                })
+            })
+        })
     }
 
     fn tool_call_signature(response: &str) -> Option<String> {
@@ -1252,10 +1799,15 @@ impl<'a> ChatService<'a> {
 
     async fn try_handle_deterministic_intent(
         &self,
+        history: &[Message],
         user_msg: &str,
         session_id: &str,
-    ) -> Result<Option<String>, HarperError> {
-        match route_intent(user_msg) {
+    ) -> Result<Option<(String, String)>, HarperError> {
+        let routed_intent = route_intent(user_msg).or_else(|| {
+            Self::infer_followup_write_file_intent(history, user_msg)
+                .map(DeterministicIntent::WriteFile)
+        });
+        match routed_intent {
             Some(DeterministicIntent::ListChangedFiles(filters)) => {
                 let audit_ctx = CommandAuditContext {
                     conn: self.conn,
@@ -1272,10 +1824,568 @@ impl<'a> ChatService<'a> {
                     filters.since.as_deref(),
                 )
                 .await?;
-                Ok(Some(response))
+                Ok(Some(("list_changed_files".to_string(), response)))
+            }
+            Some(DeterministicIntent::GitStatus) => {
+                let response = crate::tools::git::git_status()?;
+                Ok(Some(("git_status".to_string(), response)))
+            }
+            Some(DeterministicIntent::GitDiff) => {
+                let response = crate::tools::git::git_diff()?;
+                Ok(Some(("git_diff".to_string(), response)))
+            }
+            Some(DeterministicIntent::GitBranch) => {
+                let response = crate::tools::git::current_branch()?;
+                Ok(Some(("git_branch".to_string(), response)))
+            }
+            Some(DeterministicIntent::CurrentDirectory) => {
+                let cwd = std::env::current_dir().map_err(|e| {
+                    HarperError::Command(format!("Failed to determine current directory: {}", e))
+                })?;
+                Ok(Some((
+                    "current_directory".to_string(),
+                    format!("Current working directory: {}", cwd.display()),
+                )))
+            }
+            Some(DeterministicIntent::RepoIdentity) => {
+                let response = crate::tools::git::repo_identity()?;
+                Ok(Some(("repo_identity".to_string(), response)))
+            }
+            Some(DeterministicIntent::CodebaseOverview) => {
+                let response = crate::tools::codebase_investigator::overview_snapshot().await?;
+                Ok(Some(("codebase_overview".to_string(), response)))
+            }
+            Some(DeterministicIntent::ReadFile(intent)) => {
+                let response = crate::tools::filesystem::read_file(
+                    &format!("[READ_FILE {}]", intent.path),
+                    self.approver.clone(),
+                )
+                .await?;
+                Ok(Some(("read_file".to_string(), response)))
+            }
+            Some(DeterministicIntent::WriteFile(intent)) => {
+                let response = crate::tools::filesystem::write_file_direct(
+                    &intent.path,
+                    &intent.content,
+                    self.approver.clone(),
+                )
+                .await?;
+                Ok(Some(("write_file".to_string(), response)))
+            }
+            Some(DeterministicIntent::CodebaseSearch(intent)) => {
+                let response =
+                    crate::tools::codebase_investigator::search_text(&intent.pattern).await?;
+                Ok(Some(("codebase_search".to_string(), response)))
+            }
+            Some(DeterministicIntent::RunCommand(intent)) => {
+                let audit_ctx = CommandAuditContext {
+                    conn: self.conn,
+                    session_id: Some(session_id),
+                    source: "intent_run_command",
+                };
+                let response = crate::tools::shell::execute_command(
+                    &format!("[RUN_COMMAND {}]", intent.command),
+                    self.config,
+                    &self.exec_policy,
+                    None,
+                    Some(&audit_ctx),
+                    self.approver.clone(),
+                    self.runtime_events.clone(),
+                )
+                .await?;
+                let rendered = format!(
+                    "COMMAND: {}\nOUTPUT:\n{}",
+                    intent.command,
+                    response.trim_end()
+                );
+                Ok(Some(("run_command".to_string(), rendered)))
             }
             None => Ok(None),
         }
+    }
+
+    fn infer_followup_write_file_intent(
+        history: &[Message],
+        user_msg: &str,
+    ) -> Option<crate::agent::intent::WriteFileIntent> {
+        let normalized = user_msg.to_ascii_lowercase();
+        let wants_creation = normalized.contains("create the file")
+            || normalized.contains("create this file")
+            || normalized.contains("make this file")
+            || normalized.contains("write this file")
+            || normalized.contains("can you create this file")
+            || normalized.contains("can you make this file")
+            || normalized.contains("make the file")
+            || normalized.contains("write the file")
+            || normalized == "create it"
+            || normalized == "write it"
+            || normalized == "make it";
+        if !wants_creation {
+            return None;
+        }
+
+        let assistant_msg = history
+            .iter()
+            .rev()
+            .find(|message| message.role == "assistant")?;
+        let backtick_segments = Self::extract_backtick_segments(&assistant_msg.content);
+        let path = backtick_segments
+            .iter()
+            .find(|segment| {
+                segment.ends_with(".py")
+                    || segment.ends_with(".rs")
+                    || segment.ends_with(".js")
+                    || segment.ends_with(".ts")
+                    || segment.ends_with(".txt")
+                    || segment.ends_with(".md")
+                    || segment.ends_with(".json")
+                    || segment.ends_with(".sh")
+            })?
+            .to_string();
+        let path = Self::sanitize_followup_write_path(&path)?;
+
+        let content = backtick_segments
+            .iter()
+            .find(|segment| {
+                Self::sanitize_followup_write_path(segment)
+                    .as_deref()
+                    .is_none_or(|sanitized| sanitized != path)
+                    && !segment.starts_with("python")
+                    && !segment.starts_with("python3")
+                    && !segment.starts_with("cargo ")
+                    && !segment.starts_with("node ")
+                    && !segment.starts_with("bash ")
+            })
+            .cloned()
+            .or_else(|| {
+                Self::infer_code_from_plain_assistant_text(&assistant_msg.content, &path)
+            })?;
+
+        Some(crate::agent::intent::WriteFileIntent { path, content })
+    }
+
+    fn extract_backtick_segments(content: &str) -> Vec<String> {
+        let mut segments = Vec::new();
+        let mut remaining = content;
+        while let Some(start) = remaining.find('`') {
+            let after_start = &remaining[start + 1..];
+            let Some(end) = after_start.find('`') else {
+                break;
+            };
+            let segment = after_start[..end].trim();
+            if !segment.is_empty() {
+                segments.push(segment.to_string());
+            }
+            remaining = &after_start[end + 1..];
+        }
+        segments
+    }
+
+    fn sanitize_followup_write_path(path: &str) -> Option<String> {
+        let trimmed = path.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let candidate = std::path::Path::new(trimmed);
+        let sanitized = if candidate.is_absolute() || trimmed.contains("..") {
+            candidate.file_name()?.to_str()?.to_string()
+        } else {
+            trimmed.to_string()
+        };
+        if sanitized.is_empty() || sanitized.contains('/') || sanitized.contains('\\') {
+            return None;
+        }
+        Some(sanitized)
+    }
+
+    fn infer_code_from_plain_assistant_text(content: &str, path: &str) -> Option<String> {
+        if path.ends_with(".py") {
+            return content
+                .lines()
+                .find(|line| line.contains("print("))
+                .map(|line| line.trim().to_string());
+        }
+        if path.ends_with(".rs") {
+            return content
+                .lines()
+                .find(|line| line.contains("fn main"))
+                .map(|line| line.trim().to_string());
+        }
+        if path.ends_with(".md") {
+            let markdown_lines = content
+                .lines()
+                .skip_while(|line| {
+                    let trimmed = line.trim();
+                    !trimmed.starts_with('#')
+                        && !trimmed.starts_with("- ")
+                        && !trimmed.starts_with("* ")
+                        && !trimmed.chars().next().is_some_and(|c| c.is_ascii_digit())
+                })
+                .map(str::trim_end)
+                .collect::<Vec<_>>();
+            let markdown = markdown_lines.join("\n").trim().to_string();
+            if !markdown.is_empty() {
+                return Some(markdown);
+            }
+        }
+        if path.ends_with(".txt") {
+            let text = content
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .collect::<Vec<_>>()
+                .join("\n");
+            if !text.is_empty() {
+                return Some(text);
+            }
+        }
+        None
+    }
+
+    async fn summarize_deterministic_tool_result(
+        &mut self,
+        client: &Client,
+        history_for_llm: &mut Vec<Message>,
+        history: &mut Vec<Message>,
+        session_id: &str,
+        tool_name: &str,
+        tool_content: &str,
+    ) -> Result<String, HarperError> {
+        self.notify_command_activity(session_id);
+        if tool_name == "repo_identity"
+            || tool_name == "git_branch"
+            || tool_name == "git_status"
+            || tool_name == "git_diff"
+            || tool_name == "write_file"
+            || tool_name == "run_command"
+        {
+            return Ok(Self::compact_deterministic_fallback(
+                tool_name,
+                tool_content,
+            ));
+        }
+
+        let tool_message = Message {
+            role: "system".to_string(),
+            content: tool_content.to_string(),
+        };
+        history.push(tool_message.clone());
+        history_for_llm.push(tool_message);
+        history_for_llm.push(Message {
+            role: "system".to_string(),
+            content: Self::deterministic_summary_instruction(tool_name).to_string(),
+        });
+        self.emit_activity_update(session_id, Some("thinking".to_string()));
+        let response = self.call_llm(client, history_for_llm).await?;
+        if response.trim().is_empty()
+            || Self::tool_call_signature(&response).is_some()
+            || Self::deterministic_summary_is_low_value(tool_name, &response, tool_content)
+        {
+            return Ok(Self::compact_deterministic_fallback(
+                tool_name,
+                tool_content,
+            ));
+        }
+        Ok(response)
+    }
+
+    fn deterministic_summary_instruction(tool_name: &str) -> &'static str {
+        match tool_name {
+            "codebase_search" => {
+                "A deterministic `codebase_search` tool was already selected and executed. Do not call any tool. Use only this structured search context. Prioritize files with the strongest ROLE and REASONS for the query focus, explain which file is most relevant first, and avoid repeating raw match dumps."
+            }
+            "codebase_overview" => {
+                "A deterministic `codebase_overview` tool was already selected and executed. Do not call any tool. Use only this workspace snapshot. Answer briefly with a grounded codebase overview: summarize the repo structure, major crates, and likely hotspots without repeating the raw snapshot verbatim."
+            }
+            _ => {
+                "A deterministic tool was already selected and executed. Do not call any tool. Answer in plain language using only this tool result. Keep the answer short and summarize the most relevant result instead of repeating raw output."
+            }
+        }
+    }
+
+    fn deterministic_summary_is_low_value(
+        tool_name: &str,
+        response: &str,
+        tool_content: &str,
+    ) -> bool {
+        if tool_name != "codebase_search" && tool_name != "codebase_overview" {
+            return false;
+        }
+
+        let trimmed = response.trim();
+        if trimmed.starts_with("Top matches for ")
+            || trimmed.starts_with("Top source matches:")
+            || trimmed.starts_with("Tool result:")
+            || trimmed.contains("route_intent(")
+        {
+            return true;
+        }
+
+        let repeated_lines = tool_content
+            .lines()
+            .skip(1)
+            .filter(|line| !line.trim().is_empty())
+            .take(3)
+            .filter(|line| trimmed.contains(line.trim()))
+            .count();
+
+        let repetition_threshold = if tool_name == "codebase_overview" {
+            1
+        } else {
+            2
+        };
+
+        repeated_lines >= repetition_threshold
+    }
+
+    fn compact_deterministic_fallback(tool_name: &str, tool_content: &str) -> String {
+        if tool_name == "repo_identity"
+            || tool_name == "git_branch"
+            || tool_name == "current_directory"
+        {
+            return tool_content.to_string();
+        }
+        if tool_name == "git_status" {
+            return Self::format_git_status(tool_content);
+        }
+        if tool_name == "git_diff" {
+            return Self::format_git_diff(tool_content);
+        }
+        if tool_name == "write_file" {
+            return Self::format_write_file(tool_content);
+        }
+        if tool_name == "run_command" {
+            return Self::format_run_command(tool_content);
+        }
+        if tool_name == "codebase_overview" {
+            return Self::summarize_codebase_overview(tool_content);
+        }
+        if tool_name == "codebase_search" {
+            return Self::summarize_codebase_search_result(tool_content);
+        }
+
+        format!("Tool result:\n{}", tool_content)
+    }
+
+    fn format_git_status(tool_content: &str) -> String {
+        let body = tool_content
+            .strip_prefix(
+                "Git status:
+",
+            )
+            .unwrap_or(tool_content)
+            .trim();
+        if body.is_empty() {
+            return "Git working directory is clean".to_string();
+        }
+
+        let mut modified = Vec::new();
+        let mut added = Vec::new();
+        let mut deleted = Vec::new();
+        let mut untracked = Vec::new();
+        let mut renamed = Vec::new();
+        let mut other = Vec::new();
+
+        for line in body.lines() {
+            let line = line.trim_end();
+            if line.len() < 3 {
+                continue;
+            }
+            let status = &line[..2];
+            let path = line[3..].trim();
+            match status {
+                "??" => untracked.push(path.to_string()),
+                "A " | "AM" | " M" if status.starts_with('A') => added.push(path.to_string()),
+                "D " | " D" | "MD" | "AD" => deleted.push(path.to_string()),
+                "R " | "R?" | "RM" | "RR" => renamed.push(path.to_string()),
+                _ if status.contains('M') => modified.push(path.to_string()),
+                _ => other.push(format!("{} {}", status, path)),
+            }
+        }
+
+        let mut parts = Vec::new();
+        if !modified.is_empty() {
+            parts.push(format!("{} modified", modified.len()));
+        }
+        if !added.is_empty() {
+            parts.push(format!("{} added", added.len()));
+        }
+        if !deleted.is_empty() {
+            parts.push(format!("{} deleted", deleted.len()));
+        }
+        if !renamed.is_empty() {
+            parts.push(format!("{} renamed", renamed.len()));
+        }
+        if !untracked.is_empty() {
+            parts.push(format!("{} untracked", untracked.len()));
+        }
+        if !other.is_empty() {
+            parts.push(format!("{} other", other.len()));
+        }
+
+        let summary = if parts.is_empty() {
+            "Git working directory has changes.".to_string()
+        } else {
+            format!("Git working directory has {}.", parts.join(", "))
+        };
+
+        let mut notable = Vec::new();
+        notable.extend(modified.iter().take(3).cloned());
+        notable.extend(added.iter().take(3 - notable.len()).cloned());
+        if notable.len() < 3 {
+            notable.extend(untracked.iter().take(3 - notable.len()).cloned());
+        }
+
+        if notable.is_empty() {
+            summary
+        } else {
+            format!("{} Notable files: {}.", summary, notable.join(", "))
+        }
+    }
+
+    fn format_git_diff(tool_content: &str) -> String {
+        let trimmed = tool_content.trim();
+        if trimmed == "No changes to show" {
+            return trimmed.to_string();
+        }
+        let diff_body = tool_content
+            .strip_prefix("Git diff:\n")
+            .unwrap_or(tool_content)
+            .trim_end();
+        format!("Git diff:\n```diff\n{}\n```", diff_body)
+    }
+
+    fn format_write_file(tool_content: &str) -> String {
+        let mut path = None;
+        let mut content = None;
+        for line in tool_content.lines() {
+            if let Some(value) = line.strip_prefix("Wrote file: ") {
+                path = Some(value.trim().to_string());
+            } else if let Some(value) = line.strip_prefix("CONTENT: ") {
+                content = Some(value.to_string());
+            }
+        }
+
+        match (path, content) {
+            (Some(path), Some(content)) => {
+                let language = std::path::Path::new(&path)
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .unwrap_or("txt");
+                format!("Created `{}`:\n```{}\n{}\n```", path, language, content)
+            }
+            _ => format!("Tool result:\n{}", tool_content),
+        }
+    }
+
+    fn format_run_command(tool_content: &str) -> String {
+        let mut command = None;
+        let mut in_output = false;
+        let mut output_lines = Vec::new();
+
+        for line in tool_content.lines() {
+            if let Some(value) = line.strip_prefix("COMMAND: ") {
+                command = Some(value.trim().to_string());
+                continue;
+            }
+            if line.trim() == "OUTPUT:" {
+                in_output = true;
+                continue;
+            }
+            if in_output {
+                output_lines.push(line);
+            }
+        }
+
+        let command = command.unwrap_or_else(|| "command".to_string());
+        let output = output_lines.join("\n").trim().to_string();
+        if output.is_empty() {
+            return format!("Ran `{}` successfully.", command);
+        }
+
+        format!("Ran `{}`.\n```\n{}\n```", command, output)
+    }
+
+    fn summarize_codebase_search_result(tool_content: &str) -> String {
+        let mut bullets = Vec::new();
+        let mut current_file = None;
+        let mut current_snippet = None;
+        let mut current_reasons: Option<String> = None;
+
+        for line in tool_content.lines().skip(1) {
+            let trimmed = line.trim();
+            if let Some(value) = trimmed.strip_prefix("FILE: ") {
+                if let (Some(file), Some(snippet)) = (current_file.take(), current_snippet.take()) {
+                    let reasons = current_reasons.take().unwrap_or_default();
+                    let reason_suffix = if reasons.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" [{}]", reasons)
+                    };
+                    bullets.push(format!("- `{}` → {}{}", file, snippet, reason_suffix));
+                }
+                current_file = Some(value.to_string());
+                current_reasons = None;
+                current_snippet = None;
+            } else if let Some(value) = trimmed.strip_prefix("REASONS: ") {
+                current_reasons = Some(value.to_string());
+            } else if let Some(value) = trimmed.strip_prefix("- ") {
+                if current_snippet.is_none() {
+                    current_snippet = Some(value.to_string());
+                }
+            }
+            if bullets.len() >= 4 {
+                break;
+            }
+        }
+
+        if bullets.len() < 4 {
+            if let (Some(file), Some(snippet)) = (current_file.take(), current_snippet.take()) {
+                let reasons = current_reasons.take().unwrap_or_default();
+                let reason_suffix = if reasons.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [{}]", reasons)
+                };
+                bullets.push(format!("- `{}` → {}{}", file, snippet, reason_suffix));
+            }
+        }
+
+        if bullets.is_empty() {
+            return format!("Tool result:\n{}", tool_content);
+        }
+
+        format!("Top source matches:\n{}", bullets.join("\n"))
+    }
+
+    fn summarize_codebase_overview(tool_content: &str) -> String {
+        let mut lines = Vec::new();
+
+        for line in tool_content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if let Some(value) = trimmed.strip_prefix("Workspace root: ") {
+                lines.push(format!("Workspace root: `{}`", value));
+            } else if let Some(value) = trimmed.strip_prefix("Workspace package: ") {
+                lines.push(format!("Workspace package: `{}`", value));
+            } else if let Some(value) = trimmed.strip_prefix("Workspace members: ") {
+                lines.push(format!("Workspace members: {}", value));
+            } else if let Some(value) = trimmed.strip_prefix("Crate roles: ") {
+                lines.push(format!("Crate roles: {}", value));
+            } else if let Some(value) = trimmed.strip_prefix("Top-level entries: ") {
+                lines.push(format!("Top-level entries: {}", value));
+            } else if let Some(value) = trimmed.strip_prefix("Likely hotspots: ") {
+                lines.push(format!("Likely hotspots: {}", value));
+            }
+        }
+
+        if lines.is_empty() {
+            return format!("Tool result:\n{}", tool_content);
+        }
+
+        format!("Codebase overview:\n- {}", lines.join("\n- "))
     }
 
     async fn try_handle_offline_shell_proxy(
@@ -1283,6 +2393,9 @@ impl<'a> ChatService<'a> {
         user_msg: &str,
         session_id: &str,
     ) -> Result<Option<String>, HarperError> {
+        if self.execution_strategy != ExecutionStrategy::Deterministic {
+            return Ok(None);
+        }
         let commands = plan_offline_shell_commands(user_msg);
         if commands.is_empty() {
             return Ok(None);
@@ -1396,6 +2509,34 @@ impl<'a> ChatService<'a> {
         }
 
         Ok(lines.join("\n"))
+    }
+
+    fn parse_execution_strategy(value: &str) -> Option<ExecutionStrategy> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "auto" => Some(ExecutionStrategy::Auto),
+            "grounded" => Some(ExecutionStrategy::Grounded),
+            "deterministic" => Some(ExecutionStrategy::Deterministic),
+            "model" | "model-only" | "model_only" => Some(ExecutionStrategy::ModelOnly),
+            _ => None,
+        }
+    }
+
+    fn execution_strategy_name(strategy: ExecutionStrategy) -> &'static str {
+        match strategy {
+            ExecutionStrategy::Auto => "auto",
+            ExecutionStrategy::Grounded => "grounded",
+            ExecutionStrategy::Deterministic => "deterministic",
+            ExecutionStrategy::ModelOnly => "model",
+        }
+    }
+
+    fn response_looks_like_generic_capability_refusal(response: &str) -> bool {
+        let lower = response.to_ascii_lowercase();
+        lower.contains("none of the provided tools")
+            || lower.contains("i can't assist with that request")
+            || lower.contains("there is no way to perform")
+            || lower.contains("would be necessary to use a tool designed")
+            || lower.contains("the provided tools")
     }
 
     fn fetch_command_logs(
@@ -1930,6 +3071,16 @@ mod tests {
     }
 
     #[test]
+    fn forced_tool_retry_targets_codebase_queries() {
+        let user_msg = "Find where retry metadata is rendered in this repo.";
+        let prose = "You can grep for retry and metadata in the repository.";
+        assert_eq!(
+            ChatService::forced_tool_retry_target(user_msg, prose, false),
+            Some("codebase_investigator")
+        );
+    }
+
+    #[test]
     fn forced_tool_retry_runs_only_once() {
         let user_msg = "run cargo test";
         let prose = "I would run tests to verify the change.";
@@ -1937,6 +3088,77 @@ mod tests {
             ChatService::forced_tool_retry_target(user_msg, prose, true),
             None
         );
+    }
+
+    #[test]
+    fn compact_deterministic_fallback_summarizes_codebase_search() {
+        let tool_content = "Top matches for 'retry metadata':\nFILE: ./lib/harper-ui/src/interfaces/ui/widgets.rs:1036\nROLE: ui_widget_rendering\nREASONS: role=ui_widget_rendering, contains_all_terms, widget_render_path\nSNIPPETS:\n- 1036: \" Plan (Ctrl+S • C complete • I in-progress • B blocked • R retry • U replan • K ack • X clear) \"\nFILE: ./lib/harper-ui/src/interfaces/ui/widgets.rs:1229\nROLE: ui_widget_rendering\nREASONS: role=ui_widget_rendering, contains_all_terms, widget_render_path\nSNIPPETS:\n- 1229: PlanFollowup::RetryOrReplan {\nFILE: ./lib/harper-ui/src/interfaces/ui/widgets.rs:1232\nROLE: ui_widget_rendering\nREASONS: role=ui_widget_rendering, contains_all_terms, widget_render_path\nSNIPPETS:\n- 1232: retry_count,";
+        let summary = ChatService::compact_deterministic_fallback("codebase_search", tool_content);
+
+        assert!(summary.starts_with("Top source matches:\n"));
+        assert!(summary.contains("`./lib/harper-ui/src/interfaces/ui/widgets.rs:1036`"));
+        assert!(summary.contains("PlanFollowup::RetryOrReplan"));
+    }
+
+    #[test]
+    fn compact_deterministic_fallback_summarizes_codebase_overview() {
+        let tool_content = "Workspace root: /Users/niladri/harper\nWorkspace package: harper-workspace\nWorkspace members: lib/harper-core, lib/harper-ui\nCrate roles: harper-core: runtime, tools, storage, agent logic; harper-ui: TUI state, events, widgets\nTop-level entries: AGENTS.md, Cargo.toml, lib\nLikely hotspots: lib/harper-core/src/agent/chat.rs, lib/harper-ui/src/interfaces/ui/widgets.rs";
+        let summary =
+            ChatService::compact_deterministic_fallback("codebase_overview", tool_content);
+
+        assert!(summary.starts_with("Codebase overview:\n- "));
+        assert!(summary.contains("Workspace package: `harper-workspace`"));
+        assert!(summary.contains("Likely hotspots:"));
+    }
+
+    #[test]
+    fn compact_deterministic_fallback_formats_git_diff_as_fenced_block() {
+        let tool_content = "Git diff:\ndiff --git a/file.rs b/file.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        let summary = ChatService::compact_deterministic_fallback("git_diff", tool_content);
+
+        assert!(summary.starts_with("Git diff:\n```diff\n"));
+        assert!(summary.contains("+new"));
+        assert!(summary.ends_with("\n```"));
+    }
+
+    #[test]
+    fn compact_deterministic_fallback_formats_write_file_as_fenced_block() {
+        let tool_content = "Wrote file: hello-world.txt\nCONTENT: Hello World";
+        let summary = ChatService::compact_deterministic_fallback("write_file", tool_content);
+
+        assert!(summary.starts_with("Created `hello-world.txt`:\n```txt\n"));
+        assert!(summary.contains("Hello World"));
+        assert!(summary.ends_with("\n```"));
+    }
+
+    #[test]
+    fn deterministic_summary_is_low_value_for_raw_codebase_echo() {
+        let tool_content = "Top matches for 'retry metadata':\nFILE: ./lib/harper-ui/src/interfaces/ui/widgets.rs:1036\nROLE: ui_widget_rendering\nREASONS: role=ui_widget_rendering, contains_all_terms\nSNIPPETS:\n- 1036: one\nFILE: ./lib/harper-ui/src/interfaces/ui/widgets.rs:1229\nROLE: ui_widget_rendering\nREASONS: role=ui_widget_rendering, contains_all_terms\nSNIPPETS:\n- 1229: two\nFILE: ./lib/harper-ui/src/interfaces/ui/widgets.rs:1232\nROLE: ui_widget_rendering\nREASONS: role=ui_widget_rendering, contains_all_terms\nSNIPPETS:\n- 1232: three";
+        let response = "Top matches for 'retry metadata': FILE: ./lib/harper-ui/src/interfaces/ui/widgets.rs:1036 ROLE: ui_widget_rendering SNIPPETS: 1036: one FILE: ./lib/harper-ui/src/interfaces/ui/widgets.rs:1229";
+        assert!(ChatService::deterministic_summary_is_low_value(
+            "codebase_search",
+            response,
+            tool_content
+        ));
+    }
+
+    #[test]
+    fn finalize_assistant_response_keeps_non_empty_text() {
+        let result = ChatService::finalize_assistant_response("Plan updated.", None);
+        assert_eq!(result, "Plan updated.");
+    }
+
+    #[test]
+    fn finalize_assistant_response_falls_back_to_tool_output() {
+        let result =
+            ChatService::finalize_assistant_response("   \n", Some("Plan updated: 3 steps."));
+        assert_eq!(result, "Tool result:\nPlan updated: 3 steps.");
+    }
+
+    #[test]
+    fn finalize_assistant_response_uses_explicit_empty_message_when_no_tool_output() {
+        let result = ChatService::finalize_assistant_response("   \n", None);
+        assert_eq!(result, "The model returned an empty response.");
     }
 
     #[test]
@@ -1954,5 +3176,176 @@ mod tests {
         );
         assert!(title.ends_with("..."));
         assert!(title.len() <= 51);
+    }
+
+    #[test]
+    fn infer_followup_write_file_intent_uses_previous_assistant_filename_and_code() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: "hey can you create a python hello joy file".to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: "Sure. Save this content into a file named `hello_joy.py`: `print(\"Hello Joy!\")` and run it with `python3 hello_joy.py`.".to_string(),
+            },
+        ];
+
+        let intent =
+            ChatService::infer_followup_write_file_intent(&history, "please create the file")
+                .expect("follow-up write intent");
+
+        assert_eq!(intent.path, "hello_joy.py");
+        assert_eq!(intent.content, "print(\"Hello Joy!\")");
+    }
+
+    #[test]
+    fn infer_followup_write_file_intent_sanitizes_absolute_filename() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: "create a new file explaining ai in markdown".to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: "Save this as `/home/user/ai.md`\n\n# Introduction to Artificial Intelligence\n\nAI is a field of computer science.".to_string(),
+            },
+        ];
+
+        let intent =
+            ChatService::infer_followup_write_file_intent(&history, "can you create this file")
+                .expect("follow-up write intent");
+
+        assert_eq!(intent.path, "ai.md");
+        assert!(intent
+            .content
+            .contains("# Introduction to Artificial Intelligence"));
+    }
+
+    #[test]
+    fn infer_followup_write_file_intent_extracts_markdown_body() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: "create a new file explaining ai in markdown".to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: "Sure, use `ai.md`\n\n# Introduction to Artificial Intelligence\n\n## What Is AI?\n\nArtificial intelligence is ...".to_string(),
+            },
+        ];
+
+        let intent =
+            ChatService::infer_followup_write_file_intent(&history, "please create the file")
+                .expect("follow-up write intent");
+
+        assert_eq!(intent.path, "ai.md");
+        assert!(intent
+            .content
+            .starts_with("# Introduction to Artificial Intelligence"));
+        assert!(intent.content.contains("## What Is AI?"));
+    }
+
+    #[test]
+    fn request_needs_authoring_flow_for_open_ended_repo_change() {
+        assert!(ChatService::request_needs_authoring_flow(
+            "refactor the planner flow in this repo"
+        ));
+    }
+
+    #[test]
+    fn request_does_not_need_authoring_flow_for_direct_write_intent() {
+        assert!(!ChatService::request_needs_authoring_flow(
+            "create hello.rs with fn main() { println!(\"Hi\"); }"
+        ));
+    }
+
+    #[test]
+    fn request_requires_tool_for_open_ended_authoring_flow() {
+        assert_eq!(
+            ChatService::request_requires_tool("refactor the planner flow in this repo"),
+            Some("codebase_investigator")
+        );
+    }
+
+    #[test]
+    fn authoring_tool_retry_prompt_requires_plan_before_first_edit() {
+        let mut candidates = HashSet::new();
+        candidates.insert(PathBuf::from("lib/harper-ui/src/interfaces/ui/widgets.rs"));
+
+        let prompt = ChatService::authoring_tool_retry_prompt(
+            "refactor the planner flow in this repo and then update the tui rendering too",
+            r#"{"tool":"search_replace","args":{"path":"lib/harper-ui/src/interfaces/ui/widgets.rs","search":"old","replace":"new"}}"#,
+            Some(&candidates),
+            false,
+            false,
+            false,
+            &HashSet::new(),
+        )
+        .expect("should require plan");
+
+        assert!(prompt.contains("call update_plan"));
+        assert!(prompt.contains("Do not edit any file yet"));
+    }
+
+    #[test]
+    fn authoring_tool_retry_prompt_requires_inspection_before_edit() {
+        let mut candidates = HashSet::new();
+        candidates.insert(PathBuf::from("lib/harper-ui/src/interfaces/ui/widgets.rs"));
+
+        let prompt = ChatService::authoring_tool_retry_prompt(
+            "change the retry rendering behavior in the tui",
+            r#"{"tool":"search_replace","args":{"path":"lib/harper-ui/src/interfaces/ui/widgets.rs","search":"old","replace":"new"}}"#,
+            Some(&candidates),
+            false,
+            true,
+            true,
+            &HashSet::new(),
+        )
+        .expect("should require inspection");
+
+        assert!(prompt.contains("requires inspection before the first write/search_replace"));
+        assert!(prompt.contains("codebase_investigator or read_file"));
+    }
+
+    #[test]
+    fn authoring_tool_retry_prompt_rejects_edit_outside_candidates() {
+        let mut candidates = HashSet::new();
+        candidates.insert(PathBuf::from("lib/harper-ui/src/interfaces/ui/widgets.rs"));
+
+        let prompt = ChatService::authoring_tool_retry_prompt(
+            "change the retry rendering behavior in the tui",
+            r#"{"tool":"search_replace","args":{"path":"/Users/username/Documents/project/source/file.txt","search":"old","replace":"new"}}"#,
+            Some(&candidates),
+            true,
+            true,
+            true,
+            &HashSet::new(),
+        )
+        .expect("should reject non-candidate edit");
+
+        assert!(prompt.contains("must target files from the grounded candidate set"));
+        assert!(prompt.contains("widgets.rs"));
+    }
+
+    #[test]
+    fn parses_execution_strategy_values() {
+        assert_eq!(
+            ChatService::parse_execution_strategy("auto"),
+            Some(ExecutionStrategy::Auto)
+        );
+        assert_eq!(
+            ChatService::parse_execution_strategy("grounded"),
+            Some(ExecutionStrategy::Grounded)
+        );
+        assert_eq!(
+            ChatService::parse_execution_strategy("deterministic"),
+            Some(ExecutionStrategy::Deterministic)
+        );
+        assert_eq!(
+            ChatService::parse_execution_strategy("model"),
+            Some(ExecutionStrategy::ModelOnly)
+        );
+        assert_eq!(ChatService::parse_execution_strategy("bogus"), None);
     }
 }

--- a/lib/harper-core/src/agent/intent.rs
+++ b/lib/harper-core/src/agent/intent.rs
@@ -14,6 +14,8 @@
 
 //! Lightweight intent routing for deterministic actions.
 
+use std::path::Path;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangedFilesIntent {
     pub ext: Option<String>,
@@ -22,19 +24,97 @@ pub struct ChangedFilesIntent {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReadFileIntent {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodebaseSearchIntent {
+    pub pattern: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunCommandIntent {
+    pub command: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteFileIntent {
+    pub path: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeterministicIntent {
     ListChangedFiles(ChangedFilesIntent),
+    GitStatus,
+    GitDiff,
+    GitBranch,
+    CurrentDirectory,
+    RepoIdentity,
+    ReadFile(ReadFileIntent),
+    WriteFile(WriteFileIntent),
+    CodebaseOverview,
+    CodebaseSearch(CodebaseSearchIntent),
+    RunCommand(RunCommandIntent),
 }
 
 pub fn route_intent(query: &str) -> Option<DeterministicIntent> {
     let normalized = normalize(query);
     let tokens: Vec<&str> = normalized.split_whitespace().collect();
 
+    if is_git_status_intent(&normalized) {
+        return Some(DeterministicIntent::GitStatus);
+    }
+
+    if is_git_diff_intent(&normalized) {
+        return Some(DeterministicIntent::GitDiff);
+    }
+
+    if is_git_branch_intent(&normalized) {
+        return Some(DeterministicIntent::GitBranch);
+    }
+
+    if is_current_directory_intent(&normalized) {
+        return Some(DeterministicIntent::CurrentDirectory);
+    }
+
+    if is_repo_identity_intent(&normalized) {
+        return Some(DeterministicIntent::RepoIdentity);
+    }
+
     if is_changed_files_intent(&normalized, &tokens) {
         return Some(DeterministicIntent::ListChangedFiles(ChangedFilesIntent {
             ext: infer_extension_filter(&tokens),
             tracked_only: tokens.contains(&"tracked"),
             since: infer_since_filter(&tokens),
+        }));
+    }
+
+    if is_codebase_overview_intent(&normalized) {
+        return Some(DeterministicIntent::CodebaseOverview);
+    }
+
+    if let Some((path, content)) = infer_write_file_intent(query, &normalized) {
+        return Some(DeterministicIntent::WriteFile(WriteFileIntent {
+            path,
+            content,
+        }));
+    }
+
+    if let Some(path) = infer_read_file_path(query, &tokens) {
+        return Some(DeterministicIntent::ReadFile(ReadFileIntent { path }));
+    }
+
+    if let Some(pattern) = infer_codebase_search_pattern(query, &normalized) {
+        return Some(DeterministicIntent::CodebaseSearch(CodebaseSearchIntent {
+            pattern,
+        }));
+    }
+
+    if let Some(command) = infer_simple_run_command(query, &normalized) {
+        return Some(DeterministicIntent::RunCommand(RunCommandIntent {
+            command,
         }));
     }
 
@@ -86,6 +166,7 @@ fn is_changed_files_intent(normalized: &str, tokens: &[&str]) -> bool {
     normalized.contains("what am i changing")
         || normalized.contains("what i am changing")
         || normalized.contains("files i am changing")
+        || normalized.contains("files am changing")
         || normalized.contains("files im changing")
 }
 
@@ -121,6 +202,715 @@ fn infer_extension_filter(tokens: &[&str]) -> Option<String> {
     None
 }
 
+fn is_git_status_intent(normalized: &str) -> bool {
+    normalized.contains("git status")
+        || normalized.contains("status of repo")
+        || normalized.contains("status of repository")
+}
+
+fn is_git_diff_intent(normalized: &str) -> bool {
+    normalized.contains("git diff")
+        || normalized.contains("show diff")
+        || normalized.contains("show the diff")
+        || normalized.contains("check code changes")
+        || normalized.contains("check the code changes")
+        || normalized.contains("show code changes")
+        || normalized.contains("what changed in code")
+}
+
+fn is_git_branch_intent(normalized: &str) -> bool {
+    normalized.contains("which branch")
+        || normalized.contains("what branch")
+        || normalized.contains("current branch")
+        || normalized.contains("branch am i")
+        || normalized.contains("branch are we")
+        || normalized.contains("branch i am")
+        || normalized.contains("branch we are on")
+}
+
+fn is_current_directory_intent(normalized: &str) -> bool {
+    normalized.contains("current directory")
+        || normalized.contains("working directory")
+        || normalized.contains("present working directory")
+        || normalized.contains("which directory")
+        || normalized.contains("what directory")
+        || normalized.contains("where am i")
+        || normalized.contains("where are we")
+}
+
+fn is_repo_identity_intent(normalized: &str) -> bool {
+    (normalized.contains("which repo") || normalized.contains("what repo"))
+        && (normalized.contains("working on")
+            || normalized.contains("working in")
+            || normalized.contains("are we in")
+            || normalized.contains("am i in"))
+}
+
+fn is_codebase_overview_intent(normalized: &str) -> bool {
+    let has_scope = normalized.contains("codebase")
+        || normalized.contains("repo")
+        || normalized.contains("repository")
+        || normalized.contains("project");
+    let has_overview_signal = normalized.contains("tell me")
+        || normalized.contains("check")
+        || normalized.contains("summarize")
+        || normalized.contains("describe")
+        || normalized.contains("overview")
+        || normalized.contains("inspect");
+
+    has_scope
+        && has_overview_signal
+        && !normalized.contains("find where")
+        && !normalized.contains("where is")
+        && !normalized.contains("where does")
+        && !normalized.contains("what renders")
+        && !normalized.contains("who calls")
+}
+
+fn infer_read_file_path(query: &str, tokens: &[&str]) -> Option<String> {
+    let lower = query.to_ascii_lowercase();
+    let has_read_verb = ["read ", "open ", "show ", "view ", "look at "]
+        .iter()
+        .any(|marker| lower.contains(marker));
+    if !has_read_verb {
+        return None;
+    }
+
+    let raw_tokens: Vec<&str> = query.split_whitespace().collect();
+    for token in raw_tokens {
+        let cleaned = token
+            .trim_matches(|c: char| {
+                matches!(c, '.' | ',' | ';' | ':' | ')' | '(' | '"' | '\'' | '`')
+            })
+            .trim();
+        if cleaned.is_empty() {
+            continue;
+        }
+        if cleaned.contains('/') || cleaned.contains('\\') {
+            return Some(cleaned.to_string());
+        }
+        if cleaned.contains('.') && cleaned.len() > 2 {
+            return Some(cleaned.to_string());
+        }
+    }
+
+    let _ = tokens;
+    None
+}
+
+fn infer_write_file_intent(query: &str, normalized: &str) -> Option<(String, String)> {
+    if let Some(explicit) = infer_explicit_write_file_intent(query, normalized) {
+        return Some(explicit);
+    }
+
+    let wants_create = normalized.contains("create ")
+        || normalized.contains("make ")
+        || normalized.contains("write ");
+    if !wants_create {
+        return None;
+    }
+
+    if normalized.contains(" file ")
+        || normalized.starts_with("file ")
+        || normalized.ends_with(" file")
+    {
+        if let Some(content) = extract_content_after_markers(
+            query,
+            normalized,
+            &[" saying ", " that says ", " containing ", " with "],
+        ) {
+            return Some(("note.txt".to_string(), content));
+        }
+    }
+
+    let (file_kind, language_label) = if normalized.contains(" python ")
+        || normalized.contains(" py file")
+        || normalized.contains(" python file")
+        || normalized.contains(" in python")
+        || normalized.contains(" as python")
+    {
+        ("py", Some("python"))
+    } else if normalized.contains(" rust ")
+        || normalized.contains(" rs file")
+        || normalized.contains(" rust file")
+        || normalized.contains(" in rust")
+        || normalized.contains(" as rust")
+    {
+        ("rs", Some("rust"))
+    } else if normalized.contains(" javascript ")
+        || normalized.contains(" js file")
+        || normalized.contains(" javascript file")
+        || normalized.contains(" in javascript")
+        || normalized.contains(" as javascript")
+    {
+        ("js", Some("javascript"))
+    } else if normalized.contains(" typescript ")
+        || normalized.contains(" ts file")
+        || normalized.contains(" typescript file")
+        || normalized.contains(" in typescript")
+        || normalized.contains(" as typescript")
+    {
+        ("ts", Some("typescript"))
+    } else if normalized.contains(" json file")
+        || normalized.contains(" in json")
+        || normalized.contains(" as json")
+    {
+        ("json", Some("json"))
+    } else if normalized.contains(" markdown file")
+        || normalized.contains(" md file")
+        || normalized.contains(" in markdown")
+        || normalized.contains(" as markdown")
+        || normalized.contains(" in md")
+        || normalized.contains(" as md")
+    {
+        ("md", Some("markdown"))
+    } else if normalized.contains(" shell file")
+        || normalized.contains(" sh file")
+        || normalized.contains(" bash file")
+        || normalized.contains(" in shell")
+        || normalized.contains(" as shell")
+        || normalized.contains(" in bash")
+        || normalized.contains(" as bash")
+    {
+        ("sh", Some("shell"))
+    } else if normalized.contains(" txt file")
+        || normalized.ends_with(" txt")
+        || normalized.contains(" text file")
+        || normalized.contains(" in text")
+        || normalized.contains(" as text")
+        || normalized.contains(" in txt")
+        || normalized.contains(" as txt")
+    {
+        ("txt", None)
+    } else {
+        return None;
+    };
+
+    let before_kind = if let Some(idx) = normalized.find(" txt file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" text file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" python file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" py file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" rust file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" rs file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" javascript file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" js file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" typescript file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" ts file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" json file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" markdown file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" md file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in markdown") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as markdown") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in md") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as md") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" shell file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" sh file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" bash file") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in python") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as python") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in rust") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as rust") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in javascript") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as javascript") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in typescript") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as typescript") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in json") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as json") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in shell") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as shell") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in bash") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as bash") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in text") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as text") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" in txt") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.find(" as txt") {
+        &query[..idx]
+    } else if let Some(idx) = normalized.rfind(" txt") {
+        &query[..idx]
+    } else {
+        query
+    };
+
+    let descriptor = before_kind
+        .trim()
+        .trim_start_matches(|c: char| c.is_whitespace())
+        .to_string();
+    let descriptor = descriptor
+        .strip_prefix("create ")
+        .or_else(|| descriptor.strip_prefix("Create "))
+        .or_else(|| descriptor.strip_prefix("make "))
+        .or_else(|| descriptor.strip_prefix("Make "))
+        .or_else(|| descriptor.strip_prefix("write "))
+        .or_else(|| descriptor.strip_prefix("Write "))
+        .unwrap_or(descriptor.as_str())
+        .trim_start_matches("a ")
+        .trim_start_matches("an ")
+        .trim_start_matches("the ")
+        .trim();
+
+    let descriptor = if let Some(label) = language_label {
+        descriptor
+            .strip_prefix(label)
+            .or_else(|| descriptor.strip_prefix(&capitalize_first(label)))
+            .unwrap_or(descriptor)
+            .trim()
+    } else {
+        descriptor
+    };
+    let descriptor = descriptor
+        .strip_suffix(" file")
+        .unwrap_or(descriptor)
+        .trim();
+
+    if descriptor.is_empty() {
+        return None;
+    }
+
+    let authoring_descriptor = authoring_content_descriptor(descriptor);
+    let content = starter_content_for(file_kind, &authoring_descriptor);
+    let slug = slugify_filename(&authoring_slug_descriptor(&authoring_descriptor));
+    Some((format!("{}.{}", slug, file_kind), content))
+}
+
+fn authoring_content_descriptor(descriptor: &str) -> String {
+    let normalized = descriptor
+        .trim_start_matches("new file ")
+        .trim_start_matches("new ")
+        .trim_start_matches("file ")
+        .trim();
+
+    for marker in [" explaining ", " about ", " for ", " on "] {
+        if let Some(idx) = normalized.find(marker) {
+            let tail = normalized[idx + marker.len()..].trim();
+            if !tail.is_empty() {
+                return tail.to_string();
+            }
+        }
+    }
+
+    normalized.to_string()
+}
+
+fn authoring_slug_descriptor(descriptor: &str) -> String {
+    descriptor
+        .trim_start_matches("about ")
+        .trim_start_matches("explaining ")
+        .trim_start_matches("introduction to ")
+        .trim()
+        .to_string()
+}
+
+fn infer_explicit_write_file_intent(query: &str, normalized: &str) -> Option<(String, String)> {
+    let wants_create = normalized.contains("create ")
+        || normalized.contains("make ")
+        || normalized.contains("write ");
+    let wants_modify = normalized.contains("modify ")
+        || normalized.contains("update ")
+        || normalized.contains("change ")
+        || normalized.contains("replace ");
+    if !wants_create && !wants_modify {
+        return None;
+    }
+
+    let path = extract_explicit_path(query)?;
+    let lowered = query.to_ascii_lowercase();
+
+    let content = if wants_modify {
+        extract_content_after_markers(
+            query,
+            &lowered,
+            &[" to ", " with ", " containing ", " so it says ", " saying "],
+        )
+    } else {
+        extract_content_after_markers(
+            query,
+            &lowered,
+            &[" with ", " containing ", " that says ", " saying "],
+        )
+    }
+    .or_else(|| infer_content_from_explicit_path_and_query(&path, query));
+
+    content.map(|value| (path, value))
+}
+
+fn extract_explicit_path(query: &str) -> Option<String> {
+    query.split_whitespace().find_map(|token| {
+        let cleaned = token
+            .trim_matches(|c: char| {
+                matches!(c, '.' | ',' | ';' | ':' | ')' | '(' | '"' | '\'' | '`')
+            })
+            .trim();
+        if cleaned.is_empty() {
+            return None;
+        }
+
+        let lowered = cleaned.to_ascii_lowercase();
+        let has_path_separator = cleaned.contains('/') || cleaned.contains('\\');
+        let has_known_extension = [
+            ".rs", ".py", ".js", ".ts", ".json", ".md", ".sh", ".txt", ".toml", ".yaml", ".yml",
+        ]
+        .iter()
+        .any(|ext| lowered.ends_with(ext));
+
+        if has_path_separator || has_known_extension {
+            Some(cleaned.to_string())
+        } else {
+            None
+        }
+    })
+}
+
+fn extract_content_after_markers(
+    query: &str,
+    lowered_query: &str,
+    markers: &[&str],
+) -> Option<String> {
+    for marker in markers {
+        if let Some(idx) = lowered_query.find(marker) {
+            let content = query[idx + marker.len()..]
+                .trim()
+                .trim_matches(|c: char| matches!(c, '"' | '\''))
+                .to_string();
+            if !content.is_empty() {
+                return Some(content);
+            }
+        }
+    }
+    None
+}
+
+fn infer_content_from_explicit_path_and_query(path: &str, query: &str) -> Option<String> {
+    let lowered = path.to_ascii_lowercase();
+    let stem = Path::new(path)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("hello");
+    let humanized = humanize_descriptor(&stem.replace(['-', '_'], " "));
+
+    if lowered.ends_with(".py") {
+        if query.to_ascii_lowercase().contains("hello") {
+            return Some(format!("print(\"{}\")", humanized));
+        }
+        return Some(format!("print(\"{}\")", humanized));
+    }
+    if lowered.ends_with(".rs") {
+        return Some(format!(
+            "fn main() {{\n    println!(\"{}\");\n}}",
+            humanized
+        ));
+    }
+    if lowered.ends_with(".js") || lowered.ends_with(".ts") {
+        return Some(format!("console.log(\"{}\");", humanized));
+    }
+    if lowered.ends_with(".txt") {
+        return Some(humanized);
+    }
+    if lowered.ends_with(".md") {
+        return Some(format!("# {}\n", humanized));
+    }
+
+    None
+}
+
+fn humanize_descriptor(input: &str) -> String {
+    input
+        .split_whitespace()
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| {
+            let mut chars = segment.chars();
+            match chars.next() {
+                Some(first) => format!(
+                    "{}{}",
+                    first.to_ascii_uppercase(),
+                    chars.as_str().to_ascii_lowercase()
+                ),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn slugify_filename(input: &str) -> String {
+    let slug = input
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    let collapsed = slug
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    if collapsed.is_empty() {
+        "new-file".to_string()
+    } else {
+        collapsed
+    }
+}
+
+fn starter_content_for(file_kind: &str, descriptor: &str) -> String {
+    let phrase = humanize_descriptor(descriptor);
+    match file_kind {
+        "py" => format!("print(\"{}\")", phrase),
+        "rs" => format!("fn main() {{\n    println!(\"{}\");\n}}", phrase),
+        "js" => format!("console.log(\"{}\");", phrase),
+        "ts" => format!("console.log(\"{}\");", phrase),
+        "json" => format!("{{\n  \"message\": \"{}\"\n}}", phrase),
+        "md" => format!("# {}\n", phrase),
+        "sh" => format!("#!/usr/bin/env bash\necho \"{}\"\n", phrase),
+        _ => phrase,
+    }
+}
+
+fn capitalize_first(input: &str) -> String {
+    let mut chars = input.chars();
+    match chars.next() {
+        Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+        None => String::new(),
+    }
+}
+
+fn infer_codebase_search_pattern(query: &str, normalized: &str) -> Option<String> {
+    let codebase_scope = normalized.contains("repo")
+        || normalized.contains("repository")
+        || normalized.contains("codebase")
+        || normalized.contains("project")
+        || normalized.contains("this repo")
+        || normalized.contains(" in this")
+        || normalized.ends_with(" here")
+        || normalized.contains(" in here");
+    let search_intent = normalized.contains("find where")
+        || normalized.contains("where is")
+        || normalized.contains("where does")
+        || normalized.contains("what renders")
+        || normalized.contains("who calls")
+        || normalized.contains("find ")
+        || normalized.contains("locate ");
+
+    if !codebase_scope || !search_intent {
+        return None;
+    }
+
+    let mut phrase = query.to_string();
+    for marker in [
+        "Find where ",
+        "find where ",
+        "Where is ",
+        "where is ",
+        "Where does ",
+        "where does ",
+        "What renders ",
+        "what renders ",
+        "Who calls ",
+        "who calls ",
+        "Find ",
+        "find ",
+        "Locate ",
+        "locate ",
+    ] {
+        if let Some(rest) = phrase.strip_prefix(marker) {
+            phrase = rest.to_string();
+            break;
+        }
+    }
+
+    let lower_phrase = phrase.to_ascii_lowercase();
+    let cutoff_markers = [
+        " in this repo",
+        " in this repository",
+        " in this codebase",
+        " in this project",
+        " in this",
+        " in the repo",
+        " in the repository",
+        " in the codebase",
+        " in project",
+        " in here",
+        " here",
+    ];
+    for marker in cutoff_markers {
+        if let Some(idx) = lower_phrase.find(marker) {
+            phrase.truncate(idx);
+            break;
+        }
+    }
+
+    let cleaned = phrase
+        .replace(" is rendered", "")
+        .replace(" rendered", "")
+        .replace(" render", "")
+        .replace(" called", "")
+        .replace(" defined", "")
+        .replace(" used", "")
+        .trim()
+        .to_string();
+
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned)
+    }
+}
+
+fn infer_simple_run_command(query: &str, normalized: &str) -> Option<String> {
+    let prefixes = ["run ", "execute "];
+    let mut rest = None;
+    for prefix in prefixes {
+        if let Some(value) = query.strip_prefix(prefix) {
+            rest = Some(value.trim());
+            break;
+        }
+        if let Some(value) = query.strip_prefix(&prefix.to_ascii_uppercase()) {
+            rest = Some(value.trim());
+            break;
+        }
+    }
+
+    if let Some(mut candidate) = rest.map(str::trim) {
+        if let Some(stripped) = candidate.strip_prefix("the ") {
+            candidate = stripped.trim();
+        }
+        if let Some(stripped) = candidate.strip_suffix(" command") {
+            candidate = stripped.trim();
+        }
+        candidate =
+            candidate.trim_matches(|c: char| matches!(c, '.' | ',' | ';' | ':' | '"' | '\''));
+        candidate = sanitize_natural_command_candidate(candidate);
+
+        let lowered = candidate.to_ascii_lowercase();
+        match lowered.as_str() {
+            "clear" | "pwd" | "ls" | "date" | "whoami" => return Some(lowered),
+            "git status" => return Some("git status".to_string()),
+            "git diff" => return Some("git diff".to_string()),
+            "harper" | "run harper" => {
+                return Some("cargo run -p harper-ui --bin harper".to_string())
+            }
+            "fmt" | "format" | "run fmt" => return Some("cargo fmt --all".to_string()),
+            "fmt check" | "format check" => return Some("cargo fmt --all -- --check".to_string()),
+            "tests" | "test" | "run tests" | "run test" => {
+                return Some("cargo test --all-features --workspace".to_string())
+            }
+            "check" | "run check" => return Some("cargo check --workspace".to_string()),
+            _ => {}
+        }
+    }
+
+    match () {
+        _ if normalized.contains("run clear") || normalized.contains("clear command") => {
+            Some("clear".to_string())
+        }
+        _ if normalized.contains("run harper") || normalized.contains("start harper") => {
+            Some("cargo run -p harper-ui --bin harper".to_string())
+        }
+        _ if normalized.contains("run fmt")
+            || normalized.contains("run format")
+            || normalized.contains("format the workspace")
+            || normalized.contains("format the repo")
+            || normalized.contains("format this repo")
+            || normalized.contains("please format the repo")
+            || normalized.contains("run the formatter")
+            || normalized.contains("run formatter") =>
+        {
+            Some("cargo fmt --all".to_string())
+        }
+        _ if normalized.contains("run tests")
+            || normalized.contains("run the tests")
+            || normalized.contains("test this repo")
+            || normalized.contains("test the repo")
+            || normalized.contains("run the test suite")
+            || normalized.contains("run test suite") =>
+        {
+            Some("cargo test --all-features --workspace".to_string())
+        }
+        _ if normalized.contains("run check")
+            || normalized.contains("check this repo")
+            || normalized.contains("cargo check")
+            || normalized.contains("check the workspace")
+            || normalized.contains("run the checks") =>
+        {
+            Some("cargo check --workspace".to_string())
+        }
+        _ if normalized.contains("which directory")
+            || normalized.contains("what directory")
+            || normalized.contains("current directory")
+            || normalized.contains("where am i")
+            || normalized.contains("where are we") =>
+        {
+            Some("pwd".to_string())
+        }
+        _ if normalized.contains("list files here")
+            || normalized.contains("show files here")
+            || normalized.contains("list the files")
+            || normalized.contains("show the files") =>
+        {
+            Some("ls".to_string())
+        }
+        _ => None,
+    }
+}
+
+fn sanitize_natural_command_candidate(candidate: &str) -> &str {
+    let lowered = candidate.to_ascii_lowercase();
+    for suffix in [
+        " and summarize it",
+        " and summarize",
+        " then summarize it",
+        " then summarize",
+        " and explain it",
+        " and explain",
+        " and show me",
+    ] {
+        if lowered.ends_with(suffix) {
+            let idx = candidate.len() - suffix.len();
+            return candidate[..idx].trim();
+        }
+    }
+    candidate
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,15 +934,25 @@ mod tests {
     }
 
     #[test]
-    fn does_not_route_plain_file_read_request() {
+    fn routes_plain_file_read_request() {
         let intent = route_intent("show me the new file gemini.md");
-        assert!(intent.is_none());
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::ReadFile(ReadFileIntent {
+                path: "gemini.md".to_string()
+            }))
+        );
     }
 
     #[test]
-    fn does_not_route_open_file_request() {
+    fn routes_open_file_request() {
         let intent = route_intent("open gemini.md");
-        assert!(intent.is_none());
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::ReadFile(ReadFileIntent {
+                path: "gemini.md".to_string()
+            }))
+        );
     }
 
     #[test]
@@ -165,5 +965,233 @@ mod tests {
             }
             _ => panic!("intent not routed"),
         }
+    }
+
+    #[test]
+    fn routes_git_status_intent() {
+        let intent = route_intent("Run git status and summarize it.");
+        assert!(matches!(intent, Some(DeterministicIntent::GitStatus)));
+    }
+
+    #[test]
+    fn routes_git_diff_intent() {
+        let intent = route_intent("show git diff to check code changes");
+        assert!(matches!(intent, Some(DeterministicIntent::GitDiff)));
+    }
+
+    #[test]
+    fn routes_git_branch_intent() {
+        let intent = route_intent("which branch i am on");
+        assert!(matches!(intent, Some(DeterministicIntent::GitBranch)));
+    }
+
+    #[test]
+    fn routes_repo_identity_intent() {
+        let intent = route_intent("can you check which repo we are working on");
+        assert!(matches!(intent, Some(DeterministicIntent::RepoIdentity)));
+    }
+
+    #[test]
+    fn routes_codebase_overview_intent() {
+        let intent = route_intent("tell me the codebase");
+        assert!(matches!(
+            intent,
+            Some(DeterministicIntent::CodebaseOverview)
+        ));
+    }
+
+    #[test]
+    fn routes_direct_read_file_intent() {
+        let intent = route_intent("Read Cargo.toml and tell me the package name.");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::ReadFile(ReadFileIntent {
+                path: "Cargo.toml".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_codebase_search_intent() {
+        let intent = route_intent("Find where retry metadata is rendered in this repo.");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::CodebaseSearch(CodebaseSearchIntent {
+                pattern: "retry metadata".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_partial_codebase_search_intent_without_repo_noun() {
+        let intent = route_intent("Find where retry metadata is rendered in this");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::CodebaseSearch(CodebaseSearchIntent {
+                pattern: "retry metadata".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_simple_clear_command_intent() {
+        let intent = route_intent("run the clear command");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::RunCommand(RunCommandIntent {
+                command: "clear".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_run_harper_command_intent() {
+        let intent = route_intent("run harper");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::RunCommand(RunCommandIntent {
+                command: "cargo run -p harper-ui --bin harper".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_run_fmt_command_intent() {
+        let intent = route_intent("run fmt");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::RunCommand(RunCommandIntent {
+                command: "cargo fmt --all".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_natural_language_format_command_intent() {
+        let intent = route_intent("please format the repo");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::RunCommand(RunCommandIntent {
+                command: "cargo fmt --all".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_run_tests_command_intent() {
+        let intent = route_intent("run tests");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::RunCommand(RunCommandIntent {
+                command: "cargo test --all-features --workspace".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_run_check_command_intent() {
+        let intent = route_intent("run check");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::RunCommand(RunCommandIntent {
+                command: "cargo check --workspace".to_string()
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_natural_language_directory_command_intent() {
+        let intent = route_intent("which directory are we in");
+        assert_eq!(intent, Some(DeterministicIntent::CurrentDirectory));
+    }
+
+    #[test]
+    fn routes_simple_create_text_file_intent() {
+        let intent = route_intent("create a hello world txt file");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::WriteFile(WriteFileIntent {
+                path: "hello-world.txt".to_string(),
+                content: "Hello World".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_generic_create_file_saying_prompt_to_text_file() {
+        let intent = route_intent("can you create a file saying i am niladri");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::WriteFile(WriteFileIntent {
+                path: "note.txt".to_string(),
+                content: "i am niladri".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn sanitizes_git_status_summary_command_prompt() {
+        let intent = route_intent("Run git status and summarize it.");
+        assert!(matches!(intent, Some(DeterministicIntent::GitStatus)));
+    }
+
+    #[test]
+    fn routes_simple_create_python_file_intent() {
+        let intent = route_intent("create a python hello joy file");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::WriteFile(WriteFileIntent {
+                path: "hello-joy.py".to_string(),
+                content: "print(\"Hello Joy\")".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_markdown_authoring_prompt_with_in_markdown() {
+        let intent = route_intent("create a new file explaining ai in markdown");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::WriteFile(WriteFileIntent {
+                path: "ai.md".to_string(),
+                content: "# Explaining Ai\n".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_markdown_authoring_prompt_with_as_markdown() {
+        let intent = route_intent("write a file about planners as markdown");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::WriteFile(WriteFileIntent {
+                path: "planners.md".to_string(),
+                content: "# About Planners\n".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_explicit_create_file_with_content() {
+        let intent = route_intent(r#"create hello.rs with fn main() { println!("Hi"); }"#);
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::WriteFile(WriteFileIntent {
+                path: "hello.rs".to_string(),
+                content: r#"fn main() { println!("Hi"); }"#.to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_explicit_modify_file_with_content() {
+        let intent = route_intent(r#"modify notes.txt to hello from harper"#);
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::WriteFile(WriteFileIntent {
+                path: "notes.txt".to_string(),
+                content: "hello from harper".to_string(),
+            }))
+        );
     }
 }

--- a/lib/harper-core/src/agent/prompt.rs
+++ b/lib/harper-core/src/agent/prompt.rs
@@ -74,23 +74,35 @@ Capabilities: File I/O, shell execution, and persistent memory{}.",
 For multi-step work, call update_plan early, keep exactly one step in_progress when active work remains, and update the plan as progress changes.
 
 User Intent Recognition:
-- read a file -> use read_file
+- read a specific file -> use read_file
 - update or fix a file -> use search_replace or write_file
 - run a command -> use run_command
 - manage a multi-step task -> use update_plan
 - list or show files -> use run_command or list tool
-- search or find something -> use run_command with grep
+- search or find something -> use codebase_investigator or run_command with grep
 - create a new file -> use write_file
 - delete or remove a file -> ask first, then run_command
 - commit or push -> use git tools
 - understand how something works -> use codebase_investigator
 - what changed -> use git_diff or list_changed_files
-- tell me about a file -> use read_file
+- tell me about a specific file -> use read_file
 
 Use this JSON shape for built-in tools:
 {\"tool\":\"tool_name\",\"args\":{...}}
 
 If the user asks for a file read, file edit, search, diff, git inspection, or command execution, do not answer with an apology or a capability disclaimer. Emit the correct tool JSON immediately.
+
+File path rules:
+- For file tools, use repository-relative paths whenever possible.
+- Prefer the exact filename mentioned by the user.
+- If the user asks for a common root file like Cargo.toml or README.md, target that workspace file directly.
+- Do not invent absolute paths like /home/user/... or placeholder project roots.
+- After a tool succeeds, do not call the same file tool again unless the previous result clearly did not answer the request.
+
+Codebase discovery rules:
+- If the user asks about the codebase, a symbol location, where something is rendered, where logic lives, or uses an ambiguous file reference, do not guess a file path first.
+- For ambiguous repository questions, use codebase_investigator or a search command first to locate the relevant file(s).
+- Use read_file directly only when the target file is explicit and unambiguous.
 
 Core Tools:
 - read_file(args: {\"path\": \"src/main.rs\"})
@@ -242,5 +254,35 @@ Example: {\"tool\":\"read_file\",\"args\":{\"path\":\"src/main.rs\"}}",
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PromptBuilder;
+    use crate::core::{ApiConfig, ApiProvider};
+
+    fn test_config() -> ApiConfig {
+        ApiConfig {
+            provider: ApiProvider::OpenAI,
+            api_key: "test-key".to_string(),
+            base_url: "https://api.openai.com/v1/chat/completions".to_string(),
+            model_name: "gpt-5.5".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_system_prompt_includes_workspace_file_rules() {
+        let config = test_config();
+        let builder = PromptBuilder::new(&config, None, None);
+        let prompt = builder.build_system_prompt(false).await;
+
+        assert!(prompt.contains("File path rules:"));
+        assert!(prompt.contains("use repository-relative paths whenever possible"));
+        assert!(prompt.contains("Do not invent absolute paths like /home/user/..."));
+        assert!(prompt.contains("do not call the same file tool again"));
+        assert!(prompt.contains("Codebase discovery rules:"));
+        assert!(prompt.contains("do not guess a file path first"));
+        assert!(prompt.contains("use codebase_investigator or a search command first"));
     }
 }

--- a/lib/harper-core/src/core/llm_client.rs
+++ b/lib/harper-core/src/core/llm_client.rs
@@ -26,7 +26,325 @@ use ring::{
     aead::{self},
     rand::{SecureRandom, SystemRandom},
 };
-use serde_json::json;
+use serde_json::{json, Value};
+
+fn built_in_tool_functions() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "read_file",
+            "description": "Read the contents of a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The path to the file to read"
+                    }
+                },
+                "required": ["path"]
+            }
+        }),
+        json!({
+            "name": "write_file",
+            "description": "Write content to a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The path to the file to write"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "The content to write to the file"
+                    }
+                },
+                "required": ["path", "content"]
+            }
+        }),
+        json!({
+            "name": "search_replace",
+            "description": "Search and replace text in a file",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The path to the file"
+                    },
+                    "old_string": {
+                        "type": "string",
+                        "description": "The text to replace"
+                    },
+                    "new_string": {
+                        "type": "string",
+                        "description": "The replacement text"
+                    }
+                },
+                "required": ["path", "old_string", "new_string"]
+            }
+        }),
+        json!({
+            "name": "run_command",
+            "description": "Run a shell command",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "The command to run"
+                    },
+                    "declared_read_paths": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional explicit paths the command will read"
+                    },
+                    "declared_write_paths": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional explicit paths the command will write"
+                    },
+                    "requires_network": {
+                        "type": "boolean",
+                        "description": "Set true if the command needs network access"
+                    },
+                    "retry_policy": {
+                        "type": "string",
+                        "enum": ["never", "safe"],
+                        "description": "Optional explicit retry policy for transient-safe commands"
+                    }
+                },
+                "required": ["command"]
+            }
+        }),
+        json!({
+            "name": "todo",
+            "description": "Manage todo list. Supported actions: add, list, remove, clear",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["add", "list", "remove", "clear"],
+                        "description": "The action to perform"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description for 'add' action"
+                    },
+                    "index": {
+                        "type": "integer",
+                        "description": "1-based index for 'remove' action"
+                    }
+                },
+                "required": ["action"]
+            }
+        }),
+        json!({
+            "name": "update_plan",
+            "description": "Update the current execution plan for the active session",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "explanation": {
+                        "type": "string",
+                        "description": "Optional note explaining the current plan or why it changed"
+                    },
+                    "authoring_plan": {
+                        "type": "object",
+                        "description": "Optional structured authoring plan for open-ended code changes",
+                        "properties": {
+                            "primary_files": {"type": "array", "items": {"type": "string"}},
+                            "supporting_files": {"type": "array", "items": {"type": "string"}},
+                            "validation_files": {"type": "array", "items": {"type": "string"}},
+                            "planned_edits": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {"type": "string"},
+                                        "change": {"type": "string"},
+                                        "why": {"type": "string"}
+                                    },
+                                    "required": ["path", "change"]
+                                }
+                            },
+                            "validation_plan": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "command": {"type": "string"},
+                                        "scope": {"type": "string"}
+                                    },
+                                    "required": ["command"]
+                                }
+                            }
+                        }
+                    },
+                    "items": {
+                        "type": "array",
+                        "description": "Ordered plan steps",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "step": {
+                                    "type": "string",
+                                    "description": "Short step description"
+                                },
+                                "status": {
+                                    "type": "string",
+                                    "enum": ["pending", "in_progress", "completed", "blocked"],
+                                    "description": "Current status of the step"
+                                }
+                            },
+                            "required": ["step", "status"]
+                        }
+                    }
+                },
+                "required": ["items"]
+            }
+        }),
+        json!({
+            "name": "git_status",
+            "description": "Get the current git status",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }),
+        json!({
+            "name": "git_diff",
+            "description": "Get the git diff",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }),
+        json!({
+            "name": "git_commit",
+            "description": "Commit changes with a message",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "The commit message"
+                    }
+                },
+                "required": ["message"]
+            }
+        }),
+        json!({
+            "name": "git_add",
+            "description": "Add files to git staging",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "files": {
+                        "type": "string",
+                        "description": "Files to add (space-separated)"
+                    }
+                },
+                "required": ["files"]
+            }
+        }),
+        json!({
+            "name": "list_changed_files",
+            "description": "List changed files with optional filters",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "ext": {
+                        "type": "string",
+                        "description": "Optional file extension filter, for example 'rs'"
+                    },
+                    "tracked_only": {
+                        "type": "boolean",
+                        "description": "When true, exclude untracked files"
+                    },
+                    "since": {
+                        "type": "string",
+                        "description": "Optional git --since expression, for example 'today'"
+                    }
+                },
+                "required": []
+            }
+        }),
+    ]
+}
+
+fn build_ollama_tools() -> Vec<Value> {
+    built_in_tool_functions()
+        .into_iter()
+        .map(|function| json!({"type": "function", "function": function}))
+        .collect()
+}
+
+fn build_ollama_request_body(config: &ApiConfig, history: &[Message]) -> Value {
+    let messages_json: Vec<_> = history
+        .iter()
+        .map(|m| json!({"role": m.role, "content": m.content}))
+        .collect();
+
+    json!({
+        "model": config.model_name,
+        "messages": messages_json,
+        "tools": build_ollama_tools(),
+        "stream": false,
+    })
+}
+
+fn extract_assistant_reply(provider: &ApiProvider, resp_json: &Value) -> String {
+    match provider {
+        ApiProvider::OpenAI | ApiProvider::Sambanova => {
+            let message = &resp_json["choices"][0]["message"];
+            if let Some(tool_calls) = message.get("tool_calls") {
+                serde_json::to_string(tool_calls).unwrap_or_else(|_| "[No response]".to_string())
+            } else {
+                message["content"]
+                    .as_str()
+                    .unwrap_or("[No response]")
+                    .to_string()
+            }
+        }
+        ApiProvider::Gemini => {
+            let part = &resp_json["candidates"][0]["content"]["parts"][0];
+            if let Some(function_call) = part.get("functionCall") {
+                serde_json::to_string(function_call).unwrap_or_else(|_| "[No response]".to_string())
+            } else {
+                part.get("text")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("[No response]")
+                    .to_string()
+            }
+        }
+        ApiProvider::Ollama => {
+            if let Some(tool_calls) = resp_json
+                .get("message")
+                .and_then(|msg| msg.get("tool_calls"))
+                .or_else(|| resp_json.get("tool_calls"))
+            {
+                serde_json::to_string(tool_calls).unwrap_or_else(|_| "[No response]".to_string())
+            } else {
+                resp_json
+                    .get("message")
+                    .and_then(|msg| msg.get("content"))
+                    .and_then(|content| content.as_str())
+                    .map(|s| s.to_string())
+                    .or_else(|| {
+                        resp_json
+                            .get("response")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string())
+                    })
+                    .unwrap_or_else(|| "[No response]".to_string())
+            }
+        }
+    }
+}
 
 /// Call the configured LLM API with conversation history
 ///
@@ -93,223 +411,7 @@ pub async fn call_llm(
             }
 
             let tools = json!({
-                "function_declarations": [
-                    {
-                        "name": "read_file",
-                        "description": "Read the contents of a file",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "path": {
-                                    "type": "string",
-                                    "description": "The path to the file to read"
-                                }
-                            },
-                            "required": ["path"]
-                        }
-                    },
-                    {
-                        "name": "write_file",
-                        "description": "Write content to a file",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "path": {
-                                    "type": "string",
-                                    "description": "The path to the file to write"
-                                },
-                                "content": {
-                                    "type": "string",
-                                    "description": "The content to write to the file"
-                                }
-                            },
-                            "required": ["path", "content"]
-                        }
-                    },
-                    {
-                        "name": "search_replace",
-                        "description": "Search and replace text in a file",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "path": {
-                                    "type": "string",
-                                    "description": "The path to the file"
-                                },
-                                "old_string": {
-                                    "type": "string",
-                                    "description": "The text to replace"
-                                },
-                                "new_string": {
-                                    "type": "string",
-                                    "description": "The replacement text"
-                                }
-                            },
-                            "required": ["path", "old_string", "new_string"]
-                        }
-                    },
-                    {
-                        "name": "run_command",
-                        "description": "Run a shell command",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "command": {
-                                    "type": "string",
-                                    "description": "The command to run"
-                                },
-                                "declared_read_paths": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "description": "Optional explicit paths the command will read"
-                                },
-                                "declared_write_paths": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "description": "Optional explicit paths the command will write"
-                                },
-                                "requires_network": {
-                                    "type": "boolean",
-                                    "description": "Set true if the command needs network access"
-                                },
-                                "retry_policy": {
-                                    "type": "string",
-                                    "enum": ["never", "safe"],
-                                    "description": "Optional explicit retry policy for transient-safe commands"
-                                }
-                            },
-                            "required": ["command"]
-                        }
-                    },
-                    {
-                        "name": "todo",
-                        "description": "Manage todo list. Supported actions: add, list, remove, clear",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "action": {
-                                    "type": "string",
-                                    "enum": ["add", "list", "remove", "clear"],
-                                    "description": "The action to perform"
-                                },
-                                "description": {
-                                    "type": "string",
-                                    "description": "Description for 'add' action"
-                                },
-                                "index": {
-                                    "type": "integer",
-                                    "description": "1-based index for 'remove' action"
-                                }
-                            },
-                            "required": ["action"]
-                        }
-                    },
-                    {
-                        "name": "update_plan",
-                        "description": "Update the current execution plan for the active session",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "explanation": {
-                                    "type": "string",
-                                    "description": "Optional note explaining the current plan or why it changed"
-                                },
-                                "items": {
-                                    "type": "array",
-                                    "description": "Ordered plan steps",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "step": {
-                                                "type": "string",
-                                                "description": "Short step description"
-                                            },
-                                            "status": {
-                                                "type": "string",
-                                                "enum": ["pending", "in_progress", "completed", "blocked"],
-                                                "description": "Current status of the step"
-                                            }
-                                        },
-                                        "required": ["step", "status"]
-                                    }
-                                }
-                            },
-                            "required": ["items"]
-                        }
-                    },
-                    {
-                        "name": "git_status",
-                        "description": "Get the current git status",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {},
-                            "required": []
-                        }
-                    },
-                    {
-                        "name": "git_diff",
-                        "description": "Get the git diff",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {},
-                            "required": []
-                        }
-                    },
-                    {
-                        "name": "git_commit",
-                        "description": "Commit changes with a message",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "message": {
-                                    "type": "string",
-                                    "description": "The commit message"
-                                }
-                            },
-                            "required": ["message"]
-                        }
-                    },
-                    {
-                        "name": "git_add",
-                        "description": "Add files to git staging",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "files": {
-                                    "type": "string",
-                                    "description": "Files to add (space-separated)"
-                                }
-                            },
-                            "required": ["files"]
-                        }
-                    },
-                    {
-                        "name": "list_changed_files",
-                        "description": "List changed files with optional filters",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "ext": {
-                                    "type": "string",
-                                    "description": "Optional file extension filter, for example 'rs'"
-                                },
-                                "tracked_only": {
-                                    "type": "boolean",
-                                    "description": "When true, exclude untracked files"
-                                },
-                                "since": {
-                                    "type": "string",
-                                    "description": "Optional git --since expression, for example 'today'"
-                                }
-                            },
-                            "required": []
-                        }
-                    }
-                ]
+                "function_declarations": built_in_tool_functions()
             });
 
             let mut body = json!({
@@ -334,21 +436,10 @@ pub async fn call_llm(
                 .await?
         }
         ApiProvider::Ollama => {
-            let messages_json: Vec<_> = history
-                .iter()
-                .map(|m| json!({"role": m.role, "content": m.content}))
-                .collect();
-
-            let body = json!({
-                "model": config.model_name,
-                "messages": messages_json,
-                "stream": false,
-            });
-
             client
                 .post(&config.base_url)
                 .header(CONTENT_TYPE, "application/json")
-                .json(&body)
+                .json(&build_ollama_request_body(config, history))
                 .send()
                 .await?
         }
@@ -368,42 +459,7 @@ pub async fn call_llm(
         .await
         .map_err(|e| HarperError::Api(e.to_string()))?;
 
-    let assistant_reply = match config.provider {
-        ApiProvider::OpenAI | ApiProvider::Sambanova => {
-            let message = &resp_json["choices"][0]["message"];
-            if let Some(tool_calls) = message.get("tool_calls") {
-                serde_json::to_string(tool_calls).unwrap_or_else(|_| "[No response]".to_string())
-            } else {
-                message["content"]
-                    .as_str()
-                    .unwrap_or("[No response]")
-                    .to_string()
-            }
-        }
-        ApiProvider::Gemini => {
-            let part = &resp_json["candidates"][0]["content"]["parts"][0];
-            if let Some(function_call) = part.get("functionCall") {
-                serde_json::to_string(function_call).unwrap_or_else(|_| "[No response]".to_string())
-            } else {
-                part.get("text")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("[No response]")
-                    .to_string()
-            }
-        }
-        ApiProvider::Ollama => resp_json
-            .get("message")
-            .and_then(|msg| msg.get("content"))
-            .and_then(|content| content.as_str())
-            .map(|s| s.to_string())
-            .or_else(|| {
-                resp_json
-                    .get("response")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-            })
-            .unwrap_or_else(|| "[No response]".to_string()),
-    };
+    let assistant_reply = extract_assistant_reply(&config.provider, &resp_json);
 
     Ok(assistant_reply)
 }
@@ -547,7 +603,62 @@ pub fn decrypt_data(encrypted_data: &[u8], key: &[u8]) -> HarperResult<Vec<u8>> 
 mod tests {
     use super::*;
     use crate::core::constants::test_data;
+    use crate::core::{ApiConfig, ApiProvider, Message};
     use hex_literal::hex;
+    use serde_json::json;
+
+    fn test_ollama_config() -> ApiConfig {
+        ApiConfig {
+            provider: ApiProvider::Ollama,
+            api_key: String::new(),
+            base_url: "http://127.0.0.1:11434/api/chat".to_string(),
+            model_name: "qwen2.5:1.5b".to_string(),
+        }
+    }
+
+    #[test]
+    fn build_ollama_request_body_includes_tools() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: "read Cargo.toml".to_string(),
+        }];
+
+        let body = build_ollama_request_body(&test_ollama_config(), &history);
+        let tools = body
+            .get("tools")
+            .and_then(|value| value.as_array())
+            .expect("tools array");
+
+        assert!(!tools.is_empty());
+        assert_eq!(body["stream"], json!(false));
+        assert_eq!(body["model"], json!("qwen2.5:1.5b"));
+        assert_eq!(tools[0]["type"], json!("function"));
+        assert_eq!(tools[0]["function"]["name"], json!("read_file"));
+    }
+
+    #[test]
+    fn extract_assistant_reply_prefers_ollama_tool_calls() {
+        let resp_json = json!({
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "read_file",
+                            "arguments": {
+                                "path": "Cargo.toml"
+                            }
+                        }
+                    }
+                ]
+            }
+        });
+
+        let reply = extract_assistant_reply(&ApiProvider::Ollama, &resp_json);
+        assert!(reply.contains("\"name\":\"read_file\""));
+        assert!(reply.contains("Cargo.toml"));
+    }
 
     #[test]
     fn test_encrypt_decrypt_roundtrip() {

--- a/lib/harper-core/src/core/plan.rs
+++ b/lib/harper-core/src/core/plan.rs
@@ -70,6 +70,61 @@ pub enum PlanFollowup {
     },
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthoringPhase {
+    ContextBuilt,
+    PlanCreated,
+    FilesInspected,
+    EditsApplied,
+    Validated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AuthoringValidationStep {
+    pub command: String,
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AuthoringPlannedEdit {
+    pub path: String,
+    pub change: String,
+    #[serde(default)]
+    pub why: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct StructuredAuthoringPlan {
+    #[serde(default)]
+    pub primary_files: Vec<String>,
+    #[serde(default)]
+    pub supporting_files: Vec<String>,
+    #[serde(default)]
+    pub validation_files: Vec<String>,
+    #[serde(default)]
+    pub planned_edits: Vec<AuthoringPlannedEdit>,
+    #[serde(default)]
+    pub validation_plan: Vec<AuthoringValidationStep>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct AuthoringRuntime {
+    #[serde(default)]
+    pub request: Option<String>,
+    #[serde(default)]
+    pub phase: Option<AuthoringPhase>,
+    #[serde(default)]
+    pub candidate_files: Vec<String>,
+    #[serde(default)]
+    pub inspected_files: Vec<String>,
+    #[serde(default)]
+    pub edit_scope: Vec<String>,
+    #[serde(default)]
+    pub structured_plan: Option<StructuredAuthoringPlan>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct PlanRuntime {
     #[serde(default)]
@@ -84,6 +139,8 @@ pub struct PlanRuntime {
     pub jobs: Vec<PlanJobRecord>,
     #[serde(default)]
     pub followup: Option<PlanFollowup>,
+    #[serde(default)]
+    pub authoring: Option<AuthoringRuntime>,
 }
 
 impl PlanRuntime {
@@ -96,6 +153,7 @@ impl PlanRuntime {
             && self.active_job_id.is_none()
             && self.jobs.is_empty()
             && self.followup.is_none()
+            && self.authoring.is_none()
     }
 
     pub fn set_active_tool_state(
@@ -235,6 +293,147 @@ impl PlanRuntime {
         self.followup = None;
     }
 
+    pub fn seed_authoring_context(
+        &mut self,
+        request: impl Into<String>,
+        candidate_files: Vec<String>,
+    ) {
+        let mut candidate_files = candidate_files;
+        candidate_files.sort();
+        candidate_files.dedup();
+        self.authoring = Some(AuthoringRuntime {
+            request: Some(request.into()),
+            phase: Some(AuthoringPhase::ContextBuilt),
+            edit_scope: candidate_files.clone(),
+            candidate_files,
+            inspected_files: Vec::new(),
+            structured_plan: None,
+        });
+    }
+
+    pub fn mark_authoring_plan_created(&mut self) {
+        let Some(authoring) = self.authoring.as_mut() else {
+            return;
+        };
+        authoring.phase = Some(AuthoringPhase::PlanCreated);
+    }
+
+    pub fn set_authoring_structured_plan(&mut self, plan: StructuredAuthoringPlan) {
+        if self.authoring.is_none() {
+            let mut candidate_files = Vec::new();
+            candidate_files.extend(plan.primary_files.iter().cloned());
+            candidate_files.extend(plan.supporting_files.iter().cloned());
+            candidate_files.extend(plan.validation_files.iter().cloned());
+            candidate_files.extend(plan.planned_edits.iter().map(|edit| edit.path.clone()));
+            candidate_files.sort();
+            candidate_files.dedup();
+            self.authoring = Some(AuthoringRuntime {
+                request: None,
+                phase: Some(AuthoringPhase::PlanCreated),
+                candidate_files: candidate_files.clone(),
+                inspected_files: Vec::new(),
+                edit_scope: candidate_files,
+                structured_plan: Some(plan),
+            });
+            return;
+        }
+        let Some(authoring) = self.authoring.as_mut() else {
+            return;
+        };
+        let mut edit_scope = authoring.edit_scope.clone();
+        edit_scope.extend(plan.primary_files.iter().cloned());
+        edit_scope.extend(plan.supporting_files.iter().cloned());
+        edit_scope.extend(plan.validation_files.iter().cloned());
+        edit_scope.extend(plan.planned_edits.iter().map(|edit| edit.path.clone()));
+        edit_scope.sort();
+        edit_scope.dedup();
+        authoring.edit_scope = edit_scope;
+        authoring.structured_plan = Some(plan);
+        authoring.phase = Some(AuthoringPhase::PlanCreated);
+    }
+
+    pub fn mark_authoring_inspection<I>(&mut self, paths: I)
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let Some(authoring) = self.authoring.as_mut() else {
+            return;
+        };
+        for path in paths {
+            if !authoring
+                .inspected_files
+                .iter()
+                .any(|existing| existing == &path)
+            {
+                authoring.inspected_files.push(path.clone());
+            }
+            if !authoring
+                .edit_scope
+                .iter()
+                .any(|existing| existing == &path)
+            {
+                authoring.edit_scope.push(path);
+            }
+        }
+        authoring.inspected_files.sort();
+        authoring.inspected_files.dedup();
+        authoring.edit_scope.sort();
+        authoring.edit_scope.dedup();
+        authoring.phase = Some(AuthoringPhase::FilesInspected);
+    }
+
+    pub fn mark_authoring_edit_applied<I>(&mut self, paths: I)
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let Some(authoring) = self.authoring.as_mut() else {
+            return;
+        };
+        for path in paths {
+            if !authoring
+                .edit_scope
+                .iter()
+                .any(|existing| existing == &path)
+            {
+                authoring.edit_scope.push(path);
+            }
+        }
+        authoring.edit_scope.sort();
+        authoring.edit_scope.dedup();
+        authoring.phase = Some(AuthoringPhase::EditsApplied);
+    }
+
+    pub fn authoring_edit_scope(&self) -> Option<&[String]> {
+        self.authoring
+            .as_ref()
+            .map(|authoring| authoring.edit_scope.as_slice())
+    }
+
+    pub fn authoring_inspected_files(&self) -> Option<&[String]> {
+        self.authoring
+            .as_ref()
+            .map(|authoring| authoring.inspected_files.as_slice())
+    }
+
+    pub fn authoring_phase(&self) -> Option<&AuthoringPhase> {
+        self.authoring
+            .as_ref()
+            .and_then(|authoring| authoring.phase.as_ref())
+    }
+
+    pub fn authoring_structured_plan(&self) -> Option<&StructuredAuthoringPlan> {
+        self.authoring
+            .as_ref()
+            .and_then(|authoring| authoring.structured_plan.as_ref())
+    }
+
+    pub fn mark_authoring_validated(&mut self) {
+        let Some(authoring) = self.authoring.as_mut() else {
+            return;
+        };
+        authoring.phase = Some(AuthoringPhase::Validated);
+    }
+
     pub fn clear_active_state(&mut self) {
         self.active_tool = None;
         self.active_command = None;
@@ -277,7 +476,7 @@ pub struct PlanState {
 
 #[cfg(test)]
 mod tests {
-    use super::{PlanFollowup, PlanJobStatus, PlanRuntime};
+    use super::{AuthoringPhase, PlanFollowup, PlanJobStatus, PlanRuntime};
 
     #[test]
     fn runtime_deserializes_legacy_shape_with_empty_jobs() {
@@ -332,5 +531,60 @@ mod tests {
                 retry_count: 2,
             })
         );
+    }
+
+    #[test]
+    fn runtime_tracks_authoring_phase_and_scope() {
+        let mut runtime = PlanRuntime::default();
+
+        runtime.seed_authoring_context(
+            "refactor planner flow",
+            vec![
+                "lib/harper-ui/src/interfaces/ui/widgets.rs".to_string(),
+                "lib/harper-core/src/agent/chat.rs".to_string(),
+            ],
+        );
+        assert_eq!(
+            runtime.authoring_phase(),
+            Some(&AuthoringPhase::ContextBuilt)
+        );
+        assert_eq!(
+            runtime.authoring_edit_scope(),
+            Some(
+                &[
+                    "lib/harper-core/src/agent/chat.rs".to_string(),
+                    "lib/harper-ui/src/interfaces/ui/widgets.rs".to_string()
+                ][..]
+            )
+        );
+
+        runtime.mark_authoring_plan_created();
+        assert_eq!(
+            runtime.authoring_phase(),
+            Some(&AuthoringPhase::PlanCreated)
+        );
+
+        runtime.mark_authoring_inspection(vec![
+            "lib/harper-ui/src/interfaces/ui/widgets.rs".to_string()
+        ]);
+        assert_eq!(
+            runtime.authoring_phase(),
+            Some(&AuthoringPhase::FilesInspected)
+        );
+        assert_eq!(
+            runtime.authoring_inspected_files(),
+            Some(&["lib/harper-ui/src/interfaces/ui/widgets.rs".to_string()][..])
+        );
+
+        runtime.mark_authoring_edit_applied(vec!["lib/harper-core/src/tools/plan.rs".to_string()]);
+        assert_eq!(
+            runtime.authoring_phase(),
+            Some(&AuthoringPhase::EditsApplied)
+        );
+        assert!(runtime
+            .authoring_edit_scope()
+            .expect("scope")
+            .iter()
+            .any(|path| path == "lib/harper-core/src/tools/plan.rs"));
     }
 }

--- a/lib/harper-core/src/lib.rs
+++ b/lib/harper-core/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::runtime::utils;
 
 // Re-export runtime
 pub use crate::runtime::config::{
-    ApprovalProfile, ExecPolicyConfig, SandboxProfile, SupabaseAuthConfig,
+    ApprovalProfile, ExecPolicyConfig, ExecutionStrategy, SandboxProfile, SupabaseAuthConfig,
 };
 pub use crate::runtime::scheduler::TaskScheduler;
 

--- a/lib/harper-core/src/runtime/config.rs
+++ b/lib/harper-core/src/runtime/config.rs
@@ -74,10 +74,11 @@ pub struct PromptConfig {
     pub system_prompt_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct UiConfig {
     pub theme: Option<String>,
     pub keys: Option<KeyConfig>,
+    pub header_widgets: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -100,6 +101,7 @@ pub struct ToolsConfig {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ExecPolicyConfig {
     pub approval_profile: Option<ApprovalProfile>,
+    pub execution_strategy: Option<ExecutionStrategy>,
     #[allow(dead_code)]
     pub allowed_commands: Option<Vec<String>>,
     #[allow(dead_code)]
@@ -115,6 +117,7 @@ impl Default for ExecPolicyConfig {
     fn default() -> Self {
         Self {
             approval_profile: Some(ApprovalProfile::AllowListed),
+            execution_strategy: Some(ExecutionStrategy::Auto),
             allowed_commands: None,
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
@@ -139,6 +142,15 @@ pub enum ApprovalProfile {
     Strict,
     AllowListed,
     AllowAll,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionStrategy {
+    Auto,
+    Grounded,
+    Deterministic,
+    ModelOnly,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
@@ -466,6 +478,10 @@ impl UiConfig {
         }
         Ok(())
     }
+
+    pub fn effective_header_widgets(&self) -> Vec<String> {
+        self.header_widgets.clone().unwrap_or_default()
+    }
 }
 
 impl ToolsConfig {
@@ -480,6 +496,10 @@ impl ExecPolicyConfig {
     /// Validate exec policy configuration
     fn validate(&self) -> HarperResult<()> {
         Ok(())
+    }
+
+    pub fn effective_execution_strategy(&self) -> ExecutionStrategy {
+        self.execution_strategy.unwrap_or(ExecutionStrategy::Auto)
     }
 
     pub fn effective_approval_profile(&self) -> ApprovalProfile {
@@ -764,6 +784,7 @@ mod tests {
     fn workspace_sandbox_profile_sets_safe_defaults() {
         let config = ExecPolicyConfig {
             approval_profile: None,
+            execution_strategy: None,
             allowed_commands: None,
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Workspace),
@@ -786,6 +807,7 @@ mod tests {
     fn explicit_sandbox_fields_override_profile_defaults() {
         let config = ExecPolicyConfig {
             approval_profile: None,
+            execution_strategy: None,
             allowed_commands: None,
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Workspace),

--- a/lib/harper-core/src/server/mod.rs
+++ b/lib/harper-core/src/server/mod.rs
@@ -923,54 +923,52 @@ pub async fn chat_endpoint(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    if let Some(intent) = route_intent(&message) {
-        match intent {
-            crate::agent::intent::DeterministicIntent::ListChangedFiles(intent_args) => {
-                let mut git_cmd = std::process::Command::new("git");
-                git_cmd.arg("diff");
+    if let Some(crate::agent::intent::DeterministicIntent::ListChangedFiles(intent_args)) =
+        route_intent(&message)
+    {
+        let mut git_cmd = std::process::Command::new("git");
+        git_cmd.arg("diff");
 
-                if let Some(since) = intent_args.since {
-                    git_cmd.arg(format!("--since={}", since));
-                }
-                git_cmd.arg("--name-only");
-
-                if intent_args.ext.is_some() {
-                    git_cmd.arg("--");
-                    git_cmd.arg("*");
-                }
-
-                let output = git_cmd
-                    .output()
-                    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-                let files = String::from_utf8_lossy(&output.stdout);
-
-                let result = if files.trim().is_empty() {
-                    "No changed files found".to_string()
-                } else {
-                    format!("Changed files:\n{}", files)
-                };
-
-                let conn = state.conn.lock().map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Lock error: {:?}", e),
-                    )
-                })?;
-                claim_or_verify_session_access(&conn, &session_id, auth_user.as_ref())
-                    .map_err(|status| (status, "Session access denied".to_string()))?;
-                let _ = save_message(&conn, &session_id, "user", &message);
-                let _ = save_message(&conn, &session_id, "assistant", &result);
-                drop(conn);
-
-                return Ok(Json(ChatResponse {
-                    message: result,
-                    session_id,
-                    status: "completed".to_string(),
-                    pending_id: None,
-                    pending_tools: None,
-                }));
-            }
+        if let Some(since) = intent_args.since {
+            git_cmd.arg(format!("--since={}", since));
         }
+        git_cmd.arg("--name-only");
+
+        if intent_args.ext.is_some() {
+            git_cmd.arg("--");
+            git_cmd.arg("*");
+        }
+
+        let output = git_cmd
+            .output()
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let files = String::from_utf8_lossy(&output.stdout);
+
+        let result = if files.trim().is_empty() {
+            "No changed files found".to_string()
+        } else {
+            format!("Changed files:\n{}", files)
+        };
+
+        let conn = state.conn.lock().map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Lock error: {:?}", e),
+            )
+        })?;
+        claim_or_verify_session_access(&conn, &session_id, auth_user.as_ref())
+            .map_err(|status| (status, "Session access denied".to_string()))?;
+        let _ = save_message(&conn, &session_id, "user", &message);
+        let _ = save_message(&conn, &session_id, "assistant", &result);
+        drop(conn);
+
+        return Ok(Json(ChatResponse {
+            message: result,
+            session_id,
+            status: "completed".to_string(),
+            pending_id: None,
+            pending_tools: None,
+        }));
     }
 
     let conn = state.conn.lock().map_err(|e| {
@@ -2317,6 +2315,7 @@ mod tests {
                             has_error_output: false,
                         }],
                         followup: None,
+                        ..Default::default()
                     }),
                     updated_at: None,
                 },
@@ -2370,6 +2369,7 @@ mod tests {
                             has_error_output: false,
                         }],
                         followup: None,
+                        ..Default::default()
                     }),
                     updated_at: None,
                 },
@@ -2422,6 +2422,7 @@ mod tests {
                             has_error_output: false,
                         }],
                         followup: None,
+                        ..Default::default()
                     }),
                     updated_at: None,
                 },

--- a/lib/harper-core/src/tools/codebase_investigator.rs
+++ b/lib/harper-core/src/tools/codebase_investigator.rs
@@ -18,11 +18,134 @@ use crate::core::error::{HarperError, HarperResult};
 use crate::core::io_traits::UserApproval;
 use crate::tools::parsing;
 use colored::*;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
+use syn::visit::Visit;
 use tempfile::tempdir;
+use walkdir::{DirEntry, WalkDir};
+
+#[derive(Debug, Clone)]
+struct WorkspaceGraph {
+    root: String,
+    package_name: Option<String>,
+    members: Vec<WorkspaceMemberOverview>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    workspace_root: String,
+    packages: Vec<CargoPackage>,
+    workspace_members: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoPackage {
+    id: String,
+    name: String,
+    manifest_path: String,
+    targets: Vec<CargoTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoTarget {
+    kind: Vec<String>,
+    src_path: String,
+}
+
+#[derive(Debug, Clone)]
+struct WorkspaceMemberOverview {
+    name: String,
+    role: String,
+    root: String,
+    entrypoints: Vec<String>,
+    notable_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CompilerContext {
+    target_ownership: BTreeMap<String, Vec<String>>,
+    diagnostics: Vec<CompilerDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CargoCheckTarget {
+    name: String,
+    #[serde(default)]
+    kind: Vec<String>,
+    #[serde(default)]
+    src_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CargoCheckMessage {
+    reason: String,
+    #[serde(default)]
+    target: Option<CargoCheckTarget>,
+    #[serde(default)]
+    message: Option<RustcMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RustcMessage {
+    level: String,
+    #[serde(default)]
+    rendered: Option<String>,
+    #[serde(default)]
+    message: String,
+    #[serde(default)]
+    spans: Vec<RustcSpan>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RustcSpan {
+    file_name: String,
+    line_start: usize,
+    #[serde(default)]
+    is_primary: bool,
+}
+
+#[derive(Debug, Clone)]
+struct CompilerDiagnostic {
+    file: String,
+    line: usize,
+    level: String,
+    message: String,
+}
+
+#[derive(Debug, Clone)]
+struct SearchMatch {
+    score: i32,
+    path: String,
+    role: String,
+    reasons: Vec<String>,
+    snippets: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RustSemanticFile {
+    path: String,
+    module_path: String,
+    defines: Vec<String>,
+    imports: Vec<String>,
+    import_map: BTreeMap<String, String>,
+    modules: Vec<String>,
+    calls: Vec<String>,
+    method_owners: BTreeMap<String, Vec<String>>,
+    method_traits: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QueryFocus {
+    UiRendering,
+    StateFlow,
+    Tooling,
+    Runtime,
+    General,
+}
 
 /// Investigate codebase structural graph and relationships
 pub async fn investigate_codebase(
@@ -47,11 +170,585 @@ pub async fn investigate_codebase(
             let repo_url = parsing::extract_tool_args(response, action_prefix, 2)?[1].clone();
             clone_temp_context(&repo_url, approver).await
         }
+        "search_text" => {
+            let query = parsing::extract_tool_args(response, action_prefix, 2)?[1].clone();
+            search_text(&query).await
+        }
         _ => Err(HarperError::Command(format!(
             "Unknown investigation action: {}",
             action
         ))),
     }
+}
+
+pub async fn search_text(query: &str) -> HarperResult<String> {
+    let matches = collect_search_matches(query)?;
+    if matches.is_empty() {
+        return Ok(format!("No source-focused matches found for '{}'.", query));
+    }
+
+    let focus = infer_query_focus(
+        query,
+        &query
+            .split_whitespace()
+            .map(|term| term.trim().to_ascii_lowercase())
+            .filter(|term| !term.is_empty())
+            .collect::<Vec<_>>(),
+    );
+
+    Ok(format!(
+        "CODEBASE_SEARCH\nQUERY: {}\nFOCUS: {}\nTOP_MATCHES:\n{}",
+        query,
+        focus.as_str(),
+        matches
+            .into_iter()
+            .take(8)
+            .map(|entry| format_search_match(&entry))
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    ))
+}
+
+fn collect_search_matches(query: &str) -> HarperResult<Vec<SearchMatch>> {
+    let terms: Vec<String> = query
+        .split_whitespace()
+        .map(|term| term.trim().to_ascii_lowercase())
+        .filter(|term| !term.is_empty())
+        .collect();
+
+    if terms.is_empty() {
+        return Err(HarperError::Command(
+            "Search query cannot be empty.".to_string(),
+        ));
+    }
+
+    let focus = infer_query_focus(query, &terms);
+
+    let mut matches: Vec<SearchMatch> = Vec::new();
+    for entry in WalkDir::new(".")
+        .into_iter()
+        .filter_entry(|entry| !should_skip_entry(entry))
+        .filter_map(Result::ok)
+    {
+        if !entry.file_type().is_file() || !is_searchable_file(entry.path()) {
+            continue;
+        }
+
+        let Ok(content) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let lower = content.to_ascii_lowercase();
+        if !terms.iter().all(|term| lower.contains(term)) {
+            continue;
+        }
+
+        let mut file_matches = Vec::new();
+        for (idx, line) in content.lines().enumerate() {
+            let lower_line = line.to_ascii_lowercase();
+            if terms.iter().any(|term| lower_line.contains(term)) {
+                file_matches.push(format!("{}: {}", idx + 1, line.trim()));
+                if file_matches.len() >= 3 {
+                    break;
+                }
+            }
+        }
+
+        if file_matches.is_empty() {
+            continue;
+        }
+
+        let score = search_match_score(entry.path(), &lower, &file_matches, &terms, focus);
+        matches.push(SearchMatch {
+            score,
+            path: entry.path().display().to_string(),
+            role: classify_file_role(entry.path()),
+            reasons: search_match_reasons(entry.path(), &lower, &terms, focus),
+            snippets: file_matches,
+        });
+    }
+
+    matches.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path)));
+    Ok(matches)
+}
+
+pub async fn authoring_context(query: &str) -> HarperResult<String> {
+    let workspace_graph = load_workspace_graph().ok();
+    let compiler_context = load_compiler_context(workspace_graph.as_ref()).ok();
+    let overview = if let Some(graph) = &workspace_graph {
+        format_workspace_graph(graph)
+    } else {
+        overview_snapshot().await?
+    };
+    let search_query = authoring_search_query(query);
+    let candidates = if search_query.is_empty() {
+        Vec::new()
+    } else {
+        collect_search_matches(&search_query)?
+    };
+    let primary_files = candidates
+        .iter()
+        .take(4)
+        .map(|entry| {
+            format_authoring_primary_file(
+                entry,
+                workspace_graph.as_ref(),
+                compiler_context.as_ref(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let related_files = infer_related_files(
+        &candidates,
+        workspace_graph.as_ref(),
+        compiler_context.as_ref(),
+    );
+    let edit_plan = infer_edit_plan_candidates(
+        &candidates,
+        workspace_graph.as_ref(),
+        compiler_context.as_ref(),
+    );
+    let semantic_graph = build_semantic_graph(&candidates);
+    let compiler_summary = compiler_context
+        .as_ref()
+        .map(|ctx| format_compiler_context(ctx, &candidates))
+        .unwrap_or_else(|| "Compiler context unavailable.".to_string());
+
+    Ok(format!(
+        "AUTHORING_CONTEXT
+REQUEST: {}
+SEARCH_QUERY: {}
+WORKSPACE:
+{}
+
+PRIMARY_FILES:
+{}
+
+RELATED_FILES:
+{}
+
+EDIT_PLAN_CANDIDATES:
+{}
+
+SEMANTIC_GRAPH:
+{}
+
+COMPILER_CONTEXT:
+{}",
+        query,
+        if search_query.is_empty() {
+            "<none>"
+        } else {
+            search_query.as_str()
+        },
+        overview,
+        if primary_files.is_empty() {
+            "No primary files identified.".to_string()
+        } else {
+            primary_files.join(
+                "
+
+",
+            )
+        },
+        if related_files.is_empty() {
+            "No related files identified.".to_string()
+        } else {
+            related_files.join(
+                "
+",
+            )
+        },
+        if edit_plan.is_empty() {
+            "No edit-plan candidates identified.".to_string()
+        } else {
+            edit_plan.join(
+                "
+",
+            )
+        },
+        semantic_graph,
+        compiler_summary
+    ))
+}
+
+pub async fn overview_snapshot() -> HarperResult<String> {
+    if let Ok(graph) = load_workspace_graph() {
+        return Ok(format_workspace_graph(&graph));
+    }
+
+    let cwd = std::env::current_dir()
+        .map_err(|e| HarperError::Command(format!("Failed to inspect workspace: {}", e)))?;
+    Ok(format!("Workspace root: {}", cwd.display()))
+}
+
+fn load_workspace_graph() -> HarperResult<WorkspaceGraph> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .output()
+        .map_err(|e| HarperError::Command(format!("cargo metadata failed: {}", e)))?;
+
+    if !output.status.success() {
+        return Err(HarperError::Command(format!(
+            "cargo metadata failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+
+    let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)?;
+    let root = metadata.workspace_root.clone();
+    let members = metadata
+        .packages
+        .iter()
+        .filter(|package| {
+            metadata
+                .workspace_members
+                .iter()
+                .any(|member| member == &package.id)
+        })
+        .map(summarize_workspace_package)
+        .collect::<Vec<_>>();
+    let package_name = members.first().map(|member| member.name.clone());
+
+    Ok(WorkspaceGraph {
+        root,
+        package_name,
+        members,
+    })
+}
+
+fn summarize_workspace_package(package: &CargoPackage) -> WorkspaceMemberOverview {
+    let manifest_path = Path::new(&package.manifest_path);
+    let root = manifest_path
+        .parent()
+        .unwrap_or_else(|| Path::new(""))
+        .to_path_buf();
+    let root_str = root.display().to_string();
+    let role = classify_member_role(&package.name, &root_str);
+    let mut entrypoints = package
+        .targets
+        .iter()
+        .filter(|target| {
+            target
+                .kind
+                .iter()
+                .any(|kind| matches!(kind.as_str(), "bin" | "lib"))
+        })
+        .map(|target| path_relative_to_root(&root, Path::new(&target.src_path)))
+        .collect::<Vec<_>>();
+    entrypoints.sort();
+    entrypoints.dedup();
+
+    let notable_candidates = [
+        "src/agent/chat.rs",
+        "src/tools/mod.rs",
+        "src/tools/codebase_investigator.rs",
+        "src/runtime/config.rs",
+        "src/interfaces/ui/widgets.rs",
+        "src/interfaces/ui/events.rs",
+        "src/server/mod.rs",
+    ];
+    let notable_files = notable_candidates
+        .iter()
+        .filter_map(|candidate| {
+            let candidate_path = root.join(candidate);
+            if candidate_path.exists() {
+                Some(candidate.to_string())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    WorkspaceMemberOverview {
+        name: package.name.clone(),
+        role,
+        root: root_str,
+        entrypoints,
+        notable_files,
+    }
+}
+
+fn format_workspace_graph(graph: &WorkspaceGraph) -> String {
+    let mut top_level = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&graph.root) {
+        for entry in entries.flatten() {
+            if let Some(name) = entry.file_name().to_str() {
+                if matches!(name, ".git" | "target" | "node_modules" | ".harper") {
+                    continue;
+                }
+                top_level.push(name.to_string());
+            }
+        }
+    }
+    top_level.sort();
+
+    let mut summary = vec![format!("Workspace root: {}", graph.root)];
+    if let Some(package_name) = &graph.package_name {
+        summary.push(format!("Workspace package: {}", package_name));
+    }
+    if !graph.members.is_empty() {
+        summary.push(format!(
+            "Workspace members: {}",
+            graph
+                .members
+                .iter()
+                .map(|member| member.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !top_level.is_empty() {
+        summary.push(format!(
+            "Top-level entries: {}",
+            top_level
+                .into_iter()
+                .take(12)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if !graph.members.is_empty() {
+        summary.push("Workspace map:".to_string());
+        for overview in &graph.members {
+            summary.push(format!(
+                "- crate={} role={} root={} entrypoints=[{}] notable=[{}]",
+                overview.name,
+                overview.role,
+                overview.root,
+                overview.entrypoints.join(", "),
+                overview.notable_files.join(", ")
+            ));
+        }
+    }
+
+    summary.join("\n")
+}
+
+fn load_compiler_context(graph: Option<&WorkspaceGraph>) -> HarperResult<CompilerContext> {
+    let output = Command::new("cargo")
+        .args([
+            "check",
+            "--workspace",
+            "--all-targets",
+            "--message-format=json",
+        ])
+        .output()
+        .map_err(|e| HarperError::Command(format!("cargo check failed: {}", e)))?;
+
+    let mut context = CompilerContext::default();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let Ok(message) = serde_json::from_str::<CargoCheckMessage>(line) else {
+            continue;
+        };
+        if let Some(target) = message.target {
+            if !target.src_path.is_empty() {
+                let path = relativize_workspace_path(graph, &target.src_path);
+                let kinds = if target.kind.is_empty() {
+                    vec!["unknown".to_string()]
+                } else {
+                    target.kind
+                };
+                context
+                    .target_ownership
+                    .entry(path)
+                    .or_default()
+                    .extend(kinds);
+            }
+        }
+        if message.reason != "compiler-message" {
+            continue;
+        }
+        let Some(msg) = message.message else {
+            continue;
+        };
+        for span in msg.spans.iter().filter(|span| span.is_primary) {
+            if should_ignore_compiler_path(&span.file_name) {
+                continue;
+            }
+            context.diagnostics.push(CompilerDiagnostic {
+                file: relativize_workspace_path(graph, &span.file_name),
+                line: span.line_start,
+                level: msg.level.clone(),
+                message: msg.message.clone(),
+            });
+        }
+    }
+    for kinds in context.target_ownership.values_mut() {
+        kinds.sort();
+        kinds.dedup();
+    }
+    Ok(context)
+}
+
+fn relativize_workspace_path(graph: Option<&WorkspaceGraph>, raw: &str) -> String {
+    let path = Path::new(raw);
+    if let Some(graph) = graph {
+        let root = Path::new(&graph.root);
+        if let Ok(rel) = path.strip_prefix(root) {
+            return rel.display().to_string();
+        }
+    }
+    raw.trim_start_matches("./").to_string()
+}
+
+fn should_ignore_compiler_path(path: &str) -> bool {
+    path.contains("/target/") || path.ends_with("build.rs")
+}
+
+fn format_compiler_context(context: &CompilerContext, candidates: &[SearchMatch]) -> String {
+    let candidate_paths = candidates
+        .iter()
+        .map(|entry| entry.path.trim_start_matches("./").to_string())
+        .collect::<BTreeSet<_>>();
+    let mut target_lines = Vec::new();
+    for (path, kinds) in &context.target_ownership {
+        if candidate_paths.iter().any(|candidate| {
+            candidate == path || candidate.ends_with(path) || path.ends_with(candidate)
+        }) {
+            target_lines.push(format!(
+                "- target_owner: {} kinds=[{}]",
+                path,
+                kinds.join(", ")
+            ));
+        }
+    }
+    let mut diag_lines = Vec::new();
+    for diagnostic in &context.diagnostics {
+        if candidate_paths.iter().any(|candidate| {
+            candidate == &diagnostic.file
+                || candidate.ends_with(&diagnostic.file)
+                || diagnostic.file.ends_with(candidate)
+        }) {
+            diag_lines.push(format!(
+                "- diagnostic: {}:{} level={} message={}",
+                diagnostic.file, diagnostic.line, diagnostic.level, diagnostic.message
+            ));
+        }
+        if diag_lines.len() >= 8 {
+            break;
+        }
+    }
+    let ownership = if target_lines.is_empty() {
+        "No candidate target ownership found.".to_string()
+    } else {
+        target_lines.join(
+            "
+",
+        )
+    };
+    let diagnostics = if diag_lines.is_empty() {
+        "No compiler diagnostics for current candidates.".to_string()
+    } else {
+        diag_lines.join(
+            "
+",
+        )
+    };
+    format!(
+        "TARGET_OWNERSHIP:
+{}
+DIAGNOSTICS:
+{}",
+        ownership, diagnostics
+    )
+}
+
+fn classify_member_role(name: &str, root: &str) -> String {
+    if name.contains("core") || root.contains("harper-core") {
+        "runtime/tools/storage/agent".to_string()
+    } else if name.contains("ui") || root.contains("harper-ui") {
+        "tui/widgets/events".to_string()
+    } else if name.contains("mcp") {
+        "mcp_integration".to_string()
+    } else if name.contains("sandbox") || root.contains("harper-sandbox") {
+        "sandbox_execution".to_string()
+    } else if name.contains("firmware") || root.contains("harper-firmware") {
+        "firmware_support".to_string()
+    } else {
+        "workspace_member".to_string()
+    }
+}
+
+fn path_relative_to_root(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn workspace_member_for_path<'a>(
+    path: &Path,
+    graph: Option<&'a WorkspaceGraph>,
+) -> Option<&'a WorkspaceMemberOverview> {
+    let graph = graph?;
+    let path_str = path.display().to_string();
+    graph
+        .members
+        .iter()
+        .find(|member| path_str.starts_with(&member.root))
+}
+
+fn authoring_search_query(query: &str) -> String {
+    let lowered = query.to_ascii_lowercase();
+    let cleaned = lowered.replace(
+        |c: char| !c.is_ascii_alphanumeric() && !c.is_ascii_whitespace(),
+        " ",
+    );
+    let stop_words = [
+        "create",
+        "make",
+        "modify",
+        "update",
+        "change",
+        "edit",
+        "refactor",
+        "implement",
+        "add",
+        "build",
+        "wire",
+        "fix",
+        "the",
+        "a",
+        "an",
+        "this",
+        "that",
+        "these",
+        "those",
+        "repo",
+        "repository",
+        "codebase",
+        "project",
+        "file",
+        "files",
+        "screen",
+        "feature",
+        "subsystem",
+        "behavior",
+        "in",
+        "on",
+        "for",
+        "to",
+        "of",
+        "with",
+        "and",
+        "or",
+        "please",
+        "can",
+        "you",
+        "we",
+        "are",
+        "is",
+        "be",
+        "it",
+        "flow",
+    ];
+
+    cleaned
+        .split_whitespace()
+        .filter(|term| term.len() > 2 && !stop_words.contains(term))
+        .take(6)
+        .map(str::to_string)
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 async fn find_symbol_calls(symbol: &str) -> HarperResult<String> {
@@ -216,5 +913,1313 @@ fn file_contains_symbol(file: &str, symbol: &str) -> HarperResult<bool> {
             Path::new(file).display(),
             String::from_utf8_lossy(&output.stderr).trim()
         ))),
+    }
+}
+
+fn should_skip_entry(entry: &DirEntry) -> bool {
+    entry.file_name().to_str().is_none_or(|name| {
+        matches!(
+            name,
+            ".git" | "target" | "node_modules" | ".harper" | "search" | "site" | "website" | "docs"
+        )
+    })
+}
+
+fn is_searchable_file(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    if path_str.contains("/tests/")
+        || path_str.ends_with("/lib/harper-core/src/agent/intent.rs")
+        || path_str.ends_with("/lib/harper-core/src/agent/prompt.rs")
+        || path_str.ends_with("/lib/harper-core/src/agent/chat.rs")
+        || path_str.starts_with("tests/")
+        || path_str == "lib/harper-core/src/agent/intent.rs"
+        || path_str == "lib/harper-core/src/agent/prompt.rs"
+        || path_str == "lib/harper-core/src/agent/chat.rs"
+    {
+        return false;
+    }
+
+    let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    if file_name.ends_with(".lock")
+        || file_name.ends_with(".db")
+        || file_name.ends_with(".min.js")
+        || file_name.ends_with(".map")
+        || file_name.contains("lock")
+    {
+        return false;
+    }
+
+    let ext = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("");
+    matches!(ext, "rs" | "toml" | "js" | "ts" | "py" | "sh")
+}
+
+fn classify_file_role(path: &Path) -> String {
+    let path_str = path.to_string_lossy();
+    if path_str.contains("lib/harper-ui/src/interfaces/ui/widgets.rs") {
+        return "ui_widget_rendering".to_string();
+    }
+    if path_str.contains("lib/harper-ui/src/interfaces/ui/") {
+        return "ui".to_string();
+    }
+    if path_str.contains("lib/harper-core/src/runtime/") {
+        return "runtime".to_string();
+    }
+    if path_str.contains("lib/harper-core/src/tools/") {
+        return "tooling".to_string();
+    }
+    if path_str.contains("lib/harper-core/src/agent/") {
+        return "agent".to_string();
+    }
+    if path_str.contains("lib/harper-sandbox/") {
+        return "sandbox".to_string();
+    }
+    "source".to_string()
+}
+
+fn search_match_reasons(
+    path: &Path,
+    content_lower: &str,
+    terms: &[String],
+    focus: QueryFocus,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    let role = classify_file_role(path);
+    reasons.push(format!("role={}", role));
+    if terms.iter().all(|term| content_lower.contains(term)) {
+        reasons.push("contains_all_terms".to_string());
+    }
+    let path_str = path.to_string_lossy();
+    if path_str.contains("widgets.rs") {
+        reasons.push("widget_render_path".to_string());
+    }
+    if content_lower.contains("planfollowup") || content_lower.contains("retry_count") {
+        reasons.push("followup_state_reference".to_string());
+    }
+    match focus {
+        QueryFocus::UiRendering if role == "ui_widget_rendering" || role == "ui" => {
+            reasons.push("matches_ui_render_focus".to_string())
+        }
+        QueryFocus::StateFlow if content_lower.contains("planfollowup") => {
+            reasons.push("matches_state_flow_focus".to_string())
+        }
+        QueryFocus::Tooling if role == "tooling" => {
+            reasons.push("matches_tooling_focus".to_string())
+        }
+        QueryFocus::Runtime if role == "runtime" => {
+            reasons.push("matches_runtime_focus".to_string())
+        }
+        _ => {}
+    }
+    reasons
+}
+
+fn format_search_match(entry: &SearchMatch) -> String {
+    format!(
+        "FILE: {}\nROLE: {}\nREASONS: {}\nSNIPPETS:\n{}",
+        entry.path,
+        entry.role,
+        entry.reasons.join(", "),
+        entry
+            .snippets
+            .iter()
+            .map(|snippet| format!("- {}", snippet))
+            .collect::<Vec<_>>()
+            .join("\n")
+    )
+}
+
+fn format_authoring_primary_file(
+    entry: &SearchMatch,
+    graph: Option<&WorkspaceGraph>,
+    compiler: Option<&CompilerContext>,
+) -> String {
+    let path = Path::new(&entry.path);
+    let symbols = extract_file_symbols(path);
+    let crate_name = workspace_member_for_path(path, graph)
+        .map(|member| member.name.as_str())
+        .unwrap_or("<unknown>");
+    let compiler_notes = compiler
+        .map(|ctx| {
+            let target = ctx
+                .target_ownership
+                .iter()
+                .find(|(path, _)| {
+                    entry.path.trim_start_matches("./") == path.as_str()
+                        || entry.path.ends_with(path.as_str())
+                        || path.ends_with(entry.path.trim_start_matches("./"))
+                })
+                .map(|(_, kinds)| kinds.join(", "))
+                .unwrap_or_else(|| "<none>".to_string());
+            let diagnostics = ctx
+                .diagnostics
+                .iter()
+                .filter(|diag| {
+                    entry.path.trim_start_matches("./") == diag.file
+                        || entry.path.ends_with(&diag.file)
+                        || diag.file.ends_with(entry.path.trim_start_matches("./"))
+                })
+                .take(2)
+                .map(|diag| format!("{}:{} {}", diag.file, diag.line, diag.message))
+                .collect::<Vec<_>>();
+            format!(
+                "TARGET_KINDS: {}
+DIAGNOSTICS: {}",
+                target,
+                if diagnostics.is_empty() {
+                    "<none>".to_string()
+                } else {
+                    diagnostics.join(" | ")
+                }
+            )
+        })
+        .unwrap_or_else(|| {
+            "TARGET_KINDS: <none>
+DIAGNOSTICS: <none>"
+                .to_string()
+        });
+    format!(
+        "FILE: {}
+ROLE: {}
+CRATE: {}
+WHY: {}
+SYMBOLS: {}
+{}
+SNIPPETS:
+{}",
+        entry.path,
+        entry.role,
+        crate_name,
+        entry.reasons.join(", "),
+        if symbols.is_empty() {
+            "<none>".to_string()
+        } else {
+            symbols.join(", ")
+        },
+        compiler_notes,
+        entry
+            .snippets
+            .iter()
+            .map(|snippet| format!("- {}", snippet))
+            .collect::<Vec<_>>()
+            .join(
+                "
+"
+            )
+    )
+}
+fn extract_file_symbols(path: &Path) -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let mut symbols = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let candidate = if let Some(rest) = trimmed
+            .strip_prefix("pub fn ")
+            .or_else(|| trimmed.strip_prefix("fn "))
+        {
+            rest.split('(').next().map(str::trim)
+        } else if let Some(rest) = trimmed
+            .strip_prefix("pub struct ")
+            .or_else(|| trimmed.strip_prefix("struct "))
+            .or_else(|| trimmed.strip_prefix("pub enum "))
+            .or_else(|| trimmed.strip_prefix("enum "))
+            .or_else(|| trimmed.strip_prefix("pub trait "))
+            .or_else(|| trimmed.strip_prefix("trait "))
+            .or_else(|| trimmed.strip_prefix("impl "))
+        {
+            rest.split_whitespace().next().map(str::trim)
+        } else if let Some(rest) = trimmed
+            .strip_prefix("class ")
+            .or_else(|| trimmed.strip_prefix("def "))
+        {
+            rest.split(['(', ':']).next().map(str::trim)
+        } else {
+            None
+        };
+        if let Some(symbol) = candidate.filter(|value| !value.is_empty()) {
+            symbols.push(symbol.to_string());
+        }
+        if symbols.len() >= 6 {
+            break;
+        }
+    }
+    symbols
+}
+
+fn infer_related_files(
+    matches: &[SearchMatch],
+    graph: Option<&WorkspaceGraph>,
+    compiler: Option<&CompilerContext>,
+) -> Vec<String> {
+    let mut related = Vec::new();
+    let mut seen = BTreeSet::new();
+    for entry in matches.iter().take(6) {
+        let path = Path::new(&entry.path);
+        if let Some(member) = workspace_member_for_path(path, graph) {
+            let crate_line = format!(
+                "- crate: {} role={} root={}",
+                member.name, member.role, member.root
+            );
+            if seen.insert(crate_line.clone()) {
+                related.push(crate_line);
+            }
+        }
+        if let Some(parent) = path.parent() {
+            let parent_line = format!("- dir: {}", parent.display());
+            if seen.insert(parent_line.clone()) {
+                related.push(parent_line);
+            }
+        }
+        if let Some(ctx) = compiler {
+            let rel_path = entry.path.trim_start_matches("./");
+            if let Some(kinds) = ctx
+                .target_ownership
+                .iter()
+                .find(|(owned, _)| {
+                    rel_path == owned.as_str()
+                        || rel_path.ends_with(owned.as_str())
+                        || owned.ends_with(rel_path)
+                })
+                .map(|(_, kinds)| kinds)
+            {
+                let target_line = format!("- target: {} kinds=[{}]", rel_path, kinds.join(", "));
+                if seen.insert(target_line.clone()) {
+                    related.push(target_line);
+                }
+            }
+        }
+        if related.len() >= 8 {
+            break;
+        }
+    }
+    related
+}
+
+fn infer_edit_plan_candidates(
+    matches: &[SearchMatch],
+    graph: Option<&WorkspaceGraph>,
+    compiler: Option<&CompilerContext>,
+) -> Vec<String> {
+    matches
+        .iter()
+        .take(5)
+        .map(|entry| {
+            let crate_name = workspace_member_for_path(Path::new(&entry.path), graph)
+                .map(|member| member.name.as_str())
+                .unwrap_or("<unknown>");
+            let role = match entry.role.as_str() {
+                "ui_widget_rendering" | "ui" => "primary_edit_or_render_validation",
+                "runtime" => "runtime_state_or_config_support",
+                "tooling" => "tool_or_execution_support",
+                "agent" => "agent_or_prompt_support",
+                _ => "supporting_file",
+            };
+            let validation_hint = compiler
+                .and_then(|ctx| {
+                    ctx.target_ownership
+                        .iter()
+                        .find(|(owned, _)| {
+                            entry.path.trim_start_matches("./") == owned.as_str()
+                                || entry.path.ends_with(owned.as_str())
+                                || owned.ends_with(entry.path.trim_start_matches("./"))
+                        })
+                        .map(|(_, kinds)| format!("validate_with={}", kinds.join("/")))
+                })
+                .unwrap_or_else(|| "validate_with=source-check".to_string());
+            format!(
+                "- {} [crate={}] => {} ({}, {})",
+                entry.path,
+                crate_name,
+                role,
+                entry.reasons.join(", "),
+                validation_hint
+            )
+        })
+        .collect()
+}
+
+fn build_semantic_graph(matches: &[SearchMatch]) -> String {
+    let rust_files = matches
+        .iter()
+        .take(6)
+        .filter(|entry| entry.path.ends_with(".rs"))
+        .filter_map(|entry| extract_rust_semantic_file(Path::new(&entry.path)))
+        .collect::<Vec<_>>();
+
+    if rust_files.is_empty() {
+        return "No Rust semantic graph available for the current candidate set.".to_string();
+    }
+
+    let workspace_index = collect_workspace_rust_semantics();
+    let definition_to_file = build_workspace_definition_index(&workspace_index);
+    let module_to_file = build_workspace_module_index(&workspace_index);
+
+    let file_blocks = rust_files
+        .iter()
+        .map(|file| {
+            format!(
+                "FILE: {}\nMODULE: {}\nDEFINES: {}\nIMPORTS: {}\nCALLS: {}",
+                file.path,
+                file.module_path,
+                join_or_none(&file.defines),
+                join_or_none(&file.imports),
+                join_or_none(&file.calls),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let mut relationships = Vec::new();
+    for file in &rust_files {
+        let mut linked = BTreeSet::new();
+        for module_name in &file.modules {
+            let full_module = if file.module_path.is_empty() {
+                module_name.clone()
+            } else {
+                format!("{}::{}", file.module_path, module_name)
+            };
+            if let Some(target_files) = module_to_file.get(&full_module) {
+                for target_file in target_files {
+                    if target_file == &file.path {
+                        continue;
+                    }
+                    linked.insert(format!(
+                        "- {} -> {} via module {}",
+                        file.path, target_file, full_module
+                    ));
+                }
+            }
+        }
+        for symbol in file.calls.iter().chain(file.imports.iter()) {
+            for resolved_symbol in resolve_symbol_candidates(file, symbol) {
+                if let Some(target_files) = definition_to_file.get(&resolved_symbol) {
+                    for target_file in target_files {
+                        if target_file == &file.path {
+                            continue;
+                        }
+                        linked.insert(format!(
+                            "- {} -> {} via {}",
+                            file.path, target_file, resolved_symbol
+                        ));
+                    }
+                }
+                if let Some(target_files) = module_to_file.get(&resolved_symbol) {
+                    for target_file in target_files {
+                        if target_file == &file.path {
+                            continue;
+                        }
+                        linked.insert(format!(
+                            "- {} -> {} via module {}",
+                            file.path, target_file, resolved_symbol
+                        ));
+                    }
+                }
+            }
+        }
+        relationships.extend(linked);
+    }
+
+    format!(
+        "{}\n\nRELATIONSHIPS:\n{}",
+        file_blocks,
+        if relationships.is_empty() {
+            "No cross-file symbol relationships inferred.".to_string()
+        } else {
+            relationships.join("\n")
+        }
+    )
+}
+
+fn extract_rust_semantic_file(path: &Path) -> Option<RustSemanticFile> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let parsed = syn::parse_file(&content).ok()?;
+    let mut visitor = RustSemanticVisitor::default();
+    visitor.visit_file(&parsed);
+    Some(RustSemanticFile {
+        path: path.display().to_string(),
+        module_path: rust_module_path(path),
+        defines: visitor.defines.into_iter().collect(),
+        imports: visitor.imports.into_iter().collect(),
+        import_map: visitor.import_map,
+        modules: visitor.modules.into_iter().collect(),
+        calls: visitor.calls.into_iter().collect(),
+        method_owners: visitor
+            .method_owners
+            .into_iter()
+            .map(|(method, owners)| (method, owners.into_iter().collect()))
+            .collect(),
+        method_traits: visitor
+            .method_traits
+            .into_iter()
+            .map(|(method, traits)| (method, traits.into_iter().collect()))
+            .collect(),
+    })
+}
+
+fn collect_workspace_rust_semantics() -> Vec<RustSemanticFile> {
+    WalkDir::new(".")
+        .into_iter()
+        .filter_entry(|entry| !should_skip_entry(entry))
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_file())
+        .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("rs"))
+        .filter(|entry| is_searchable_file(entry.path()))
+        .filter_map(|entry| extract_rust_semantic_file(entry.path()))
+        .collect()
+}
+
+fn build_workspace_definition_index(files: &[RustSemanticFile]) -> HashMap<String, Vec<String>> {
+    let mut index = HashMap::new();
+    for file in files {
+        for symbol in &file.defines {
+            push_unique_index_entry(&mut index, symbol.clone(), file.path.clone());
+            push_unique_index_entry(
+                &mut index,
+                format!("{}::{}", file.module_path, symbol),
+                file.path.clone(),
+            );
+        }
+        for (method, owners) in &file.method_owners {
+            for owner in owners {
+                push_unique_index_entry(
+                    &mut index,
+                    format!("{}::{}", owner, method),
+                    file.path.clone(),
+                );
+                push_unique_index_entry(
+                    &mut index,
+                    format!("{}::{}::{}", file.module_path, owner, method),
+                    file.path.clone(),
+                );
+            }
+        }
+        for (method, traits) in &file.method_traits {
+            for trait_name in traits {
+                push_unique_index_entry(
+                    &mut index,
+                    format!("{}::{}", trait_name, method),
+                    file.path.clone(),
+                );
+            }
+            if let Some(owners) = file.method_owners.get(method) {
+                for owner in owners {
+                    for trait_name in traits {
+                        push_unique_index_entry(
+                            &mut index,
+                            format!("{}::{}::{}", owner, trait_name, method),
+                            file.path.clone(),
+                        );
+                        push_unique_index_entry(
+                            &mut index,
+                            format!(
+                                "{}::{}::{}::{}",
+                                file.module_path, owner, trait_name, method
+                            ),
+                            file.path.clone(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+    index
+}
+
+fn push_unique_index_entry(index: &mut HashMap<String, Vec<String>>, key: String, value: String) {
+    let entry = index.entry(key).or_default();
+    if !entry.iter().any(|existing| existing == &value) {
+        entry.push(value);
+    }
+}
+
+fn build_workspace_module_index(files: &[RustSemanticFile]) -> HashMap<String, Vec<String>> {
+    let mut index = HashMap::new();
+    for file in files {
+        index
+            .entry(file.module_path.clone())
+            .or_insert_with(Vec::new)
+            .push(file.path.clone());
+    }
+    index
+}
+
+fn resolve_symbol_candidates(file: &RustSemanticFile, symbol: &str) -> Vec<String> {
+    let mut candidates = BTreeSet::new();
+    candidates.insert(symbol.to_string());
+    if let Some(mapped) = file.import_map.get(symbol) {
+        candidates.insert(mapped.clone());
+        if let Some(last) = mapped.split("::").last() {
+            candidates.insert(last.to_string());
+        }
+    }
+    if let Some((head, tail)) = symbol.split_once("::") {
+        if let Some(mapped) = file.import_map.get(head) {
+            candidates.insert(format!("{}::{}", mapped, tail));
+        }
+    } else if let Some(owners) = file.method_owners.get(symbol) {
+        for owner in owners {
+            candidates.insert(format!("{}::{}", owner, symbol));
+            if let Some(mapped) = file.import_map.get(owner) {
+                candidates.insert(format!("{}::{}", mapped, symbol));
+            }
+        }
+        if let Some(traits) = file.method_traits.get(symbol) {
+            for owner in owners {
+                for trait_name in traits {
+                    candidates.insert(format!("{}::{}::{}", owner, trait_name, symbol));
+                }
+            }
+        }
+    }
+    if let Some(traits) = file.method_traits.get(symbol) {
+        for trait_name in traits {
+            candidates.insert(format!("{}::{}", trait_name, symbol));
+            if let Some(mapped) = file.import_map.get(trait_name) {
+                candidates.insert(format!("{}::{}", mapped, symbol));
+            }
+        }
+    }
+    for imported in file.import_map.values() {
+        if let Some(last) = imported.split("::").last() {
+            candidates.insert(format!("{}::{}", last, symbol));
+            candidates.insert(format!("{}::{}", imported, symbol));
+        }
+    }
+    candidates.into_iter().collect()
+}
+
+fn rust_module_path(path: &Path) -> String {
+    let mut components = path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+
+    if let Some(src_idx) = components.iter().position(|part| *part == "src") {
+        components.drain(..=src_idx);
+    }
+
+    if let Some(last) = components.last_mut() {
+        if *last == "mod.rs" {
+            components.pop();
+        } else if last.ends_with(".rs") {
+            *last = last.trim_end_matches(".rs");
+        }
+    }
+
+    components
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
+#[derive(Default)]
+struct RustSemanticVisitor {
+    defines: BTreeSet<String>,
+    imports: BTreeSet<String>,
+    import_map: BTreeMap<String, String>,
+    modules: BTreeSet<String>,
+    calls: BTreeSet<String>,
+    method_owners: BTreeMap<String, BTreeSet<String>>,
+    method_traits: BTreeMap<String, BTreeSet<String>>,
+    current_impl_owner: Option<String>,
+    current_impl_trait: Option<String>,
+    variable_types: BTreeMap<String, String>,
+}
+
+impl<'ast> Visit<'ast> for RustSemanticVisitor {
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        self.defines.insert(node.sig.ident.to_string());
+        for input in &node.sig.inputs {
+            if let syn::FnArg::Typed(arg) = input {
+                if let syn::Pat::Ident(pat_ident) = &*arg.pat {
+                    if let Some(type_name) = rust_type_name(&arg.ty) {
+                        self.variable_types
+                            .insert(pat_ident.ident.to_string(), type_name);
+                    }
+                }
+            }
+        }
+        syn::visit::visit_item_fn(self, node);
+    }
+
+    fn visit_item_struct(&mut self, node: &'ast syn::ItemStruct) {
+        self.defines.insert(node.ident.to_string());
+        syn::visit::visit_item_struct(self, node);
+    }
+
+    fn visit_item_enum(&mut self, node: &'ast syn::ItemEnum) {
+        self.defines.insert(node.ident.to_string());
+        syn::visit::visit_item_enum(self, node);
+    }
+
+    fn visit_item_trait(&mut self, node: &'ast syn::ItemTrait) {
+        self.defines.insert(node.ident.to_string());
+        syn::visit::visit_item_trait(self, node);
+    }
+
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        if node.content.is_none() {
+            self.modules.insert(node.ident.to_string());
+        }
+        syn::visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
+        let previous_trait = self.current_impl_trait.take();
+        if let Some((_, path, _)) = &node.trait_ {
+            if let Some(segment) = path.segments.last() {
+                self.imports.insert(segment.ident.to_string());
+                self.current_impl_trait = Some(segment.ident.to_string());
+            }
+        }
+        let previous_owner = self.current_impl_owner.take();
+        self.current_impl_owner = rust_type_name(&node.self_ty);
+        syn::visit::visit_item_impl(self, node);
+        self.current_impl_owner = previous_owner;
+        self.current_impl_trait = previous_trait;
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        self.defines.insert(node.sig.ident.to_string());
+        if let Some(owner) = &self.current_impl_owner {
+            self.method_owners
+                .entry(node.sig.ident.to_string())
+                .or_default()
+                .insert(owner.clone());
+            self.defines
+                .insert(format!("{}::{}", owner, node.sig.ident));
+            if let Some(trait_name) = &self.current_impl_trait {
+                self.method_traits
+                    .entry(node.sig.ident.to_string())
+                    .or_default()
+                    .insert(trait_name.clone());
+                self.defines
+                    .insert(format!("{}::{}::{}", owner, trait_name, node.sig.ident));
+                self.defines
+                    .insert(format!("{}::{}", trait_name, node.sig.ident));
+            }
+        }
+        for input in &node.sig.inputs {
+            if let syn::FnArg::Typed(arg) = input {
+                if let syn::Pat::Ident(pat_ident) = &*arg.pat {
+                    if let Some(type_name) = rust_type_name(&arg.ty) {
+                        self.variable_types
+                            .insert(pat_ident.ident.to_string(), type_name);
+                    }
+                }
+            }
+        }
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        if let syn::Pat::Type(pat_type) = &node.pat {
+            if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                if let Some(type_name) = rust_type_name(&pat_type.ty) {
+                    self.variable_types
+                        .insert(pat_ident.ident.to_string(), type_name);
+                }
+            }
+        } else if let syn::Pat::Ident(pat_ident) = &node.pat {
+            if let Some(init) = &node.init {
+                if let Some(type_name) =
+                    rust_expr_inferred_type_name(&init.expr, &self.variable_types)
+                {
+                    self.variable_types
+                        .insert(pat_ident.ident.to_string(), type_name);
+                }
+            }
+        }
+        syn::visit::visit_local(self, node);
+    }
+
+    fn visit_item_use(&mut self, node: &'ast syn::ItemUse) {
+        collect_use_tree(
+            &node.tree,
+            &mut Vec::new(),
+            &mut self.imports,
+            &mut self.import_map,
+        );
+        syn::visit::visit_item_use(self, node);
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(expr_path) = &*node.func {
+            let segments = expr_path
+                .path
+                .segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>();
+            if let Some(segment) = segments.last() {
+                self.calls.insert(segment.to_string());
+            }
+            if segments.len() > 1 {
+                self.calls.insert(segments.join("::"));
+            }
+        }
+        syn::visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        self.calls.insert(node.method.to_string());
+        if let Some(owner) = rust_expr_owner_name(&node.receiver, &self.variable_types) {
+            self.calls.insert(format!("{}::{}", owner, node.method));
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn rust_type_name(ty: &syn::Type) -> Option<String> {
+    match ty {
+        syn::Type::Path(type_path) => type_path
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string()),
+        syn::Type::Reference(reference) => rust_type_name(&reference.elem),
+        syn::Type::Group(group) => rust_type_name(&group.elem),
+        syn::Type::Paren(paren) => rust_type_name(&paren.elem),
+        _ => None,
+    }
+}
+
+fn rust_expr_owner_name(
+    expr: &syn::Expr,
+    variable_types: &BTreeMap<String, String>,
+) -> Option<String> {
+    match expr {
+        syn::Expr::Path(expr_path) => {
+            if expr_path.path.segments.len() == 1 {
+                if let Some(segment) = expr_path.path.segments.last() {
+                    if let Some(type_name) = variable_types.get(&segment.ident.to_string()) {
+                        return Some(type_name.clone());
+                    }
+                }
+            }
+            expr_path
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string())
+        }
+        syn::Expr::Reference(reference) => rust_expr_owner_name(&reference.expr, variable_types),
+        syn::Expr::Paren(paren) => rust_expr_owner_name(&paren.expr, variable_types),
+        syn::Expr::Call(call) => rust_expr_owner_name(&call.func, variable_types),
+        syn::Expr::MethodCall(method_call) => Some(method_call.method.to_string()),
+        _ => None,
+    }
+}
+
+fn rust_expr_inferred_type_name(
+    expr: &syn::Expr,
+    variable_types: &BTreeMap<String, String>,
+) -> Option<String> {
+    match expr {
+        syn::Expr::Struct(expr_struct) => expr_struct
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string()),
+        syn::Expr::Call(call) => match &*call.func {
+            syn::Expr::Path(expr_path) => expr_path
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.to_string()),
+            other => rust_expr_owner_name(other, variable_types),
+        },
+        syn::Expr::Path(_) => rust_expr_owner_name(expr, variable_types),
+        syn::Expr::Reference(reference) => {
+            rust_expr_inferred_type_name(&reference.expr, variable_types)
+        }
+        syn::Expr::Paren(paren) => rust_expr_inferred_type_name(&paren.expr, variable_types),
+        _ => None,
+    }
+}
+
+fn collect_use_tree(
+    tree: &syn::UseTree,
+    prefix: &mut Vec<String>,
+    imports: &mut BTreeSet<String>,
+    import_map: &mut BTreeMap<String, String>,
+) {
+    match tree {
+        syn::UseTree::Path(path) => {
+            prefix.push(path.ident.to_string());
+            collect_use_tree(&path.tree, prefix, imports, import_map);
+            prefix.pop();
+        }
+        syn::UseTree::Name(name) => {
+            let alias = name.ident.to_string();
+            imports.insert(alias.clone());
+            let mut full = prefix.clone();
+            full.push(alias.clone());
+            import_map.insert(alias, full.join("::"));
+        }
+        syn::UseTree::Rename(rename) => {
+            let alias = rename.rename.to_string();
+            imports.insert(alias.clone());
+            let mut full = prefix.clone();
+            full.push(rename.ident.to_string());
+            import_map.insert(alias, full.join("::"));
+        }
+        syn::UseTree::Group(group) => {
+            for item in &group.items {
+                collect_use_tree(item, prefix, imports, import_map);
+            }
+        }
+        syn::UseTree::Glob(_) => {}
+    }
+}
+
+fn join_or_none(values: &[String]) -> String {
+    if values.is_empty() {
+        "<none>".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+fn search_match_score(
+    path: &Path,
+    content_lower: &str,
+    snippets: &[String],
+    terms: &[String],
+    focus: QueryFocus,
+) -> i32 {
+    let path_str = path.to_string_lossy();
+    let mut score = 0;
+
+    if path_str.starts_with("./lib/harper-ui/src") || path_str.starts_with("lib/harper-ui/src") {
+        score += 60;
+    } else if path_str.starts_with("./lib/harper-core/src")
+        || path_str.starts_with("lib/harper-core/src")
+    {
+        score += 40;
+    }
+
+    if path_str.contains("widgets.rs") {
+        score += 40;
+    }
+    if path_str.contains("events.rs") || path_str.contains("tui.rs") || path_str.contains("app.rs")
+    {
+        score += 20;
+    }
+    if path_str.contains("/tests/")
+        || path_str.contains("agent/intent.rs")
+        || path_str.contains("agent/prompt.rs")
+        || path_str.contains("agent/chat.rs")
+    {
+        score -= 40;
+    }
+
+    if terms.iter().all(|term| {
+        snippets
+            .iter()
+            .any(|snippet| snippet.to_ascii_lowercase().contains(term))
+    }) {
+        score += 20;
+    }
+
+    if content_lower.contains("planfollowup") || content_lower.contains("followup") {
+        score += 10;
+    }
+
+    match focus {
+        QueryFocus::UiRendering => {
+            if path_str.contains("widgets.rs") {
+                score += 50;
+            }
+            if path_str.contains("interfaces/ui/") {
+                score += 30;
+            }
+        }
+        QueryFocus::StateFlow => {
+            if content_lower.contains("planfollowup") || content_lower.contains("retry_count") {
+                score += 30;
+            }
+        }
+        QueryFocus::Tooling => {
+            if path_str.contains("/tools/") {
+                score += 25;
+            }
+        }
+        QueryFocus::Runtime => {
+            if path_str.contains("/runtime/") {
+                score += 25;
+            }
+        }
+        QueryFocus::General => {}
+    }
+
+    score
+}
+
+impl QueryFocus {
+    fn as_str(self) -> &'static str {
+        match self {
+            QueryFocus::UiRendering => "ui_rendering",
+            QueryFocus::StateFlow => "state_flow",
+            QueryFocus::Tooling => "tooling",
+            QueryFocus::Runtime => "runtime",
+            QueryFocus::General => "general",
+        }
+    }
+}
+
+fn infer_query_focus(query: &str, terms: &[String]) -> QueryFocus {
+    let lower = query.to_ascii_lowercase();
+    if lower.contains("render") || lower.contains("ui") || lower.contains("widget") {
+        return QueryFocus::UiRendering;
+    }
+    if lower.contains("retry")
+        || lower.contains("followup")
+        || lower.contains("state")
+        || terms
+            .iter()
+            .any(|term| matches!(term.as_str(), "retry" | "metadata" | "followup"))
+    {
+        return QueryFocus::StateFlow;
+    }
+    if lower.contains("tool") || lower.contains("command") {
+        return QueryFocus::Tooling;
+    }
+    if lower.contains("runtime") || lower.contains("config") || lower.contains("policy") {
+        return QueryFocus::Runtime;
+    }
+    QueryFocus::General
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::{
+        authoring_search_query, build_workspace_definition_index, classify_member_role,
+        extract_rust_semantic_file, format_workspace_graph, infer_query_focus, is_searchable_file,
+        path_relative_to_root, resolve_symbol_candidates, rust_module_path,
+        workspace_member_for_path, QueryFocus, RustSemanticFile, WorkspaceGraph,
+        WorkspaceMemberOverview,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn excludes_self_referential_agent_files_from_search() {
+        assert!(!is_searchable_file(Path::new(
+            "lib/harper-core/src/agent/intent.rs"
+        )));
+        assert!(!is_searchable_file(Path::new(
+            "lib/harper-core/src/agent/prompt.rs"
+        )));
+        assert!(!is_searchable_file(Path::new(
+            "lib/harper-core/src/agent/chat.rs"
+        )));
+        assert!(!is_searchable_file(Path::new("tests/integration.rs")));
+        assert!(is_searchable_file(Path::new(
+            "lib/harper-ui/src/interfaces/ui/widgets.rs"
+        )));
+    }
+
+    #[test]
+    fn infers_ui_render_focus_for_render_queries() {
+        assert_eq!(
+            infer_query_focus(
+                "Find where retry metadata is rendered in this repo.",
+                &["retry".to_string(), "metadata".to_string()]
+            ),
+            QueryFocus::UiRendering
+        );
+    }
+
+    #[test]
+    fn authoring_search_query_strips_authoring_boilerplate() {
+        assert_eq!(
+            authoring_search_query("refactor the planner flow in this repo"),
+            "planner"
+        );
+        assert_eq!(
+            authoring_search_query("change the retry rendering behavior in the tui"),
+            "retry rendering tui"
+        );
+    }
+
+    #[test]
+    fn extracts_rust_semantic_file_symbols_and_calls() {
+        let src = r#"
+use std::path::{Path, PathBuf};
+
+pub fn search_text() {}
+
+pub fn authoring_context() {
+    search_text();
+    let _ = PathBuf::new();
+}
+"#;
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), src).unwrap();
+        let semantic = extract_rust_semantic_file(temp.path()).expect("semantic file");
+        assert!(semantic
+            .defines
+            .iter()
+            .any(|symbol| symbol == "search_text"));
+        assert!(semantic
+            .defines
+            .iter()
+            .any(|symbol| symbol == "authoring_context"));
+        assert!(semantic
+            .imports
+            .iter()
+            .any(|symbol| symbol == "Path" || symbol == "PathBuf"));
+    }
+
+    #[test]
+    fn infers_rust_module_path_from_source_file() {
+        assert_eq!(
+            rust_module_path(Path::new(
+                "lib/harper-core/src/tools/codebase_investigator.rs"
+            )),
+            "tools::codebase_investigator"
+        );
+        assert_eq!(
+            rust_module_path(Path::new("lib/harper-ui/src/interfaces/ui/mod.rs")),
+            "interfaces::ui"
+        );
+    }
+
+    #[test]
+    fn builds_workspace_definition_index_for_qualified_and_unqualified_symbols() {
+        let files = vec![RustSemanticFile {
+            path: "src/tools/example.rs".to_string(),
+            module_path: "tools::example".to_string(),
+            defines: vec!["search_text".to_string()],
+            imports: Vec::new(),
+            import_map: BTreeMap::new(),
+            modules: Vec::new(),
+            calls: Vec::new(),
+            method_owners: BTreeMap::new(),
+            method_traits: BTreeMap::new(),
+        }];
+        let index = build_workspace_definition_index(&files);
+        assert_eq!(
+            index.get("search_text"),
+            Some(&vec!["src/tools/example.rs".to_string()])
+        );
+        assert_eq!(
+            index.get("tools::example::search_text"),
+            Some(&vec!["src/tools/example.rs".to_string()])
+        );
+    }
+
+    #[test]
+    fn extracts_use_aliases_and_module_declarations() {
+        let src = r#"
+mod helper;
+use crate::tools::codebase_investigator::search_text as searcher;
+use crate::agent::{chat::ChatService, intent::route_intent};
+
+fn run() {
+    searcher("retry metadata");
+    route_intent("check repo");
+}
+"#;
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), src).unwrap();
+        let semantic = extract_rust_semantic_file(temp.path()).unwrap();
+        assert!(semantic.modules.iter().any(|m| m == "helper"));
+        assert!(semantic.imports.iter().any(|m| m == "searcher"));
+        assert_eq!(
+            semantic.import_map.get("searcher").map(String::as_str),
+            Some("crate::tools::codebase_investigator::search_text")
+        );
+        assert!(semantic.calls.iter().any(|c| c == "searcher"));
+    }
+
+    #[test]
+    fn resolves_alias_candidates_to_full_paths() {
+        let mut import_map = BTreeMap::new();
+        import_map.insert(
+            "searcher".to_string(),
+            "crate::tools::codebase_investigator::search_text".to_string(),
+        );
+        let file = RustSemanticFile {
+            path: "lib/harper-core/src/tools/example.rs".to_string(),
+            module_path: "tools::example".to_string(),
+            defines: vec!["run".to_string()],
+            imports: vec!["searcher".to_string()],
+            import_map,
+            modules: Vec::new(),
+            calls: vec!["searcher".to_string()],
+            method_owners: BTreeMap::new(),
+            method_traits: BTreeMap::new(),
+        };
+        let candidates = resolve_symbol_candidates(&file, "searcher");
+        assert!(candidates.iter().any(|c| c == "searcher"));
+        assert!(candidates
+            .iter()
+            .any(|c| c == "crate::tools::codebase_investigator::search_text"));
+        assert!(candidates.iter().any(|c| c == "search_text"));
+    }
+
+    #[test]
+    fn extracts_impl_method_owners_and_receiver_calls() {
+        let src = r#"
+struct Planner;
+
+impl Planner {
+    fn replan(&self) {}
+}
+
+fn run(planner: Planner) {
+    planner.replan();
+}
+"#;
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), src).unwrap();
+        let semantic = extract_rust_semantic_file(temp.path()).unwrap();
+        assert!(semantic.defines.iter().any(|d| d == "Planner::replan"));
+        assert_eq!(
+            semantic
+                .method_owners
+                .get("replan")
+                .map(|owners| owners.as_slice()),
+            Some(&["Planner".to_string()][..])
+        );
+        assert!(semantic.calls.iter().any(|c| c == "Planner::replan"));
+    }
+
+    #[test]
+    fn indexes_qualified_method_definitions() {
+        let mut method_owners = BTreeMap::new();
+        method_owners.insert("replan".to_string(), vec!["Planner".to_string()]);
+        let mut method_traits = BTreeMap::new();
+        method_traits.insert("replan".to_string(), vec!["Refactorable".to_string()]);
+        let files = vec![RustSemanticFile {
+            path: "src/tools/example.rs".to_string(),
+            module_path: "tools::example".to_string(),
+            defines: vec![
+                "Planner".to_string(),
+                "Planner::replan".to_string(),
+                "Planner::Refactorable::replan".to_string(),
+            ],
+            imports: Vec::new(),
+            import_map: BTreeMap::new(),
+            modules: Vec::new(),
+            calls: Vec::new(),
+            method_owners,
+            method_traits,
+        }];
+        let index = build_workspace_definition_index(&files);
+        assert_eq!(
+            index.get("Planner::replan"),
+            Some(&vec!["src/tools/example.rs".to_string()])
+        );
+        assert_eq!(
+            index.get("tools::example::Planner::replan"),
+            Some(&vec!["src/tools/example.rs".to_string()])
+        );
+        assert_eq!(
+            index.get("Refactorable::replan"),
+            Some(&vec!["src/tools/example.rs".to_string()])
+        );
+        assert_eq!(
+            index.get("Planner::Refactorable::replan"),
+            Some(&vec!["src/tools/example.rs".to_string()])
+        );
+    }
+
+    #[test]
+    fn extracts_trait_impl_methods_and_initializer_based_receiver_calls() {
+        let src = r#"
+trait Runner {
+    fn run(&self);
+}
+
+struct Planner;
+
+impl Runner for Planner {
+    fn run(&self) {}
+}
+
+fn execute() {
+    let planner = Planner {};
+    planner.run();
+}
+"#;
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), src).unwrap();
+        let semantic = extract_rust_semantic_file(temp.path()).unwrap();
+        assert!(semantic.defines.iter().any(|d| d == "Planner::Runner::run"));
+        assert_eq!(
+            semantic
+                .method_traits
+                .get("run")
+                .map(|traits| traits.as_slice()),
+            Some(&["Runner".to_string()][..])
+        );
+        assert!(semantic.calls.iter().any(|c| c == "Planner::run"));
+    }
+
+    #[test]
+    fn classifies_workspace_member_for_path_from_graph() {
+        let graph = WorkspaceGraph {
+            root: "/repo".to_string(),
+            package_name: Some("harper-workspace".to_string()),
+            members: vec![
+                WorkspaceMemberOverview {
+                    name: "harper-core".to_string(),
+                    role: "runtime/tools/storage/agent".to_string(),
+                    root: "lib/harper-core".to_string(),
+                    entrypoints: vec!["src/lib.rs".to_string()],
+                    notable_files: Vec::new(),
+                },
+                WorkspaceMemberOverview {
+                    name: "harper-ui".to_string(),
+                    role: "tui/widgets/events".to_string(),
+                    root: "lib/harper-ui".to_string(),
+                    entrypoints: vec!["src/lib.rs".to_string()],
+                    notable_files: Vec::new(),
+                },
+            ],
+        };
+        let member = workspace_member_for_path(
+            Path::new("lib/harper-ui/src/interfaces/ui/widgets.rs"),
+            Some(&graph),
+        )
+        .unwrap();
+        assert_eq!(member.name, "harper-ui");
+    }
+
+    #[test]
+    fn formats_workspace_graph_with_member_summary() {
+        let graph = WorkspaceGraph {
+            root: "/repo".to_string(),
+            package_name: Some("harper-workspace".to_string()),
+            members: vec![WorkspaceMemberOverview {
+                name: "harper-core".to_string(),
+                role: classify_member_role("harper-core", "lib/harper-core"),
+                root: "lib/harper-core".to_string(),
+                entrypoints: vec!["src/lib.rs".to_string()],
+                notable_files: vec!["src/tools/codebase_investigator.rs".to_string()],
+            }],
+        };
+        let rendered = format_workspace_graph(&graph);
+        assert!(rendered.contains("Workspace root: /repo"));
+        assert!(rendered.contains("Workspace members: harper-core"));
+        assert!(rendered.contains("crate=harper-core"));
+    }
+
+    #[test]
+    fn path_relative_to_root_prefers_member_relative_paths() {
+        let root = Path::new("/repo/lib/harper-core");
+        let rel = path_relative_to_root(root, Path::new("/repo/lib/harper-core/src/lib.rs"));
+        assert_eq!(rel, "src/lib.rs");
     }
 }

--- a/lib/harper-core/src/tools/filesystem.rs
+++ b/lib/harper-core/src/tools/filesystem.rs
@@ -22,16 +22,195 @@ use crate::memory::cache::CacheAlignedBuffer;
 use crate::tools::parsing;
 use colored::*;
 use std::io::{self, Write};
+use std::path::Path;
+use walkdir::WalkDir;
 
 use crate::core::io_traits::UserApproval;
 use std::sync::Arc;
+
+fn ground_workspace_path_for_cwd(raw_path: &str, cwd: &Path) -> HarperResult<String> {
+    let path = Path::new(raw_path);
+    if !path.is_absolute() {
+        return Ok(raw_path.to_string());
+    }
+
+    if path.starts_with(cwd) {
+        return Ok(raw_path.to_string());
+    }
+
+    if let Some(file_name) = path.file_name() {
+        let candidate = cwd.join(file_name);
+        if candidate.exists() {
+            return Ok(candidate.to_string_lossy().into_owned());
+        }
+    }
+
+    Err(HarperError::Command(format!(
+        "Refusing file path outside the current workspace: {}. Use a repository-relative path.",
+        raw_path
+    )))
+}
+
+fn ground_workspace_path(raw_path: &str) -> HarperResult<String> {
+    let cwd = std::env::current_dir()
+        .map_err(|e| HarperError::Command(format!("Failed to get current dir: {}", e)))?;
+    ground_workspace_path_for_cwd(raw_path, &cwd)
+}
+
+fn should_skip_workspace_dir(name: &str) -> bool {
+    matches!(name, ".git" | "target" | "node_modules")
+}
+
+fn looks_like_placeholder_path(raw_path: &str) -> bool {
+    let normalized = raw_path.replace('\\', "/").to_ascii_lowercase();
+    normalized.starts_with("/users/username/")
+        || normalized.starts_with("/home/user/")
+        || normalized.starts_with("user_request/")
+        || normalized.contains("/user_request/")
+        || normalized.contains("actual_tool_call")
+        || normalized.contains("placeholder")
+}
+
+fn find_workspace_file_match_for_cwd(raw_path: &str, cwd: &Path) -> HarperResult<Option<String>> {
+    let query = raw_path.trim().trim_start_matches("./");
+    if query.is_empty() {
+        return Ok(None);
+    }
+
+    let query_path = Path::new(query);
+    let basename = query_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(query);
+    let stem = Path::new(basename)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or(basename);
+
+    let mut exact_relative = Vec::new();
+    let mut exact_basename = Vec::new();
+    let mut exact_stem = Vec::new();
+
+    for entry in WalkDir::new(cwd)
+        .into_iter()
+        .filter_entry(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_none_or(|name| !should_skip_workspace_dir(name))
+        })
+        .filter_map(Result::ok)
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        let relative = path.strip_prefix(cwd).unwrap_or(path);
+        let relative_str = relative.to_string_lossy().replace('\\', "/");
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        let file_stem = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or("");
+
+        if relative_str == query {
+            exact_relative.push(path.to_string_lossy().into_owned());
+        } else if file_name == basename {
+            exact_basename.push(path.to_string_lossy().into_owned());
+        } else if file_stem == stem {
+            exact_stem.push(path.to_string_lossy().into_owned());
+        }
+    }
+
+    for matches in [exact_relative, exact_basename, exact_stem] {
+        if matches.len() == 1 {
+            return Ok(matches.into_iter().next());
+        }
+        if matches.len() > 1 {
+            return Err(HarperError::Command(format!(
+                "Multiple workspace files match '{}'. Use a more specific path.",
+                raw_path
+            )));
+        }
+    }
+
+    Ok(None)
+}
+
+fn resolve_read_target_for_cwd(raw_path: &str, cwd: &Path) -> HarperResult<String> {
+    let grounded = match ground_workspace_path_for_cwd(raw_path, cwd) {
+        Ok(grounded) => grounded,
+        Err(err) => {
+            if Path::new(raw_path).is_absolute() {
+                if let Some(candidate) = find_workspace_file_match_for_cwd(raw_path, cwd)? {
+                    return Ok(candidate);
+                }
+                if looks_like_placeholder_path(raw_path) {
+                    let display_name = Path::new(raw_path)
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or(raw_path);
+                    return Err(HarperError::Command(format!(
+                        "Read target uses a placeholder path not present in this workspace: {}. Inspect the repo and choose a real repository-relative file.",
+                        display_name
+                    )));
+                }
+            }
+            return Err(err);
+        }
+    };
+    let path = Path::new(&grounded);
+    let candidate_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+
+    if candidate_path.is_file() {
+        return Ok(candidate_path.to_string_lossy().into_owned());
+    }
+
+    if !candidate_path.exists() {
+        if let Some(candidate) = find_workspace_file_match_for_cwd(raw_path, cwd)? {
+            return Ok(candidate);
+        }
+    }
+
+    Ok(grounded)
+}
+
+fn resolve_read_target(raw_path: &str) -> HarperResult<String> {
+    let cwd = std::env::current_dir()
+        .map_err(|e| HarperError::Command(format!("Failed to get current dir: {}", e)))?;
+    resolve_read_target_for_cwd(raw_path, &cwd)
+}
+
+fn validate_read_target(path: &str) -> HarperResult<()> {
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        HarperError::Command(format!("Read target does not exist: {} ({})", path, e))
+    })?;
+
+    if !metadata.is_file() {
+        return Err(HarperError::Command(format!(
+            "Read target is not a file: {}. Choose a file path, not a directory.",
+            path
+        )));
+    }
+
+    Ok(())
+}
 
 /// Read a file
 pub async fn read_file(
     response: &str,
     approver: Option<Arc<dyn UserApproval>>,
 ) -> HarperResult<String> {
-    let path = parsing::extract_tool_arg(response, "[READ_FILE")?;
+    let path = resolve_read_target(&parsing::extract_tool_arg(response, "[READ_FILE")?)?;
+    validate_read_target(&path)?;
 
     if let Some(appr) = approver {
         if !appr.approve("Read file?", &path).await? {
@@ -55,11 +234,18 @@ pub async fn write_file(
     approver: Option<Arc<dyn UserApproval>>,
 ) -> HarperResult<String> {
     let args = parsing::extract_tool_args(response, "[WRITE_FILE", 2)?;
-    let path = &args[0];
-    let content = &args[1];
+    write_file_direct(&args[0], &args[1], approver).await
+}
+
+pub async fn write_file_direct(
+    raw_path: &str,
+    content: &str,
+    approver: Option<Arc<dyn UserApproval>>,
+) -> HarperResult<String> {
+    let path = ground_workspace_path(raw_path)?;
 
     let is_approved = if let Some(appr) = approver {
-        appr.approve("Write to file?", path).await?
+        appr.approve("Write to file?", &path).await?
     } else {
         let p = path.clone();
         tokio::task::spawn_blocking(move || {
@@ -91,14 +277,10 @@ pub async fn write_file(
         path.magenta()
     );
 
-    write_cache_aligned(path, content.as_bytes())
+    write_cache_aligned(&path, content.as_bytes())
         .map_err(|e| HarperError::Command(format!("Failed to write file {}: {}", path, e)))?;
 
-    Ok(format!(
-        "Successfully wrote {} bytes to {}",
-        content.len(),
-        path
-    ))
+    Ok(format!("Wrote file: {}\nCONTENT: {}", path, content))
 }
 
 /// Search and replace in a file
@@ -107,12 +289,13 @@ pub async fn search_replace(
     approver: Option<Arc<dyn UserApproval>>,
 ) -> HarperResult<String> {
     let args = parsing::extract_tool_args(response, "[SEARCH_REPLACE", 3)?;
-    let path = &args[0];
+    let path = resolve_read_target(&args[0])?;
+    validate_read_target(&path)?;
     let old_string = &args[1];
     let new_string = &args[2];
 
     let is_approved = if let Some(appr) = approver {
-        appr.approve("Search and replace in file?", path).await?
+        appr.approve("Search and replace in file?", &path).await?
     } else {
         let p = path.clone();
         tokio::task::spawn_blocking(move || {
@@ -144,13 +327,13 @@ pub async fn search_replace(
         path.magenta()
     );
 
-    let content = std::fs::read_to_string(path)
+    let content = std::fs::read_to_string(&path)
         .map_err(|e| HarperError::Command(format!("Failed to read file {}: {}", path, e)))?;
 
     let new_content = content.replace(old_string, new_string);
     let replacements = content.matches(old_string).count();
 
-    write_cache_aligned(path, new_content.as_bytes())
+    write_cache_aligned(&path, new_content.as_bytes())
         .map_err(|e| HarperError::Command(format!("Failed to write file {}: {}", path, e)))?;
 
     Ok(format!("Replaced {} occurrences in {}", replacements, path))
@@ -160,4 +343,115 @@ fn write_cache_aligned(path: &str, bytes: &[u8]) -> std::io::Result<()> {
     let mut buffer = CacheAlignedBuffer::with_capacity(bytes.len());
     buffer.write_bytes(bytes);
     std::fs::write(path, buffer.as_slice())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::error::HarperResult;
+    use crate::core::io_traits::UserApproval;
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct AllowApproval;
+
+    #[async_trait]
+    impl UserApproval for AllowApproval {
+        async fn approve(&self, _prompt: &str, _command: &str) -> HarperResult<bool> {
+            Ok(true)
+        }
+    }
+    use super::{
+        ground_workspace_path_for_cwd, resolve_read_target_for_cwd, search_replace,
+        validate_read_target,
+    };
+    use crate::core::error::HarperError;
+
+    #[test]
+    fn grounds_foreign_absolute_path_to_workspace_basename_match() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_file = temp.path().join("Cargo.toml");
+        std::fs::write(&workspace_file, "[package]\nname = \"harper\"\n").expect("write");
+
+        let grounded =
+            ground_workspace_path_for_cwd("/home/user/projects/my_project/Cargo.toml", temp.path())
+                .expect("grounded");
+
+        assert_eq!(grounded, workspace_file.to_string_lossy());
+    }
+
+    #[test]
+    fn rejects_foreign_absolute_path_without_workspace_match() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let err = ground_workspace_path_for_cwd(
+            "/home/user/projects/my_project/secrets.env",
+            temp.path(),
+        )
+        .expect_err("should reject");
+
+        assert!(matches!(err, HarperError::Command(_)));
+        assert!(err.to_string().contains("outside the current workspace"));
+    }
+
+    #[test]
+    fn validate_read_target_rejects_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let err = validate_read_target(temp.path().to_string_lossy().as_ref())
+            .expect_err("should reject");
+
+        assert!(matches!(err, HarperError::Command(_)));
+        assert!(err.to_string().contains("not a file"));
+    }
+
+    #[test]
+    fn resolve_read_target_finds_unique_workspace_basename_match() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let nested = temp.path().join("crates/harper-core");
+        std::fs::create_dir_all(&nested).expect("mkdir");
+        let target = nested.join("Cargo.toml");
+        std::fs::write(&target, "[package]\nname = \"harper-core\"\n").expect("write");
+
+        let resolved = resolve_read_target_for_cwd("Cargo.toml", temp.path()).expect("resolved");
+        assert_eq!(resolved, target.to_string_lossy());
+    }
+
+    #[test]
+    fn resolve_read_target_rejects_ambiguous_workspace_match() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let a = temp.path().join("a");
+        let b = temp.path().join("b");
+        std::fs::create_dir_all(&a).expect("mkdir a");
+        std::fs::create_dir_all(&b).expect("mkdir b");
+        std::fs::write(a.join("README.md"), "a").expect("write a");
+        std::fs::write(b.join("README.md"), "b").expect("write b");
+
+        let err = resolve_read_target_for_cwd("README.md", temp.path()).expect_err("ambiguous");
+        assert!(matches!(err, HarperError::Command(_)));
+        assert!(err.to_string().contains("Multiple workspace files match"));
+    }
+
+    #[tokio::test]
+    async fn search_replace_grounds_foreign_absolute_path_to_workspace_match() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let previous = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(temp.path()).expect("set cwd");
+
+        let target = temp.path().join("widgets.rs");
+        std::fs::write(
+            &target,
+            "retry_count
+",
+        )
+        .expect("write target");
+
+        let response = r#"[SEARCH_REPLACE /Users/username/Documents/project/source/widgets.rs retry_count retry_total]"#;
+        let result = search_replace(response, Some(Arc::new(AllowApproval)))
+            .await
+            .expect("search replace");
+        let content = std::fs::read_to_string(&target).expect("read back");
+
+        std::env::set_current_dir(previous).expect("restore cwd");
+
+        assert!(result.contains("Replaced 1 occurrences"));
+        assert!(content.contains("retry_total"));
+    }
 }

--- a/lib/harper-core/src/tools/git.rs
+++ b/lib/harper-core/src/tools/git.rs
@@ -25,6 +25,7 @@ use crate::tools::shell::{self, CommandAuditContext};
 use colored::*;
 use std::collections::HashSet;
 use std::io;
+use std::path::Path;
 
 use crate::core::io_traits::UserApproval;
 use std::sync::Arc;
@@ -73,6 +74,64 @@ pub fn git_status() -> crate::core::error::HarperResult<String> {
         .map_err(|e| HarperError::Command(format!("Failed to run git status: {}", e)))?;
 
     Ok(process_git_status_output(output))
+}
+
+pub fn repo_identity() -> crate::core::error::HarperResult<String> {
+    let top_level = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|e| HarperError::Command(format!("Failed to determine git root: {}", e)))?;
+    if !top_level.status.success() {
+        return Err(HarperError::Command(
+            String::from_utf8_lossy(&top_level.stderr)
+                .trim()
+                .to_string(),
+        ));
+    }
+
+    let root = String::from_utf8_lossy(&top_level.stdout)
+        .trim()
+        .to_string();
+    let repo_name = Path::new(&root)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("unknown");
+
+    let branch_output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .map_err(|e| HarperError::Command(format!("Failed to determine branch: {}", e)))?;
+    let branch = if branch_output.status.success() {
+        String::from_utf8_lossy(&branch_output.stdout)
+            .trim()
+            .to_string()
+    } else {
+        "unknown".to_string()
+    };
+
+    Ok(format!(
+        "Current repo: {} (root: {}, branch: {})",
+        repo_name, root, branch
+    ))
+}
+
+pub fn current_branch() -> crate::core::error::HarperResult<String> {
+    let branch_output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .map_err(|e| HarperError::Command(format!("Failed to determine branch: {}", e)))?;
+    if !branch_output.status.success() {
+        return Err(HarperError::Command(
+            String::from_utf8_lossy(&branch_output.stderr)
+                .trim()
+                .to_string(),
+        ));
+    }
+
+    let branch = String::from_utf8_lossy(&branch_output.stdout)
+        .trim()
+        .to_string();
+    Ok(format!("Current branch: {}", branch))
 }
 
 /// Get git status asynchronously

--- a/lib/harper-core/src/tools/mod.rs
+++ b/lib/harper-core/src/tools/mod.rs
@@ -440,9 +440,8 @@ impl<'a> ToolService<'a> {
                 let path = args.get("path").and_then(|v| v.as_str());
                 let content = args.get("content").and_then(|v| v.as_str());
                 if let (Some(path), Some(content)) = (path, content) {
-                    let bracket_command = format!("[WRITE_FILE {} {}]", path, content);
                     let write_result =
-                        filesystem::write_file(&bracket_command, self.approver.clone()).await?;
+                        filesystem::write_file_direct(path, content, self.approver.clone()).await?;
                     let final_response = self
                         .call_llm_after_tool(client, history, raw_response, &write_result)
                         .await?;
@@ -757,6 +756,7 @@ impl<'a> ToolService<'a> {
         tool_output: &str,
     ) -> Result<String, HarperError> {
         self.emit_activity_update(Some("thinking".to_string()));
+        let completed_tool_name = Self::tool_name_from_call(tool_call_json);
         let plan_sync_outcome = self.sync_plan_after_tool(tool_call_json)?;
         // Create a new history vector by cloning the existing one
         let mut new_history = history.to_vec();
@@ -792,11 +792,259 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
             content: system_message,
         });
 
-        // Call the LLM with the new history. If that fails (quota, blocked API, etc.),
-        // fall back to returning the tool output directly so the user still gets a result.
         match crate::core::llm_client::call_llm(client, self.config, &new_history).await {
-            Ok(response) => Ok(response),
+            Ok(response)
+                if completed_tool_name.as_deref() == Some("read_file")
+                    && Self::response_looks_like_file_tool_call(&response) =>
+            {
+                new_history.push(Message {
+                    role: "system".to_string(),
+                    content: "You already have the completed file contents. Do not call read_file, write_file, or search_replace again. Answer the user now in plain language only from the file result you already have.".to_string(),
+                });
+                match crate::core::llm_client::call_llm(client, self.config, &new_history).await {
+                    Ok(retry_response) => Ok(Self::finalize_read_file_followup_response(
+                        &retry_response,
+                        tool_output,
+                    )),
+                    Err(_) => Ok(format!("Tool result:\n{}", tool_output)),
+                }
+            }
+            Ok(response) if Self::response_looks_like_tool_call(&response) => {
+                new_history.push(Message {
+                    role: "system".to_string(),
+                    content: "You already have the completed tool result. Do not call any tool again. Respond now in plain language only.".to_string(),
+                });
+                match crate::core::llm_client::call_llm(client, self.config, &new_history).await {
+                    Ok(retry_response) => Ok(Self::finalize_tool_followup_response(
+                        completed_tool_name.as_deref(),
+                        &retry_response,
+                        tool_output,
+                    )),
+                    Err(_) => Ok(format!("Tool result:\n{}", tool_output)),
+                }
+            }
+            Ok(response) => Ok(Self::finalize_tool_followup_response(
+                completed_tool_name.as_deref(),
+                &response,
+                tool_output,
+            )),
             Err(_) => Ok(format!("Tool result:\n{}", tool_output)),
+        }
+    }
+
+    fn response_looks_like_file_tool_call(response: &str) -> bool {
+        matches!(
+            Self::tool_name_from_call(response).as_deref(),
+            Some("read_file" | "write_file" | "search_replace")
+        )
+    }
+
+    fn response_looks_like_tool_call(response: &str) -> bool {
+        if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(response.trim()) {
+            if let Some(tool_calls) = json_value.as_array() {
+                if let Some(first_call) = tool_calls.first() {
+                    if first_call.get("function").is_some() {
+                        return true;
+                    }
+                }
+            }
+
+            if json_value
+                .get("tool")
+                .or_else(|| json_value.get("name"))
+                .or_else(|| json_value.get("mcp_tool"))
+                .is_some()
+            {
+                return true;
+            }
+        }
+
+        let upper = response.trim().to_uppercase();
+        upper.starts_with(tools::RUN_COMMAND)
+            || upper.starts_with(tools::READ_FILE)
+            || upper.starts_with(tools::WRITE_FILE)
+            || upper.starts_with(tools::SEARCH_REPLACE)
+            || upper.starts_with(tools::TODO)
+            || upper.starts_with(tools::SEARCH)
+            || upper.starts_with(git_tools::GIT_STATUS)
+            || upper.starts_with(git_tools::GIT_DIFF)
+            || upper.starts_with(git_tools::GIT_COMMIT)
+            || upper.starts_with(git_tools::GIT_ADD)
+            || upper.starts_with(tools::GITHUB_ISSUE)
+            || upper.starts_with(tools::GITHUB_PR)
+            || upper.starts_with(tools::API_TEST)
+            || upper.starts_with(tools::CODE_ANALYZE)
+            || upper.starts_with(tools::CODEBASE_INVESTIGATE)
+            || upper.starts_with(tools::DB_QUERY)
+            || upper.starts_with(tools::IMAGE_INFO)
+            || upper.starts_with(tools::IMAGE_RESIZE)
+            || upper.starts_with(tools::SCREENPIPE)
+            || upper.starts_with(tools::FIRMWARE)
+    }
+
+    fn finalize_tool_followup_response(
+        tool_name: Option<&str>,
+        response: &str,
+        tool_output: &str,
+    ) -> String {
+        if response.trim().is_empty()
+            || Self::response_looks_like_tool_call(response)
+            || Self::response_is_low_value_tool_echo(response)
+        {
+            Self::format_tool_followup_fallback(tool_name, tool_output)
+        } else {
+            response.to_string()
+        }
+    }
+
+    fn finalize_read_file_followup_response(response: &str, tool_output: &str) -> String {
+        if response.trim().is_empty()
+            || Self::response_looks_like_file_tool_call(response)
+            || Self::response_is_low_value_tool_echo(response)
+        {
+            Self::format_tool_followup_fallback(Some("read_file"), tool_output)
+        } else {
+            response.to_string()
+        }
+    }
+
+    fn response_is_low_value_tool_echo(response: &str) -> bool {
+        let trimmed = response.trim();
+        trimmed.starts_with("Tool result:")
+            || trimmed.starts_with("Tool Result:")
+            || trimmed.starts_with("tool result:")
+    }
+
+    fn format_tool_followup_fallback(tool_name: Option<&str>, tool_output: &str) -> String {
+        match tool_name {
+            Some("git_status") => Self::format_git_status(tool_output),
+            Some("git_diff") => Self::format_git_diff(tool_output),
+            Some("write_file") => Self::format_write_file(tool_output),
+            Some("run_command") => Self::format_run_command(tool_output),
+            _ => format!("Tool result:\n{}", tool_output),
+        }
+    }
+
+    fn format_git_status(tool_content: &str) -> String {
+        let body = tool_content
+            .strip_prefix("Git status:\n")
+            .unwrap_or(tool_content)
+            .trim();
+        if body.is_empty() || body == "clean" {
+            return "Git working directory is clean.".to_string();
+        }
+
+        let mut modified = 0usize;
+        let mut added = 0usize;
+        let mut deleted = 0usize;
+        let mut renamed = 0usize;
+        let mut untracked = 0usize;
+        let mut notable = Vec::new();
+
+        for line in body.lines() {
+            let line = line.trim_end();
+            if line.len() < 3 {
+                continue;
+            }
+            let status = &line[..2];
+            let path = line[2..].trim();
+            if notable.len() < 6 && !path.is_empty() {
+                notable.push(path.to_string());
+            }
+            match status {
+                "??" => untracked += 1,
+                s if s.contains('M') => modified += 1,
+                s if s.contains('A') => added += 1,
+                s if s.contains('D') => deleted += 1,
+                s if s.contains('R') => renamed += 1,
+                _ => modified += 1,
+            }
+        }
+
+        let mut parts = Vec::new();
+        if modified > 0 {
+            parts.push(format!("{} modified", modified));
+        }
+        if added > 0 {
+            parts.push(format!("{} added", added));
+        }
+        if deleted > 0 {
+            parts.push(format!("{} deleted", deleted));
+        }
+        if renamed > 0 {
+            parts.push(format!("{} renamed", renamed));
+        }
+        if untracked > 0 {
+            parts.push(format!("{} untracked", untracked));
+        }
+
+        let summary = if parts.is_empty() {
+            "Git working directory has changes.".to_string()
+        } else {
+            format!("Git working directory has {}.", parts.join(", "))
+        };
+
+        if notable.is_empty() {
+            summary
+        } else {
+            format!("{} Notable files: {}.", summary, notable.join(", "))
+        }
+    }
+
+    fn format_git_diff(tool_content: &str) -> String {
+        format!("Git diff:\n```diff\n{}\n```", tool_content.trim_end())
+    }
+
+    fn format_write_file(tool_content: &str) -> String {
+        let mut path = None;
+        let mut content = None;
+        for line in tool_content.lines() {
+            if let Some(value) = line.strip_prefix("Wrote file: ") {
+                path = Some(value.trim().to_string());
+            }
+            if let Some(value) = tool_content.strip_prefix("Wrote file: ") {
+                let rest = value.lines().collect::<Vec<_>>();
+                if let Some(idx) = rest.iter().position(|line| line.starts_with("CONTENT:")) {
+                    let joined = rest[idx..].join("\n");
+                    content = joined
+                        .strip_prefix("CONTENT:")
+                        .map(|v| v.trim_start().to_string());
+                }
+                break;
+            }
+        }
+
+        match (path, content) {
+            (Some(path), Some(content)) => {
+                let ext = std::path::Path::new(&path)
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .unwrap_or("txt");
+                format!(
+                    "Created `{}`:\n```{}\n{}\n```",
+                    path,
+                    ext,
+                    content.trim_end()
+                )
+            }
+            _ => format!("Tool result:\n{}", tool_content),
+        }
+    }
+
+    fn format_run_command(tool_content: &str) -> String {
+        let command = tool_content
+            .lines()
+            .find_map(|line| line.strip_prefix("COMMAND: "))
+            .unwrap_or("command");
+        let output = tool_content
+            .split_once("OUTPUT:\n")
+            .map(|(_, output)| output.trim_end())
+            .unwrap_or("");
+
+        if output.is_empty() {
+            format!("Ran `{}` successfully.", command)
+        } else {
+            format!("Ran `{}` successfully.\n\n{}", command, output)
         }
     }
 
@@ -1172,6 +1420,93 @@ mod tests {
             base_url: "https://api.openai.com/v1/chat/completions".to_string(),
             model_name: "gpt-5.5".to_string(),
         }
+    }
+
+    #[test]
+    fn finalize_tool_followup_response_falls_back_when_blank() {
+        let response = ToolService::finalize_tool_followup_response(None, "   \n", "Plan updated.");
+        assert_eq!(response, "Tool result:\nPlan updated.");
+    }
+
+    #[test]
+    fn finalize_tool_followup_response_keeps_non_empty_response() {
+        let response = ToolService::finalize_tool_followup_response(
+            None,
+            "I updated the plan and will inspect the codebase next.",
+            "Plan updated.",
+        );
+        assert_eq!(
+            response,
+            "I updated the plan and will inspect the codebase next."
+        );
+    }
+
+    #[test]
+    fn response_looks_like_tool_call_detects_json_tool_calls() {
+        assert!(ToolService::response_looks_like_tool_call(
+            r#"[{"function":{"name":"read_file","arguments":{"path":"Cargo.toml"}}}]"#
+        ));
+        assert!(ToolService::response_looks_like_tool_call(
+            r#"{"tool":"read_file","args":{"path":"Cargo.toml"}}"#
+        ));
+    }
+
+    #[test]
+    fn finalize_tool_followup_response_falls_back_when_tool_call_repeats() {
+        let response = ToolService::finalize_tool_followup_response(
+            Some("read_file"),
+            r#"{"tool":"read_file","args":{"path":"Cargo.toml"}}"#,
+            "package = \"harper-workspace\"",
+        );
+        assert_eq!(response, "Tool result:\npackage = \"harper-workspace\"");
+    }
+
+    #[test]
+    fn finalize_tool_followup_response_formats_git_status_fallback() {
+        let response = ToolService::finalize_tool_followup_response(
+            Some("git_status"),
+            "   \n",
+            "Git status:\nM src/main.rs\n?? docs/testing/",
+        );
+        assert_eq!(
+            response,
+            "Git working directory has 1 modified, 1 untracked. Notable files: src/main.rs, docs/testing/."
+        );
+    }
+
+    #[test]
+    fn finalize_tool_followup_response_formats_run_command_fallback() {
+        let response = ToolService::finalize_tool_followup_response(
+            Some("run_command"),
+            "   \n",
+            "COMMAND: cargo fmt --all\nOUTPUT:\n",
+        );
+        assert_eq!(response, "Ran `cargo fmt --all` successfully.");
+    }
+
+    #[test]
+    fn response_looks_like_file_tool_call_detects_file_tools() {
+        assert!(ToolService::response_looks_like_file_tool_call(
+            r#"{"tool":"read_file","args":{"path":"Cargo.toml"}}"#
+        ));
+        assert!(ToolService::response_looks_like_file_tool_call(
+            r#"[SEARCH_REPLACE src/main.rs old new]"#
+        ));
+        assert!(!ToolService::response_looks_like_file_tool_call(
+            r#"{"tool":"run_command","args":{"command":"git status"}}"#
+        ));
+    }
+
+    #[test]
+    fn finalize_read_file_followup_response_falls_back_when_file_tool_repeats() {
+        let response = ToolService::finalize_read_file_followup_response(
+            r#"{"tool":"read_file","args":{"path":"package.json"}}"#,
+            "[package]\nname = \"harper-workspace\"\n",
+        );
+        assert_eq!(
+            response,
+            "Tool result:\n[package]\nname = \"harper-workspace\"\n"
+        );
     }
 
     #[test]

--- a/lib/harper-core/src/tools/plan.rs
+++ b/lib/harper-core/src/tools/plan.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use crate::core::error::{HarperError, HarperResult};
-use crate::core::plan::{PlanItem, PlanJobStatus, PlanRuntime, PlanState, PlanStepStatus};
+use crate::core::plan::{
+    AuthoringPlannedEdit, AuthoringValidationStep, PlanItem, PlanJobStatus, PlanRuntime, PlanState,
+    PlanStepStatus, StructuredAuthoringPlan,
+};
 use rusqlite::Connection;
 
 pub fn update_plan(
@@ -60,10 +63,22 @@ pub fn update_plan(
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
 
+    let structured_authoring_plan = args
+        .get("authoring_plan")
+        .map(parse_authoring_plan)
+        .transpose()?;
+
+    let existing_runtime =
+        crate::memory::storage::load_plan_state(conn, session_id)?.and_then(|plan| plan.runtime);
+    let mut runtime = existing_runtime.unwrap_or_default();
+    if let Some(authoring_plan) = structured_authoring_plan {
+        runtime.set_authoring_structured_plan(authoring_plan);
+    }
+
     let plan = PlanState {
         explanation: explanation.clone(),
         items,
-        runtime: None,
+        runtime: (!runtime.is_empty()).then_some(runtime),
         updated_at: None,
     };
 
@@ -315,6 +330,48 @@ pub fn clear_plan_followup(conn: &Connection, session_id: &str) -> HarperResult<
     crate::memory::storage::save_plan_state(conn, session_id, &plan)
 }
 
+pub fn seed_plan_authoring_context(
+    conn: &Connection,
+    session_id: &str,
+    request: &str,
+    candidate_files: Vec<String>,
+) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.seed_authoring_context(request.to_string(), candidate_files);
+    })
+}
+
+pub fn mark_plan_authoring_plan_created(conn: &Connection, session_id: &str) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.mark_authoring_plan_created();
+    })
+}
+
+pub fn mark_plan_authoring_inspection(
+    conn: &Connection,
+    session_id: &str,
+    inspected_files: Vec<String>,
+) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.mark_authoring_inspection(inspected_files);
+    })
+}
+
+pub fn mark_plan_authoring_edit_applied(
+    conn: &Connection,
+    session_id: &str,
+    edited_files: Vec<String>,
+) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.mark_authoring_edit_applied(edited_files);
+    })
+}
+pub fn mark_plan_authoring_validated(conn: &Connection, session_id: &str) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.mark_authoring_validated();
+    })
+}
+
 pub fn replan_blocked_step(
     conn: &Connection,
     session_id: &str,
@@ -400,12 +457,149 @@ fn parse_status(value: Option<&serde_json::Value>) -> HarperResult<PlanStepStatu
     }
 }
 
+fn parse_authoring_plan(value: &serde_json::Value) -> HarperResult<StructuredAuthoringPlan> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| HarperError::Validation("authoring_plan must be an object".to_string()))?;
+
+    let parse_paths = |key: &str| -> HarperResult<Vec<String>> {
+        let Some(raw) = object.get(key) else {
+            return Ok(Vec::new());
+        };
+        let items = raw.as_array().ok_or_else(|| {
+            HarperError::Validation(format!("authoring_plan.{} must be an array", key))
+        })?;
+        let mut paths = Vec::new();
+        for item in items {
+            let path = item
+                .as_str()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    HarperError::Validation(format!(
+                        "authoring_plan.{} entries must be non-empty strings",
+                        key
+                    ))
+                })?;
+            paths.push(path.to_string());
+        }
+        Ok(paths)
+    };
+
+    let parse_planned_edits = || -> HarperResult<Vec<AuthoringPlannedEdit>> {
+        let Some(raw) = object.get("planned_edits") else {
+            return Ok(Vec::new());
+        };
+        let items = raw.as_array().ok_or_else(|| {
+            HarperError::Validation("authoring_plan.planned_edits must be an array".to_string())
+        })?;
+        let mut edits = Vec::new();
+        for item in items {
+            let edit = item.as_object().ok_or_else(|| {
+                HarperError::Validation(
+                    "authoring_plan.planned_edits entries must be objects".to_string(),
+                )
+            })?;
+            let path = edit
+                .get("path")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    HarperError::Validation(
+                        "authoring_plan.planned_edits.path is required".to_string(),
+                    )
+                })?;
+            let change = edit
+                .get("change")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    HarperError::Validation(
+                        "authoring_plan.planned_edits.change is required".to_string(),
+                    )
+                })?;
+            let why = edit
+                .get("why")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned);
+            edits.push(AuthoringPlannedEdit {
+                path: path.to_string(),
+                change: change.to_string(),
+                why,
+            });
+        }
+        Ok(edits)
+    };
+
+    let parse_validation = || -> HarperResult<Vec<AuthoringValidationStep>> {
+        let Some(raw) = object.get("validation_plan") else {
+            return Ok(Vec::new());
+        };
+        let items = raw.as_array().ok_or_else(|| {
+            HarperError::Validation("authoring_plan.validation_plan must be an array".to_string())
+        })?;
+        let mut steps = Vec::new();
+        for item in items {
+            let step = item.as_object().ok_or_else(|| {
+                HarperError::Validation(
+                    "authoring_plan.validation_plan entries must be objects".to_string(),
+                )
+            })?;
+            let command = step
+                .get("command")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    HarperError::Validation(
+                        "authoring_plan.validation_plan.command is required".to_string(),
+                    )
+                })?;
+            let scope = step
+                .get("scope")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned);
+            steps.push(AuthoringValidationStep {
+                command: command.to_string(),
+                scope,
+            });
+        }
+        Ok(steps)
+    };
+
+    let plan = StructuredAuthoringPlan {
+        primary_files: parse_paths("primary_files")?,
+        supporting_files: parse_paths("supporting_files")?,
+        validation_files: parse_paths("validation_files")?,
+        planned_edits: parse_planned_edits()?,
+        validation_plan: parse_validation()?,
+    };
+
+    if plan.primary_files.is_empty()
+        && plan.supporting_files.is_empty()
+        && plan.planned_edits.is_empty()
+    {
+        return Err(HarperError::Validation(
+            "authoring_plan must include primary_files, supporting_files, or planned_edits"
+                .to_string(),
+        ));
+    }
+
+    Ok(plan)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         append_active_plan_job_output, clear_plan_followup, clear_plan_state,
-        finish_active_plan_job, finish_active_plan_job_with_output, replan_blocked_step,
-        set_plan_step_status, start_plan_job,
+        finish_active_plan_job, finish_active_plan_job_with_output, mark_plan_authoring_validated,
+        replan_blocked_step, set_plan_step_status, start_plan_job, update_plan,
     };
     use crate::core::plan::{PlanItem, PlanJobStatus, PlanState, PlanStepStatus};
     use rusqlite::Connection;
@@ -448,6 +642,92 @@ mod tests {
             plan.runtime
                 .as_ref()
                 .and_then(|runtime| runtime.active_job_id.clone())
+        );
+    }
+
+    #[test]
+    fn update_plan_persists_structured_authoring_plan() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+
+        let args = serde_json::json!({
+            "items": [{"step": "Inspect files", "status": "in_progress"}],
+            "authoring_plan": {
+                "primary_files": ["lib/harper-ui/src/interfaces/ui/widgets.rs"],
+                "supporting_files": ["lib/harper-core/src/agent/chat.rs"],
+                "planned_edits": [
+                    {
+                        "path": "lib/harper-ui/src/interfaces/ui/widgets.rs",
+                        "change": "Adjust planner retry rendering",
+                        "why": "UI render path"
+                    }
+                ],
+                "validation_plan": [
+                    {"command": "cargo check -p harper-ui", "scope": "narrow"}
+                ]
+            }
+        });
+
+        update_plan(&conn, "authoring-plan-session", &args).expect("update plan");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "authoring-plan-session")
+            .expect("load plan")
+            .expect("plan present");
+        let runtime = plan.runtime.expect("runtime present");
+        let authoring = runtime.authoring.expect("authoring runtime present");
+        let structured = authoring.structured_plan.expect("structured plan present");
+        assert_eq!(
+            structured.primary_files,
+            vec!["lib/harper-ui/src/interfaces/ui/widgets.rs".to_string()]
+        );
+        assert_eq!(structured.validation_plan.len(), 1);
+        assert!(authoring
+            .edit_scope
+            .iter()
+            .any(|path| path == "lib/harper-ui/src/interfaces/ui/widgets.rs"));
+    }
+
+    #[test]
+    fn mark_plan_authoring_validated_advances_phase() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::save_plan_state(
+            &conn,
+            "authoring-validated-session",
+            &PlanState {
+                explanation: None,
+                items: vec![PlanItem {
+                    step: "Validate changes".to_string(),
+                    status: PlanStepStatus::InProgress,
+                    job_id: None,
+                }],
+                runtime: Some(crate::core::plan::PlanRuntime {
+                    authoring: Some(crate::core::plan::AuthoringRuntime {
+                        request: Some("refactor planner flow".to_string()),
+                        phase: Some(crate::core::plan::AuthoringPhase::EditsApplied),
+                        candidate_files: vec![],
+                        inspected_files: vec![],
+                        edit_scope: vec![],
+                        structured_plan: None,
+                    }),
+                    ..Default::default()
+                }),
+                updated_at: None,
+            },
+        )
+        .expect("save plan");
+
+        mark_plan_authoring_validated(&conn, "authoring-validated-session")
+            .expect("mark validated");
+
+        let plan = crate::memory::storage::load_plan_state(&conn, "authoring-validated-session")
+            .expect("load plan")
+            .expect("plan present");
+        assert_eq!(
+            plan.runtime
+                .and_then(|rt| rt.authoring)
+                .and_then(|authoring| authoring.phase),
+            Some(crate::core::plan::AuthoringPhase::Validated)
         );
     }
 

--- a/lib/harper-core/src/tools/shell.rs
+++ b/lib/harper-core/src/tools/shell.rs
@@ -1319,6 +1319,7 @@ mod tests {
     fn configured_sandbox_maps_runtime_policy() {
         let exec_policy = ExecPolicyConfig {
             approval_profile: Some(ApprovalProfile::AllowListed),
+            execution_strategy: None,
             allowed_commands: Some(vec!["git".to_string()]),
             blocked_commands: Some(vec!["rm".to_string()]),
             sandbox_profile: Some(SandboxProfile::Disabled),
@@ -1353,6 +1354,7 @@ mod tests {
     fn approval_profile_allow_all_skips_approval() {
         let exec_policy = ExecPolicyConfig {
             approval_profile: Some(ApprovalProfile::AllowAll),
+            execution_strategy: None,
             allowed_commands: None,
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
@@ -1372,6 +1374,7 @@ mod tests {
     fn approval_profile_strict_requires_approval_even_for_allowlisted_commands() {
         let exec_policy = ExecPolicyConfig {
             approval_profile: Some(ApprovalProfile::Strict),
+            execution_strategy: None,
             allowed_commands: Some(vec!["git".to_string()]),
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
@@ -1391,6 +1394,7 @@ mod tests {
     fn approval_profile_allow_listed_uses_allowlist() {
         let exec_policy = ExecPolicyConfig {
             approval_profile: Some(ApprovalProfile::AllowListed),
+            execution_strategy: None,
             allowed_commands: Some(vec!["git".to_string()]),
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
@@ -1411,6 +1415,7 @@ mod tests {
     fn approval_profile_allow_listed_requires_approval_for_declared_writes() {
         let exec_policy = ExecPolicyConfig {
             approval_profile: Some(ApprovalProfile::AllowListed),
+            execution_strategy: None,
             allowed_commands: Some(vec!["cp".to_string()]),
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Workspace),
@@ -1443,6 +1448,7 @@ mod tests {
     fn approval_profile_allow_listed_skips_approval_for_writes_inside_writable_roots() {
         let exec_policy = ExecPolicyConfig {
             approval_profile: Some(ApprovalProfile::AllowListed),
+            execution_strategy: None,
             allowed_commands: Some(vec!["cp".to_string()]),
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Workspace),
@@ -1475,6 +1481,7 @@ mod tests {
     fn approval_profile_allow_listed_requires_approval_for_network_intent() {
         let exec_policy = ExecPolicyConfig {
             approval_profile: Some(ApprovalProfile::AllowListed),
+            execution_strategy: None,
             allowed_commands: Some(vec!["curl".to_string()]),
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),
@@ -1614,6 +1621,7 @@ mod tests {
 
         let exec_policy = ExecPolicyConfig {
             approval_profile: Some(ApprovalProfile::AllowAll),
+            execution_strategy: None,
             allowed_commands: None,
             blocked_commands: None,
             sandbox_profile: Some(SandboxProfile::Disabled),

--- a/lib/harper-ui/src/interfaces/ui/app.rs
+++ b/lib/harper-ui/src/interfaces/ui/app.rs
@@ -15,7 +15,7 @@
 use harper_core::core::Message;
 use harper_core::memory::session_service::GlobalStats;
 use harper_core::ResolvedAgents;
-use harper_core::{ApprovalProfile, AuthSession, PlanState, SandboxProfile};
+use harper_core::{ApprovalProfile, AuthSession, ExecutionStrategy, PlanState, SandboxProfile};
 use serde::Deserialize;
 use std::fs;
 use std::sync::{Arc, Mutex};
@@ -207,6 +207,10 @@ pub async fn gather_sidebar_entries_async(messages: &[Message]) -> Vec<String> {
 }
 
 impl ChatState {
+    pub fn follow_latest_messages(&mut self) {
+        self.scroll_offset = 0;
+    }
+
     pub fn refresh_plan_state(&mut self) {
         if let Some(plan) = &self.active_plan {
             let max_steps = plan.items.len().saturating_sub(1);
@@ -325,6 +329,7 @@ pub enum AppState {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExecutionPolicyListField {
+    HeaderWidgets,
     AllowedCommands,
     BlockedCommands,
 }
@@ -357,6 +362,21 @@ pub struct UiMessage {
     pub expires_at: Option<Instant>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeaderWidget {
+    Session,
+    Plan,
+    Agents,
+    Web,
+    Auth,
+    Focus,
+    Model,
+    Cwd,
+    Strategy,
+    Approval,
+    Activity,
+}
+
 #[derive(Clone)]
 pub struct TuiApp {
     pub state: AppState,
@@ -368,16 +388,19 @@ pub struct TuiApp {
     pub cut_buffer: String,
     pub approval_history: Vec<String>,
     pub model_label: String,
+    pub current_working_dir: String,
     pub auth_session: Option<AuthSession>,
     pub auth_flow_id: Option<String>,
     pub auth_server_base_url: Option<String>,
     pub auth_last_poll_at: Option<Instant>,
     pub approval_profile: ApprovalProfile,
+    pub execution_strategy: ExecutionStrategy,
     pub sandbox_profile: SandboxProfile,
     pub retry_max_attempts: u32,
     pub allowed_commands: Vec<String>,
     pub blocked_commands: Vec<String>,
     pub execution_policy_editor: Option<ExecutionPolicyEditorState>,
+    pub header_widgets: Vec<HeaderWidget>,
 }
 
 impl Default for TuiApp {
@@ -392,16 +415,31 @@ impl Default for TuiApp {
             cut_buffer: String::new(),
             approval_history: Vec::new(),
             model_label: String::new(),
+            current_working_dir: String::new(),
             auth_session: None,
             auth_flow_id: None,
             auth_server_base_url: None,
             auth_last_poll_at: None,
             approval_profile: ApprovalProfile::AllowListed,
+            execution_strategy: ExecutionStrategy::Auto,
             sandbox_profile: SandboxProfile::Disabled,
             retry_max_attempts: 1,
             allowed_commands: Vec::new(),
             blocked_commands: Vec::new(),
             execution_policy_editor: None,
+            header_widgets: vec![
+                HeaderWidget::Session,
+                HeaderWidget::Plan,
+                HeaderWidget::Agents,
+                HeaderWidget::Web,
+                HeaderWidget::Auth,
+                HeaderWidget::Focus,
+                HeaderWidget::Model,
+                HeaderWidget::Cwd,
+                HeaderWidget::Strategy,
+                HeaderWidget::Approval,
+                HeaderWidget::Activity,
+            ],
         }
     }
 }
@@ -433,7 +471,7 @@ impl TuiApp {
     }
 
     pub fn execution_policy_row_count(&self) -> usize {
-        6
+        8
     }
 
     pub fn set_error_message(&mut self, content: String) {
@@ -568,8 +606,7 @@ impl TuiApp {
                             chat_state.agents_scroll_offset.saturating_add(1);
                     }
                     NavigationFocus::Messages => {
-                        chat_state.scroll_offset =
-                            (chat_state.scroll_offset + 1).min(chat_state.messages.len());
+                        chat_state.scroll_offset = chat_state.scroll_offset.saturating_sub(1);
                     }
                 }
             }
@@ -630,7 +667,7 @@ impl TuiApp {
                             chat_state.agents_scroll_offset.saturating_sub(1);
                     }
                     NavigationFocus::Messages => {
-                        chat_state.scroll_offset = chat_state.scroll_offset.saturating_sub(1);
+                        chat_state.scroll_offset = chat_state.scroll_offset.saturating_add(1);
                     }
                 }
             }

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -111,6 +111,7 @@ pub(crate) fn create_chat_state(
         sidebar_entries: Vec::new(),
     };
     chat_state.refresh_review_state();
+    chat_state.follow_latest_messages();
     chat_state
 }
 
@@ -158,6 +159,9 @@ fn parse_command_list(input: &str) -> Vec<String> {
 
 fn start_execution_policy_editor(app: &mut TuiApp, field: ExecutionPolicyListField) {
     let input = match field {
+        ExecutionPolicyListField::HeaderWidgets => {
+            settings::header_widgets_summary(&app.header_widgets)
+        }
         ExecutionPolicyListField::AllowedCommands => app.allowed_commands.join(", "),
         ExecutionPolicyListField::BlockedCommands => app.blocked_commands.join(", "),
     };
@@ -321,6 +325,9 @@ pub fn handle_event(
                     KeyCode::Enter => {
                         let values = parse_command_list(&editor.input);
                         match editor.field {
+                            ExecutionPolicyListField::HeaderWidgets => {
+                                app.header_widgets = settings::parse_header_widgets(&values);
+                            }
                             ExecutionPolicyListField::AllowedCommands => {
                                 app.allowed_commands = values;
                             }
@@ -329,7 +336,7 @@ pub fn handle_event(
                             }
                         }
                         app.execution_policy_editor = None;
-                        app.set_status_message("Updated execution policy command list".to_string());
+                        app.set_status_message("Updated execution policy settings".to_string());
                         return EventResult::Continue;
                     }
                     KeyCode::Backspace => {
@@ -795,14 +802,18 @@ fn handle_enter(app: &mut TuiApp, session_service: &SessionService) -> EventResu
                 app.approval_profile = settings::next_approval_profile(app.approval_profile);
             }
             1 => {
-                app.sandbox_profile = settings::next_sandbox_profile(app.sandbox_profile);
+                app.execution_strategy = settings::next_execution_strategy(app.execution_strategy);
             }
             2 => {
+                app.sandbox_profile = settings::next_sandbox_profile(app.sandbox_profile);
+            }
+            3 => {
                 app.retry_max_attempts = settings::next_retry_max_attempts(app.retry_max_attempts);
             }
-            3 => start_execution_policy_editor(app, ExecutionPolicyListField::AllowedCommands),
-            4 => start_execution_policy_editor(app, ExecutionPolicyListField::BlockedCommands),
-            5 => return EventResult::SaveExecutionPolicy,
+            4 => start_execution_policy_editor(app, ExecutionPolicyListField::HeaderWidgets),
+            5 => start_execution_policy_editor(app, ExecutionPolicyListField::AllowedCommands),
+            6 => start_execution_policy_editor(app, ExecutionPolicyListField::BlockedCommands),
+            7 => return EventResult::SaveExecutionPolicy,
             _ => {}
         },
         AppState::ViewSession(session_id, _, _) => {
@@ -1001,20 +1012,20 @@ fn handle_process_list(app: &mut TuiApp) {
 fn handle_char_input(app: &mut TuiApp, c: char) {
     if let AppState::Chat(chat_state) = &mut app.state {
         chat_state.input.push(c);
-        chat_state.reset_completion();
+        refresh_chat_completions(chat_state);
     }
 }
 
 fn handle_backspace(app: &mut TuiApp) {
     if let AppState::Chat(chat_state) = &mut app.state {
         chat_state.input.pop();
-        chat_state.reset_completion();
+        refresh_chat_completions(chat_state);
     }
 }
 fn handle_paste(app: &mut TuiApp, content: String) {
     if let AppState::Chat(chat_state) = &mut app.state {
         chat_state.input.push_str(&content);
-        chat_state.reset_completion();
+        refresh_chat_completions(chat_state);
     }
 }
 
@@ -1040,7 +1051,7 @@ fn handle_image_paste(app: &mut TuiApp) {
             Ok(file_path) => {
                 let reference = format!("@{}", file_path.display());
                 chat_state.input.push_str(&reference);
-                chat_state.reset_completion();
+                refresh_chat_completions(chat_state);
                 app.set_info_message(format!(
                     "Image pasted and saved as: {}",
                     file_path.display()
@@ -1106,6 +1117,43 @@ fn handle_copy(app: &mut TuiApp) {
                 }
             }
         }
+    }
+}
+
+fn slash_command_candidates(input: &str) -> Vec<String> {
+    let commands = vec![
+        "/help",
+        "/quit",
+        "/clear",
+        "/exit",
+        "/audit",
+        "/strategy",
+        "/strategy auto",
+        "/strategy grounded",
+        "/strategy deterministic",
+        "/strategy model",
+        "/auth login github",
+        "/auth login google",
+        "/auth login apple",
+        "/auth logout",
+        "/auth status",
+    ];
+    let mut matches = commands
+        .into_iter()
+        .filter(|cmd| cmd.starts_with(input))
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    matches.sort();
+    matches
+}
+
+fn refresh_chat_completions(chat_state: &mut ChatState) {
+    if chat_state.input.starts_with('/') {
+        chat_state.completion_candidates = slash_command_candidates(&chat_state.input);
+        chat_state.completion_index = 0;
+        chat_state.completion_prefix = Some(chat_state.input.clone());
+    } else {
+        chat_state.reset_completion();
     }
 }
 
@@ -1185,26 +1233,8 @@ fn handle_tab(app: &mut TuiApp) {
                     (chat_state.completion_index + 1) % chat_state.completion_candidates.len();
             }
         } else if chat_state.input.starts_with('/') {
-            // Command completion
             if chat_state.completion_candidates.is_empty() {
-                let commands = vec![
-                    "/help",
-                    "/quit",
-                    "/clear",
-                    "/exit",
-                    "/audit",
-                    "/auth login github",
-                    "/auth login google",
-                    "/auth login apple",
-                    "/auth logout",
-                    "/auth status",
-                ];
-                for cmd in commands {
-                    if cmd.starts_with(&chat_state.input) {
-                        chat_state.completion_candidates.push(cmd.to_string());
-                    }
-                }
-                chat_state.completion_candidates.sort();
+                chat_state.completion_candidates = slash_command_candidates(&chat_state.input);
                 chat_state.completion_index = 0;
             }
             if !chat_state.completion_candidates.is_empty() {
@@ -1372,7 +1402,7 @@ mod tests {
     #[test]
     fn test_enter_execution_policy_save_returns_async_event() {
         let mut app = TuiApp::new();
-        app.state = AppState::ExecutionPolicy(5);
+        app.state = AppState::ExecutionPolicy(7);
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         harper_core::memory::storage::init_db(&conn).unwrap();
         let session_service = SessionService::new(&conn);
@@ -1389,7 +1419,7 @@ mod tests {
     fn test_enter_execution_policy_allowed_commands_opens_editor() {
         let mut app = TuiApp::new();
         app.allowed_commands = vec!["git".to_string()];
-        app.state = AppState::ExecutionPolicy(3);
+        app.state = AppState::ExecutionPolicy(5);
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         harper_core::memory::storage::init_db(&conn).unwrap();
         let session_service = SessionService::new(&conn);
@@ -1429,7 +1459,7 @@ mod tests {
     fn test_enter_execution_policy_retry_attempts_cycles_value() {
         let mut app = TuiApp::new();
         app.retry_max_attempts = 1;
-        app.state = AppState::ExecutionPolicy(2);
+        app.state = AppState::ExecutionPolicy(3);
         let conn = rusqlite::Connection::open_in_memory().unwrap();
         harper_core::memory::storage::init_db(&conn).unwrap();
         let session_service = SessionService::new(&conn);

--- a/lib/harper-ui/src/interfaces/ui/settings.rs
+++ b/lib/harper-ui/src/interfaces/ui/settings.rs
@@ -12,49 +12,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use harper_core::{ApprovalProfile, SandboxProfile};
+use harper_core::{ApprovalProfile, ExecutionStrategy, SandboxProfile};
+
+use super::app::HeaderWidget;
 use std::fs;
 use std::io;
 use std::path::Path;
 
-pub fn save_execution_policy_settings(
-    approval: ApprovalProfile,
-    sandbox: SandboxProfile,
-    retry_max_attempts: u32,
-    allowed_commands: &[String],
-    blocked_commands: &[String],
-) -> io::Result<()> {
+pub struct ExecPolicySettings<'a> {
+    pub approval: ApprovalProfile,
+    pub execution_strategy: ExecutionStrategy,
+    pub sandbox: SandboxProfile,
+    pub retry_max_attempts: u32,
+    pub allowed_commands: &'a [String],
+    pub blocked_commands: &'a [String],
+    pub header_widgets: &'a [HeaderWidget],
+}
+
+pub fn save_execution_policy_settings(settings: ExecPolicySettings<'_>) -> io::Result<()> {
     let path = Path::new("config/local.toml");
     let existing = fs::read_to_string(path).unwrap_or_default();
-    let updated = upsert_exec_policy_settings(
-        &existing,
-        approval,
-        sandbox,
-        retry_max_attempts,
-        allowed_commands,
-        blocked_commands,
-    );
+    let updated = upsert_exec_policy_settings(&existing, &settings);
     fs::write(path, updated)
 }
 
-fn upsert_exec_policy_settings(
-    input: &str,
-    approval: ApprovalProfile,
-    sandbox: SandboxProfile,
-    retry_max_attempts: u32,
-    allowed_commands: &[String],
-    blocked_commands: &[String],
-) -> String {
-    let approval_line = format!("approval_profile = \"{}\"", approval_profile_name(approval));
-    let sandbox_line = format!("sandbox_profile = \"{}\"", sandbox_profile_name(sandbox));
-    let retry_line = format!("retry_max_attempts = {}", retry_max_attempts);
+fn upsert_exec_policy_settings(input: &str, settings: &ExecPolicySettings<'_>) -> String {
+    let approval_line = format!(
+        "approval_profile = \"{}\"",
+        approval_profile_name(settings.approval)
+    );
+    let strategy_line = format!(
+        "execution_strategy = \"{}\"",
+        execution_strategy_name(settings.execution_strategy)
+    );
+    let sandbox_line = format!(
+        "sandbox_profile = \"{}\"",
+        sandbox_profile_name(settings.sandbox)
+    );
+    let retry_line = format!("retry_max_attempts = {}", settings.retry_max_attempts);
     let allowed_line = format!(
         "allowed_commands = {}",
-        serde_json::to_string(allowed_commands).unwrap_or_else(|_| "[]".to_string())
+        serde_json::to_string(settings.allowed_commands).unwrap_or_else(|_| "[]".to_string())
     );
     let blocked_line = format!(
         "blocked_commands = {}",
-        serde_json::to_string(blocked_commands).unwrap_or_else(|_| "[]".to_string())
+        serde_json::to_string(settings.blocked_commands).unwrap_or_else(|_| "[]".to_string())
+    );
+    let header_widgets_line = format!(
+        "header_widgets = {}",
+        serde_json::to_string(&header_widget_names(settings.header_widgets))
+            .unwrap_or_else(|_| "[]".to_string())
     );
 
     let mut lines: Vec<String> = input.lines().map(str::to_string).collect();
@@ -75,6 +82,7 @@ fn upsert_exec_policy_settings(
                 .filter(|line| {
                     let trimmed = line.trim_start();
                     !(trimmed.starts_with("approval_profile")
+                        || trimmed.starts_with("execution_strategy")
                         || trimmed.starts_with("sandbox_profile")
                         || trimmed.starts_with("retry_max_attempts")
                         || trimmed.starts_with("allowed_commands")
@@ -86,6 +94,7 @@ fn upsert_exec_policy_settings(
             section_body.insert(0, allowed_line);
             section_body.insert(0, retry_line);
             section_body.insert(0, sandbox_line);
+            section_body.insert(0, strategy_line);
             section_body.insert(0, approval_line);
 
             lines.splice(start + 1..section_end, section_body);
@@ -96,10 +105,40 @@ fn upsert_exec_policy_settings(
             }
             lines.push("[exec_policy]".to_string());
             lines.push(approval_line);
+            lines.push(strategy_line);
             lines.push(sandbox_line);
             lines.push(retry_line);
             lines.push(allowed_line);
             lines.push(blocked_line);
+        }
+    }
+
+    let ui_section_start = lines.iter().position(|line| line.trim() == "[ui]");
+
+    match ui_section_start {
+        Some(start) => {
+            let section_end = lines
+                .iter()
+                .enumerate()
+                .skip(start + 1)
+                .find(|(_, line)| line.trim_start().starts_with('['))
+                .map(|(index, _)| index)
+                .unwrap_or(lines.len());
+
+            let mut section_body: Vec<String> = lines[start + 1..section_end]
+                .iter()
+                .filter(|line| !line.trim_start().starts_with("header_widgets"))
+                .cloned()
+                .collect();
+            section_body.insert(0, header_widgets_line);
+            lines.splice(start + 1..section_end, section_body);
+        }
+        None => {
+            if !lines.is_empty() && !lines.last().is_some_and(|line| line.trim().is_empty()) {
+                lines.push(String::new());
+            }
+            lines.push("[ui]".to_string());
+            lines.push(header_widgets_line);
         }
     }
 
@@ -115,6 +154,15 @@ pub fn approval_profile_name(profile: ApprovalProfile) -> &'static str {
         ApprovalProfile::Strict => "strict",
         ApprovalProfile::AllowListed => "allow_listed",
         ApprovalProfile::AllowAll => "allow_all",
+    }
+}
+
+pub fn execution_strategy_name(strategy: ExecutionStrategy) -> &'static str {
+    match strategy {
+        ExecutionStrategy::Auto => "auto",
+        ExecutionStrategy::Grounded => "grounded",
+        ExecutionStrategy::Deterministic => "deterministic",
+        ExecutionStrategy::ModelOnly => "model",
     }
 }
 
@@ -134,6 +182,15 @@ pub fn next_approval_profile(profile: ApprovalProfile) -> ApprovalProfile {
     }
 }
 
+pub fn next_execution_strategy(strategy: ExecutionStrategy) -> ExecutionStrategy {
+    match strategy {
+        ExecutionStrategy::Auto => ExecutionStrategy::Grounded,
+        ExecutionStrategy::Grounded => ExecutionStrategy::Deterministic,
+        ExecutionStrategy::Deterministic => ExecutionStrategy::ModelOnly,
+        ExecutionStrategy::ModelOnly => ExecutionStrategy::Auto,
+    }
+}
+
 pub fn next_sandbox_profile(profile: SandboxProfile) -> SandboxProfile {
     match profile {
         SandboxProfile::Disabled => SandboxProfile::Workspace,
@@ -146,26 +203,89 @@ pub fn next_retry_max_attempts(value: u32) -> u32 {
     (value + 1) % 4
 }
 
+pub fn header_widget_name(widget: HeaderWidget) -> &'static str {
+    match widget {
+        HeaderWidget::Session => "session",
+        HeaderWidget::Plan => "plan",
+        HeaderWidget::Agents => "agents",
+        HeaderWidget::Web => "web",
+        HeaderWidget::Auth => "auth",
+        HeaderWidget::Focus => "focus",
+        HeaderWidget::Model => "model",
+        HeaderWidget::Cwd => "cwd",
+        HeaderWidget::Strategy => "strategy",
+        HeaderWidget::Approval => "approval",
+        HeaderWidget::Activity => "activity",
+    }
+}
+
+pub fn header_widget_names(widgets: &[HeaderWidget]) -> Vec<&'static str> {
+    widgets.iter().map(|w| header_widget_name(*w)).collect()
+}
+
+pub fn parse_header_widgets(values: &[String]) -> Vec<HeaderWidget> {
+    let mut parsed = Vec::new();
+    for value in values {
+        let widget = match value.trim().to_ascii_lowercase().as_str() {
+            "session" => Some(HeaderWidget::Session),
+            "plan" => Some(HeaderWidget::Plan),
+            "agents" => Some(HeaderWidget::Agents),
+            "web" => Some(HeaderWidget::Web),
+            "auth" => Some(HeaderWidget::Auth),
+            "focus" => Some(HeaderWidget::Focus),
+            "model" => Some(HeaderWidget::Model),
+            "cwd" => Some(HeaderWidget::Cwd),
+            "strategy" => Some(HeaderWidget::Strategy),
+            "approval" => Some(HeaderWidget::Approval),
+            "activity" => Some(HeaderWidget::Activity),
+            _ => None,
+        };
+        if let Some(widget) = widget {
+            if !parsed.contains(&widget) {
+                parsed.push(widget);
+            }
+        }
+    }
+    if !parsed.contains(&HeaderWidget::Model) {
+        parsed.insert(0, HeaderWidget::Model);
+    }
+    if parsed.is_empty() {
+        vec![HeaderWidget::Model]
+    } else {
+        parsed
+    }
+}
+
+pub fn header_widgets_summary(widgets: &[HeaderWidget]) -> String {
+    header_widget_names(widgets).join(", ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        approval_profile_name, next_approval_profile, next_retry_max_attempts,
-        next_sandbox_profile, sandbox_profile_name, upsert_exec_policy_settings,
+        approval_profile_name, execution_strategy_name, next_approval_profile,
+        next_execution_strategy, next_retry_max_attempts, next_sandbox_profile,
+        sandbox_profile_name, upsert_exec_policy_settings, ExecPolicySettings, HeaderWidget,
     };
-    use harper_core::{ApprovalProfile, SandboxProfile};
+    use harper_core::{ApprovalProfile, ExecutionStrategy, SandboxProfile};
 
     #[test]
     fn upsert_exec_policy_profiles_creates_section() {
         let output = upsert_exec_policy_settings(
             "",
-            ApprovalProfile::AllowListed,
-            SandboxProfile::Workspace,
-            2,
-            &["git".to_string()],
-            &["rm".to_string()],
+            &ExecPolicySettings {
+                approval: ApprovalProfile::AllowListed,
+                execution_strategy: ExecutionStrategy::Grounded,
+                sandbox: SandboxProfile::Workspace,
+                retry_max_attempts: 2,
+                allowed_commands: &["git".to_string()],
+                blocked_commands: &["rm".to_string()],
+                header_widgets: &[HeaderWidget::Model, HeaderWidget::Strategy],
+            },
         );
         assert!(output.contains("[exec_policy]"));
         assert!(output.contains("approval_profile = \"allow_listed\""));
+        assert!(output.contains("execution_strategy = \"grounded\""));
         assert!(output.contains("sandbox_profile = \"workspace\""));
         assert!(output.contains("retry_max_attempts = 2"));
         assert!(output.contains("allowed_commands = [\"git\"]"));
@@ -177,13 +297,18 @@ mod tests {
         let input = "[exec_policy]\napproval_profile = \"strict\"\nsandbox_profile = \"disabled\"\nallowed_commands = [\"git\"]\nblocked_commands = [\"rm\"]\n";
         let output = upsert_exec_policy_settings(
             input,
-            ApprovalProfile::AllowAll,
-            SandboxProfile::NetworkedWorkspace,
-            3,
-            &["ls".to_string()],
-            &["sudo".to_string()],
+            &ExecPolicySettings {
+                approval: ApprovalProfile::AllowAll,
+                execution_strategy: ExecutionStrategy::Deterministic,
+                sandbox: SandboxProfile::NetworkedWorkspace,
+                retry_max_attempts: 3,
+                allowed_commands: &["ls".to_string()],
+                blocked_commands: &["sudo".to_string()],
+                header_widgets: &[HeaderWidget::Model, HeaderWidget::Cwd],
+            },
         );
         assert!(output.contains("approval_profile = \"allow_all\""));
+        assert!(output.contains("execution_strategy = \"deterministic\""));
         assert!(output.contains("sandbox_profile = \"networked_workspace\""));
         assert!(output.contains("retry_max_attempts = 3"));
         assert!(output.contains("allowed_commands = [\"ls\"]"));
@@ -198,6 +323,10 @@ mod tests {
             "allow_listed"
         );
         assert_eq!(
+            execution_strategy_name(ExecutionStrategy::Grounded),
+            "grounded"
+        );
+        assert_eq!(
             sandbox_profile_name(SandboxProfile::NetworkedWorkspace),
             "networked_workspace"
         );
@@ -208,6 +337,10 @@ mod tests {
         assert_eq!(
             next_approval_profile(ApprovalProfile::Strict),
             ApprovalProfile::AllowListed
+        );
+        assert_eq!(
+            next_execution_strategy(ExecutionStrategy::Auto),
+            ExecutionStrategy::Grounded
         );
         assert_eq!(
             next_sandbox_profile(SandboxProfile::Workspace),

--- a/lib/harper-ui/src/interfaces/ui/tui.rs
+++ b/lib/harper-ui/src/interfaces/ui/tui.rs
@@ -33,7 +33,8 @@ use harper_core::agent::chat::ChatService;
 use harper_core::core::io_traits::{RuntimeEventSink, UserApproval};
 use harper_core::core::ApiConfig;
 use harper_core::memory::session_service::SessionService;
-use harper_core::runtime::config::ExecPolicyConfig;
+use harper_core::runtime::config::{ExecPolicyConfig, UiConfig};
+use harper_core::ExecutionStrategy;
 use harper_core::{PlanState, ResolvedAgents, SessionStateView};
 use rusqlite::Connection;
 
@@ -51,6 +52,11 @@ pub struct TuiApproval {
 
 pub struct TuiRuntimeEvents {
     ui_tx: mpsc::Sender<UiUpdate>,
+}
+
+pub struct TuiRunOptions {
+    pub custom_commands: HashMap<String, String>,
+    pub server_base_url: Option<String>,
 }
 
 #[async_trait]
@@ -207,14 +213,35 @@ fn spawn_sidebar_gathering(chat_state: &ChatState, ui_tx: &mpsc::Sender<UiUpdate
     });
 }
 
+fn parse_strategy_command(
+    input: &str,
+    current: ExecutionStrategy,
+) -> Option<Result<ExecutionStrategy, ExecutionStrategy>> {
+    let trimmed = input.trim();
+    let command = trimmed.strip_prefix("/strategy")?;
+    let value = command.trim();
+    if value.is_empty() {
+        return Some(Err(current));
+    }
+
+    let strategy = match value.to_ascii_lowercase().as_str() {
+        "auto" => ExecutionStrategy::Auto,
+        "grounded" => ExecutionStrategy::Grounded,
+        "deterministic" => ExecutionStrategy::Deterministic,
+        "model" | "model-only" | "model_only" => ExecutionStrategy::ModelOnly,
+        _ => return Some(Err(current)),
+    };
+    Some(Ok(strategy))
+}
+
 pub async fn run_tui(
     conn: &Connection,
     api_config: &ApiConfig,
     session_service: &SessionService<'_>,
     theme: &Theme,
-    custom_commands: HashMap<String, String>,
     exec_policy: &ExecPolicyConfig,
-    server_base_url: Option<String>,
+    ui_config: &UiConfig,
+    options: TuiRunOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Set up terminal
     enable_raw_mode()?;
@@ -225,9 +252,17 @@ pub async fn run_tui(
 
     let mut app = TuiApp::new();
     app.model_label = format!("{:?} / {}", api_config.provider, api_config.model_name);
+    app.current_working_dir = std::env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_default();
     app.auth_session = auth::load_auth_session();
-    app.auth_server_base_url = server_base_url.clone();
+    app.auth_server_base_url = options.server_base_url.clone();
     app.approval_profile = exec_policy.effective_approval_profile();
+    app.execution_strategy = exec_policy.effective_execution_strategy();
+    let configured_widgets = ui_config.effective_header_widgets();
+    if !configured_widgets.is_empty() {
+        app.header_widgets = settings::parse_header_widgets(&configured_widgets);
+    }
     app.sandbox_profile = exec_policy.effective_sandbox_profile();
     app.retry_max_attempts = exec_policy.effective_retry_max_attempts();
     app.allowed_commands = exec_policy.allowed_commands.clone().unwrap_or_default();
@@ -241,7 +276,7 @@ pub async fn run_tui(
 
     // Clone data for worker
     let worker_api_config = api_config.clone();
-    let worker_custom_commands = custom_commands.clone();
+    let worker_custom_commands = options.custom_commands.clone();
     let worker_exec_policy = Arc::new(Mutex::new(exec_policy.clone()));
     let ui_exec_policy = worker_exec_policy.clone();
     let db_path = conn
@@ -413,6 +448,27 @@ pub async fn run_tui(
                         EventResult::Quit => break,
                         EventResult::SendMessage(msg) => {
                             if let AppState::Chat(chat_state) = &mut app.state {
+                                if let Some(strategy) = parse_strategy_command(&msg, app.execution_strategy) {
+                                    match strategy {
+                                        Ok(new_strategy) => {
+                                            app.execution_strategy = new_strategy;
+                                            if let Ok(mut policy) = ui_exec_policy.lock() {
+                                                policy.execution_strategy = Some(new_strategy);
+                                            }
+                                            app.set_status_message(format!(
+                                                "Execution strategy set to {}",
+                                                settings::execution_strategy_name(new_strategy)
+                                            ));
+                                        }
+                                        Err(current_only) => {
+                                            app.set_info_message(format!(
+                                                "Current execution strategy: {}",
+                                                settings::execution_strategy_name(current_only)
+                                            ));
+                                        }
+                                    }
+                                    continue;
+                                }
                                 if let Some(command) = auth::parse_tui_auth_command(&msg) {
                                     match command {
                                         auth::TuiAuthCommand::Login { provider } => {
@@ -465,6 +521,7 @@ pub async fn run_tui(
                                     role: "user".to_string(),
                                     content: msg.clone(),
                                 });
+                                chat_state.follow_latest_messages();
                                 chat_state.awaiting_response = true;
                                 chat_state.command_output = None;
                                 app.set_activity_status(Some("thinking".to_string()));
@@ -711,15 +768,20 @@ pub async fn run_tui(
                         }
                         EventResult::SaveExecutionPolicy => {
                             match settings::save_execution_policy_settings(
-                                app.approval_profile,
-                                app.sandbox_profile,
-                                app.retry_max_attempts,
-                                &app.allowed_commands,
-                                &app.blocked_commands,
+                                settings::ExecPolicySettings {
+                                    approval: app.approval_profile,
+                                    execution_strategy: app.execution_strategy,
+                                    sandbox: app.sandbox_profile,
+                                    retry_max_attempts: app.retry_max_attempts,
+                                    allowed_commands: &app.allowed_commands,
+                                    blocked_commands: &app.blocked_commands,
+                                    header_widgets: &app.header_widgets,
+                                },
                             ) {
                                 Ok(()) => {
                                     if let Ok(mut policy) = ui_exec_policy.lock() {
                                         policy.approval_profile = Some(app.approval_profile);
+                                        policy.execution_strategy = Some(app.execution_strategy);
                                         policy.sandbox_profile = Some(app.sandbox_profile);
                                         policy.allowed_commands = if app.allowed_commands.is_empty()
                                         {
@@ -919,6 +981,7 @@ pub async fn run_tui(
                             if let AppState::Chat(chat_state) = &mut app.state {
                                 if chat_state.session_id == session_view.session_id {
                                     chat_state.messages = session_view.messages;
+                                    chat_state.follow_latest_messages();
                                     chat_state.awaiting_response = false;
                                     chat_state.active_plan = session_view.plan;
                                     chat_state.active_agents = session_view.agents;

--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -25,8 +25,8 @@ use harper_core::core::plan::{PlanFollowup, PlanJobRecord, PlanJobStatus};
 use harper_core::{PlanRuntime, PlanState, PlanStepStatus, ResolvedAgents};
 
 // Refined shortcuts for a cleaner footer
-const FOOTER_SHORTCUTS: [[(&str, &str); 9]; 2] = [
-    [
+const FOOTER_SHORTCUTS: &[&[(&str, &str)]] = &[
+    &[
         ("G", "Help"),
         ("W", "Search"),
         ("B", "Sidebar"),
@@ -35,9 +35,8 @@ const FOOTER_SHORTCUTS: [[(&str, &str); 9]; 2] = [
         ("M", "Msgs"),
         ("C", "ID"),
         ("O", "Export"),
-        ("D", "Delete"),
     ],
-    [
+    &[
         ("X", "Exit"),
         ("R", "Load"),
         ("L", "Preview"),
@@ -50,70 +49,62 @@ const FOOTER_SHORTCUTS: [[(&str, &str); 9]; 2] = [
     ],
 ];
 
-use crate::plugins::syntax::highlight_code;
+use crate::plugins::syntax::highlight_code_lines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
 
-pub fn parse_content_with_code<'a>(
+enum MessageSegment {
+    Paragraph(String),
+    Heading(String),
+    StructuredLine(String),
+    CodeBlock {
+        language: Option<String>,
+        content: String,
+    },
+    Blank,
+}
+
+fn wrapped_line_count(lines: &[Line<'static>], width: u16) -> usize {
+    if width == 0 {
+        return 0;
+    }
+
+    lines
+        .iter()
+        .map(|line| {
+            let line_width = line.width();
+            if line_width == 0 {
+                1
+            } else {
+                line_width.div_ceil(width as usize)
+            }
+        })
+        .sum()
+}
+
+pub fn parse_content_with_code(
     syntax_set: &SyntaxSet,
     theme_set: &ThemeSet,
-    content: &'a str,
+    content: &str,
+    theme: &Theme,
     default_color: Color,
     syntax_theme: &str,
-) -> Vec<Span<'a>> {
-    let mut spans = Vec::new();
-    let mut remaining = content;
-
-    while let Some(start) = remaining.find("```") {
-        if start > 0 {
-            spans.push(Span::styled(
-                &remaining[..start],
-                Style::default().fg(default_color),
-            ));
-        }
-
-        let after_start = &remaining[start + 3..];
-        if let Some(end) = after_start.find("```") {
-            let code_block = &after_start[..end];
-            if let Some(newline_pos) = code_block.find('\n') {
-                let language = &code_block[..newline_pos].trim();
-                let code = &code_block[newline_pos + 1..];
-                spans.extend(highlight_code(
-                    syntax_set,
-                    theme_set,
-                    language,
-                    code,
-                    syntax_theme,
-                ));
-            } else {
-                spans.push(Span::styled(code_block, Style::default().fg(default_color)));
-            }
-            remaining = &after_start[end + 3..];
-        } else {
-            spans.push(Span::styled(
-                &remaining[start..],
-                Style::default().fg(default_color),
-            ));
-            remaining = "";
-            break;
-        }
-    }
-
-    if !remaining.is_empty() {
-        spans.push(Span::styled(remaining, Style::default().fg(default_color)));
-    }
-
-    spans
+) -> Vec<Line<'static>> {
+    render_message_segments(
+        parse_message_segments(content),
+        syntax_set,
+        theme_set,
+        theme,
+        default_color,
+        syntax_theme,
+    )
 }
 
 pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
     let area = frame.area();
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Min(0),
-            Constraint::Length(2), // Slimmer footer
-        ])
+        .constraints([Constraint::Min(0), Constraint::Length(2)])
         .split(area);
 
     let main_area = chunks[0];
@@ -125,12 +116,8 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
             let chat_area = if chat_state.sidebar_visible {
                 let chunks = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([
-                        Constraint::Percentage(20), // Slimmer sidebar
-                        Constraint::Percentage(80),
-                    ])
+                    .constraints([Constraint::Percentage(20), Constraint::Percentage(80)])
                     .split(main_area);
-
                 draw_zen_sidebar(frame, &chat_state.sidebar_entries, theme, chunks[0]);
                 chunks[1]
             } else {
@@ -168,6 +155,8 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 .as_ref()
                 .map(|review| review_panel_height(review, chat_state.review_selected))
                 .unwrap_or(0);
+            let completion_height = completion_popup_height(chat_state);
+
             let mut constraints = vec![Constraint::Length(3), Constraint::Min(5)];
             if has_review {
                 constraints.push(Constraint::Length(review_height));
@@ -182,6 +171,7 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 constraints.push(Constraint::Length(agents_height));
             }
             constraints.push(Constraint::Length(3));
+
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints(constraints)
@@ -189,51 +179,19 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
 
             draw_chat_summary(frame, app, chat_state, theme, chunks[0]);
 
-            // Messages area - Typography focused
-            let safe_scroll_offset = chat_state.scroll_offset.min(chat_state.messages.len());
-            let displayed_messages = &chat_state.messages[safe_scroll_offset..];
-            let mut message_lines: Vec<Line> = Vec::new();
-
-            for msg in displayed_messages.iter().filter(|msg| msg.role != "system") {
-                let label = match msg.role.as_str() {
-                    "user" => "User ›",
-                    "assistant" => "Harper ›",
-                    _ => "System ›",
-                };
-
-                let label_style = match msg.role.as_str() {
-                    "user" => Style::default()
-                        .fg(theme.accent)
-                        .add_modifier(Modifier::BOLD),
-                    "assistant" => Style::default()
-                        .fg(theme.title)
-                        .add_modifier(Modifier::BOLD),
-                    _ => theme.muted_style(),
-                };
-
-                message_lines.push(Line::from(vec![Span::styled(label, label_style)]));
-
-                let content_color = if msg.role == "user" {
-                    theme.foreground
-                } else {
-                    theme.output
-                };
-
-                if msg.content.contains("```") {
-                    let spans = parse_content_with_code(
-                        &theme.syntax_set,
-                        &theme.theme_set,
-                        &msg.content,
-                        content_color,
-                        &theme.syntax_theme,
-                    );
-                    message_lines.push(Line::from(spans));
-                } else {
-                    for line in msg.content.lines() {
-                        message_lines.push(Line::styled(line, content_color));
-                    }
-                }
-                message_lines.push(Line::raw("")); // Breathing room
+            let mut message_lines: Vec<Line<'static>> = Vec::new();
+            for msg in chat_state
+                .messages
+                .iter()
+                .filter(|msg| msg.role != "system")
+            {
+                append_rendered_message_lines(
+                    &mut message_lines,
+                    msg,
+                    theme,
+                    theme.input,
+                    theme.output,
+                );
             }
 
             if chat_state.awaiting_response {
@@ -258,13 +216,20 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
             }
 
             let chat_block = Block::default()
-                .borders(Borders::NONE) // No noise
+                .borders(Borders::NONE)
                 .padding(Padding::uniform(1));
-
+            let visible_line_capacity = chunks[1].height.saturating_sub(2) as usize;
+            let content_width = chunks[1].width.saturating_sub(2);
+            let total_wrapped_lines = wrapped_line_count(&message_lines, content_width);
             let messages_widget = Paragraph::new(message_lines)
                 .block(chat_block)
                 .wrap(Wrap { trim: false });
-
+            let max_scroll_offset = total_wrapped_lines.saturating_sub(visible_line_capacity);
+            let effective_scroll_offset = chat_state.scroll_offset.min(max_scroll_offset);
+            let paragraph_scroll = total_wrapped_lines
+                .saturating_sub(visible_line_capacity + effective_scroll_offset)
+                as u16;
+            let messages_widget = messages_widget.scroll((paragraph_scroll, 0));
             frame.render_widget(messages_widget, chunks[1]);
 
             let mut next_panel_index = 2;
@@ -290,7 +255,6 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 }
                 next_panel_index += 1;
             }
-
             if has_plan {
                 if let Some(plan) = &chat_state.active_plan {
                     draw_plan_panel(
@@ -329,7 +293,6 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 );
             }
 
-            // Input area - Minimalist
             let input_block = Block::default()
                 .borders(Borders::TOP)
                 .border_style(theme.muted_style())
@@ -339,7 +302,6 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 Span::styled("› ", Style::default().fg(theme.accent)),
                 Span::styled(&chat_state.input, Style::default().fg(theme.input)),
             ])];
-
             if chat_state.input.trim().is_empty() {
                 input_text.push(Line::from(Span::styled(
                     "Type a message... (Ctrl+G for help)",
@@ -348,13 +310,23 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
             }
 
             let input_widget = Paragraph::new(input_text).block(input_block);
-
             let input_index = 2
                 + usize::from(has_review)
                 + usize::from(has_command_output)
                 + usize::from(has_plan)
                 + usize::from(has_agents);
             frame.render_widget(input_widget, chunks[input_index]);
+
+            if completion_height > 0 {
+                let popup_area = Rect {
+                    x: chunks[input_index].x,
+                    y: chunks[input_index].y.saturating_sub(completion_height),
+                    width: chunks[input_index].width.min(48),
+                    height: completion_height,
+                };
+                frame.render_widget(Clear, popup_area);
+                draw_completion_popup(frame, chat_state, theme, popup_area);
+            }
         }
         AppState::Sessions(sessions, selected) => draw_sessions(
             frame,
@@ -378,7 +350,9 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
         AppState::Stats(stats) => draw_stats(frame, stats, theme, main_area),
     }
 
-    draw_zen_footer(frame, app, theme, footer_area);
+    if !matches!(app.state, AppState::Chat(_)) {
+        draw_zen_footer(frame, app, theme, footer_area);
+    }
 
     if let Some(approval) = &app.pending_approval {
         draw_approval(frame, approval, theme);
@@ -398,6 +372,549 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
     }
 }
 
+fn render_diff_lines(content: &str, theme: &Theme) -> Vec<Line<'static>> {
+    content
+        .lines()
+        .map(|line| {
+            let style = if line.starts_with("+++") || line.starts_with("---") {
+                theme.info_style().add_modifier(Modifier::BOLD)
+            } else if line.starts_with('+') {
+                Style::default().fg(theme.success)
+            } else if line.starts_with('-') {
+                Style::default().fg(theme.error)
+            } else if line.starts_with("@@") {
+                theme.accent_style().add_modifier(Modifier::BOLD)
+            } else if line.starts_with("diff --git") || line.starts_with("index ") {
+                theme.muted_style().add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.foreground)
+            };
+            Line::styled(line.to_string(), style)
+        })
+        .collect()
+}
+
+fn parse_message_segments(content: &str) -> Vec<MessageSegment> {
+    let raw_lines: Vec<&str> = content.lines().collect();
+    let mut segments = Vec::new();
+    let mut paragraph = Vec::new();
+    let mut idx = 0usize;
+
+    let flush_paragraph = |paragraph: &mut Vec<&str>, segments: &mut Vec<MessageSegment>| {
+        if paragraph.is_empty() {
+            return;
+        }
+        let text = paragraph.join("\n");
+        if !text.trim().is_empty() {
+            segments.push(MessageSegment::Paragraph(text));
+        }
+        paragraph.clear();
+    };
+
+    while idx < raw_lines.len() {
+        let raw_line = raw_lines[idx];
+        let trimmed = raw_line.trim_end();
+        let normalized = trimmed.trim();
+
+        if normalized.is_empty() {
+            flush_paragraph(&mut paragraph, &mut segments);
+            if !matches!(segments.last(), Some(MessageSegment::Blank)) {
+                segments.push(MessageSegment::Blank);
+            }
+            idx += 1;
+            continue;
+        }
+
+        if let Some(rest) = normalized.strip_prefix("```") {
+            flush_paragraph(&mut paragraph, &mut segments);
+            let language = if rest.trim().is_empty() {
+                None
+            } else {
+                Some(rest.trim().to_string())
+            };
+            let mut code_lines = Vec::new();
+            idx += 1;
+            while idx < raw_lines.len() && raw_lines[idx].trim_end() != "```" {
+                code_lines.push(raw_lines[idx].trim_end());
+                idx += 1;
+            }
+            if idx < raw_lines.len() {
+                idx += 1;
+            }
+            segments.push(MessageSegment::CodeBlock {
+                language,
+                content: code_lines.join("\n"),
+            });
+            continue;
+        }
+
+        if normalized.starts_with('#') {
+            flush_paragraph(&mut paragraph, &mut segments);
+            segments.push(MessageSegment::Heading(
+                normalized.trim_start_matches('#').trim().to_string(),
+            ));
+            idx += 1;
+            continue;
+        }
+
+        let is_structured_line = normalized.starts_with("- ")
+            || normalized.starts_with("* ")
+            || normalized.starts_with("> ")
+            || normalized
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_digit())
+                && normalized.contains(". ");
+        if is_structured_line {
+            flush_paragraph(&mut paragraph, &mut segments);
+            segments.push(MessageSegment::StructuredLine(normalized.to_string()));
+            idx += 1;
+            continue;
+        }
+
+        if let Some((language, code, consumed)) = infer_unfenced_code_lines(&raw_lines[idx..]) {
+            flush_paragraph(&mut paragraph, &mut segments);
+            segments.push(MessageSegment::CodeBlock {
+                language: Some(language.to_string()),
+                content: code,
+            });
+            idx += consumed;
+            continue;
+        }
+
+        paragraph.push(trimmed);
+        idx += 1;
+    }
+
+    flush_paragraph(&mut paragraph, &mut segments);
+    segments
+}
+
+fn render_message_segments(
+    segments: Vec<MessageSegment>,
+    syntax_set: &SyntaxSet,
+    theme_set: &ThemeSet,
+    theme: &Theme,
+    default_color: Color,
+    syntax_theme: &str,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for segment in segments {
+        match segment {
+            MessageSegment::Paragraph(text) => {
+                lines.extend(normalize_plain_message_lines(&text, default_color, theme));
+            }
+            MessageSegment::Heading(text) => {
+                lines.push(parse_inline_markdown_line(&text, default_color, true));
+            }
+            MessageSegment::StructuredLine(text) => {
+                lines.push(parse_inline_markdown_line(&text, default_color, false));
+            }
+            MessageSegment::CodeBlock { language, content } => match language.as_deref() {
+                Some(language) if language.eq_ignore_ascii_case("diff") => {
+                    lines.extend(render_diff_lines(&content, theme));
+                }
+                Some(language) => {
+                    lines.extend(highlight_code_lines(
+                        syntax_set,
+                        theme_set,
+                        language,
+                        &content,
+                        syntax_theme,
+                    ));
+                }
+                None => {
+                    lines.extend(normalize_plain_message_lines(
+                        &content,
+                        default_color,
+                        theme,
+                    ));
+                }
+            },
+            MessageSegment::Blank => lines.push(Line::raw("")),
+        }
+    }
+    lines
+}
+
+fn normalize_plain_message_lines(content: &str, color: Color, theme: &Theme) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let mut paragraph: Vec<&str> = Vec::new();
+    let raw_lines: Vec<&str> = content.lines().collect();
+
+    let flush_paragraph = |paragraph: &mut Vec<&str>, lines: &mut Vec<Line<'static>>| {
+        if paragraph.is_empty() {
+            return;
+        }
+        let normalized = paragraph.join(" ");
+        let normalized = normalized.split_whitespace().collect::<Vec<_>>().join(" ");
+        if !normalized.is_empty() {
+            if let Some((language, code)) = infer_unfenced_code_block(&normalized) {
+                lines.extend(highlight_code_lines(
+                    &theme.syntax_set,
+                    &theme.theme_set,
+                    language,
+                    code,
+                    &theme.syntax_theme,
+                ));
+            } else if let Some((prefix, language, code, suffix)) =
+                split_inline_code_paragraph(&normalized)
+            {
+                if !prefix.is_empty() {
+                    lines.push(parse_inline_markdown_line(prefix, color, false));
+                }
+                lines.extend(highlight_code_lines(
+                    &theme.syntax_set,
+                    &theme.theme_set,
+                    language,
+                    code,
+                    &theme.syntax_theme,
+                ));
+                if !suffix.is_empty() {
+                    lines.push(parse_inline_markdown_line(suffix, color, false));
+                }
+            } else {
+                lines.push(parse_inline_markdown_line(&normalized, color, false));
+            }
+        }
+        paragraph.clear();
+    };
+
+    let mut idx = 0usize;
+    while idx < raw_lines.len() {
+        let raw_line = raw_lines[idx];
+        let trimmed = raw_line.trim();
+        if trimmed.is_empty() {
+            flush_paragraph(&mut paragraph, &mut lines);
+            if !lines.is_empty() {
+                lines.push(Line::raw(""));
+            }
+            idx += 1;
+            continue;
+        }
+
+        let is_structured_line = trimmed.starts_with("- ")
+            || trimmed.starts_with("* ")
+            || trimmed.starts_with("> ")
+            || trimmed.starts_with('#')
+            || trimmed.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+                && trimmed.contains(". ");
+
+        if looks_like_code_intro(trimmed)
+            && raw_lines
+                .get(idx + 1)
+                .is_some_and(|next| infer_unfenced_code_lines(std::slice::from_ref(next)).is_some())
+        {
+            flush_paragraph(&mut paragraph, &mut lines);
+            lines.push(parse_inline_markdown_line(trimmed, color, false));
+            idx += 1;
+            continue;
+        }
+
+        if let Some((language, code, consumed)) = infer_unfenced_code_lines(&raw_lines[idx..]) {
+            flush_paragraph(&mut paragraph, &mut lines);
+            lines.extend(highlight_code_lines(
+                &theme.syntax_set,
+                &theme.theme_set,
+                language,
+                &code,
+                &theme.syntax_theme,
+            ));
+            idx += consumed;
+            continue;
+        }
+
+        if is_structured_line {
+            flush_paragraph(&mut paragraph, &mut lines);
+            lines.push(parse_inline_markdown_line(
+                trimmed,
+                color,
+                trimmed.starts_with('#'),
+            ));
+            idx += 1;
+            continue;
+        }
+
+        paragraph.push(trimmed);
+        idx += 1;
+    }
+
+    flush_paragraph(&mut paragraph, &mut lines);
+    lines
+}
+
+fn parse_inline_markdown_line(content: &str, color: Color, heading: bool) -> Line<'static> {
+    let base_style = if heading {
+        Style::default().fg(color).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(color)
+    };
+
+    let mut spans = Vec::new();
+    let mut remaining = content;
+    while !remaining.is_empty() {
+        let bold_index = remaining.find("**");
+        let code_index = remaining.find('`');
+        let next_marker = match (bold_index, code_index) {
+            (Some(bold), Some(code)) => {
+                if bold < code {
+                    Some((bold, "bold"))
+                } else {
+                    Some((code, "code"))
+                }
+            }
+            (Some(bold), None) => Some((bold, "bold")),
+            (None, Some(code)) => Some((code, "code")),
+            (None, None) => None,
+        };
+
+        let Some((index, kind)) = next_marker else {
+            if !remaining.is_empty() {
+                spans.push(Span::styled(remaining.to_string(), base_style));
+            }
+            break;
+        };
+
+        if index > 0 {
+            spans.push(Span::styled(remaining[..index].to_string(), base_style));
+        }
+
+        remaining = &remaining[index..];
+        match kind {
+            "bold" => {
+                if let Some(end) = remaining[2..].find("**") {
+                    let text = &remaining[2..2 + end];
+                    spans.push(Span::styled(
+                        text.to_string(),
+                        base_style.add_modifier(Modifier::BOLD),
+                    ));
+                    remaining = &remaining[2 + end + 2..];
+                } else {
+                    spans.push(Span::styled(remaining.to_string(), base_style));
+                    break;
+                }
+            }
+            "code" => {
+                if let Some(end) = remaining[1..].find('`') {
+                    let text = &remaining[1..1 + end];
+                    spans.push(Span::styled(
+                        text.to_string(),
+                        base_style
+                            .fg(Color::Rgb(193, 223, 173))
+                            .add_modifier(Modifier::ITALIC),
+                    ));
+                    remaining = &remaining[1 + end + 1..];
+                } else {
+                    spans.push(Span::styled(remaining.to_string(), base_style));
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+
+    Line::from(spans)
+}
+
+fn infer_unfenced_code_lines(lines: &[&str]) -> Option<(&'static str, String, usize)> {
+    let first = lines.first()?.trim_end();
+    if first.trim().is_empty() || !is_code_like_line(first.trim()) {
+        return None;
+    }
+    let language = detect_code_language(first.trim())?;
+
+    let mut collected = vec![first];
+    let mut consumed = 1usize;
+    while let Some(next) = lines.get(consumed) {
+        let trimmed = next.trim_end();
+        if trimmed.trim().is_empty() {
+            break;
+        }
+        if is_code_like_continuation(trimmed) || is_code_like_line(trimmed.trim()) {
+            collected.push(trimmed);
+            consumed += 1;
+        } else {
+            break;
+        }
+    }
+
+    Some((language, collected.join("\n"), consumed))
+}
+
+fn infer_unfenced_code_block(normalized: &str) -> Option<(&'static str, &str)> {
+    let language = detect_code_language(normalized)?;
+    if is_code_like_line(normalized) {
+        Some((language, normalized))
+    } else {
+        None
+    }
+}
+
+fn split_inline_code_paragraph(normalized: &str) -> Option<(&str, &'static str, &str, &str)> {
+    let colon = normalized.find(':')?;
+    let (prefix, after_prefix) = normalized.split_at(colon + 1);
+    if !looks_like_code_intro(prefix.trim()) {
+        return None;
+    }
+
+    let after = after_prefix.trim();
+    if let Some(rest) = after.strip_prefix("print(") {
+        let mut depth = 1i32;
+        let mut end_index = "print(".len();
+        for ch in rest.chars() {
+            end_index += ch.len_utf8();
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        let code = &after[..end_index];
+                        let suffix = after[end_index..].trim_start();
+                        return Some((prefix.trim_end(), "py", code, suffix));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    None
+}
+
+fn looks_like_code_intro(line: &str) -> bool {
+    let lower = line.trim().to_ascii_lowercase();
+    lower.starts_with("here is")
+        || lower.contains("script:")
+        || lower.contains("code:")
+        || lower.contains("command:")
+}
+
+fn is_code_like_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with("fn ")
+        || trimmed.starts_with("pub fn ")
+        || trimmed.starts_with("def ")
+        || trimmed.starts_with("class ")
+        || trimmed.starts_with("import ")
+        || trimmed.starts_with("from ")
+        || trimmed.starts_with("use ")
+        || trimmed.starts_with("struct ")
+        || trimmed.starts_with("enum ")
+        || trimmed.starts_with("trait ")
+        || trimmed.starts_with("impl ")
+        || trimmed.starts_with("let ")
+        || trimmed.starts_with("const ")
+        || trimmed.starts_with("async fn ")
+        || trimmed.starts_with("#!/bin/")
+        || trimmed.starts_with("print(")
+        || trimmed.starts_with('{')
+        || trimmed.starts_with('[')
+        || trimmed.contains(" = ")
+        || trimmed.ends_with('{')
+}
+
+fn is_code_like_continuation(line: &str) -> bool {
+    let trimmed = line.trim();
+    line.starts_with(' ')
+        || line.starts_with('\t')
+        || trimmed.starts_with('}')
+        || trimmed.starts_with(')')
+        || trimmed.starts_with("else")
+        || trimmed.starts_with("elif")
+        || trimmed.starts_with("return ")
+        || trimmed.starts_with("println!(")
+        || trimmed.starts_with("print(")
+}
+
+fn detect_code_language(content: &str) -> Option<&'static str> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.starts_with("diff --git")
+        || trimmed.starts_with("@@")
+        || trimmed.contains("\n@@ ")
+        || (trimmed.starts_with('+') || trimmed.starts_with('-')) && trimmed.lines().count() > 1
+    {
+        return Some("diff");
+    }
+    if trimmed.starts_with("fn ")
+        || trimmed.starts_with("pub fn ")
+        || trimmed.starts_with("use ")
+        || trimmed.starts_with("struct ")
+        || trimmed.starts_with("enum ")
+        || trimmed.starts_with("trait ")
+        || trimmed.starts_with("impl ")
+        || trimmed.contains("println!(")
+    {
+        return Some("rs");
+    }
+    if trimmed.starts_with("def ")
+        || trimmed.starts_with("class ")
+        || trimmed.starts_with("import ")
+        || trimmed.starts_with("from ")
+        || trimmed.starts_with("print(")
+    {
+        return Some("py");
+    }
+    if trimmed.starts_with("#!/bin/")
+        || trimmed.starts_with("echo ")
+        || trimmed.starts_with("cargo ")
+        || trimmed.starts_with("git ")
+        || trimmed.starts_with("cd ")
+    {
+        return Some("sh");
+    }
+    if trimmed.starts_with('[') && trimmed.contains(']') || trimmed.contains(" = ") {
+        return Some("toml");
+    }
+    if (trimmed.starts_with('{') && trimmed.ends_with('}'))
+        || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+    {
+        return Some("json");
+    }
+    None
+}
+
+fn append_rendered_message_lines(
+    message_lines: &mut Vec<Line<'static>>,
+    msg: &harper_core::core::Message,
+    theme: &Theme,
+    user_color: Color,
+    assistant_color: Color,
+) {
+    let label = match msg.role.as_str() {
+        "user" => "User ›",
+        "assistant" => "Harper ›",
+        _ => "System ›",
+    };
+    let label_style = match msg.role.as_str() {
+        "user" => Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD),
+        "assistant" => Style::default()
+            .fg(theme.title)
+            .add_modifier(Modifier::BOLD),
+        _ => theme.muted_style(),
+    };
+    let default_color = if msg.role == "user" {
+        user_color
+    } else {
+        assistant_color
+    };
+
+    message_lines.push(Line::from(vec![Span::styled(label, label_style)]));
+    message_lines.extend(parse_content_with_code(
+        &theme.syntax_set,
+        &theme.theme_set,
+        &msg.content,
+        theme,
+        default_color,
+        &theme.syntax_theme,
+    ));
+    message_lines.push(Line::raw(""));
+}
+
 fn review_panel_height(review: &ReviewState, selected: usize) -> u16 {
     let findings = review.findings.len().min(3);
     let model_line = usize::from(review.model.is_some());
@@ -407,6 +924,16 @@ fn review_panel_height(review: &ReviewState, selected: usize) -> u16 {
         .map(|finding| 2 + finding.message.lines().count().min(3))
         .unwrap_or(0);
     (findings + model_line + detail_lines + 4) as u16
+}
+
+fn header_widget_enabled(app: &TuiApp, widget: super::app::HeaderWidget) -> bool {
+    app.header_widgets.contains(&widget)
+}
+
+fn push_header_separator(spans: &mut Vec<Span<'static>>, _theme: &Theme) {
+    if !spans.is_empty() {
+        spans.push(Span::raw("  "));
+    }
 }
 
 fn draw_chat_summary(
@@ -452,9 +979,9 @@ fn draw_chat_summary(
             format!("agents: {} sections", agents.effective_rule_sections.len())
         });
     let web_status = if chat_state.web_search_enabled {
-        "web: on"
+        "web: on".to_string()
     } else {
-        "web: off"
+        "web: off".to_string()
     };
     let auth_status = app.auth_status_label();
     let focus_status = format!("focus: {}", chat_state.navigation_focus_label());
@@ -463,72 +990,109 @@ fn draw_chat_summary(
     } else {
         Some(format!("model: {}", app.model_label))
     };
+    let cwd_status = if app.current_working_dir.is_empty() {
+        None
+    } else {
+        Some(format!("cwd: {}", app.current_working_dir))
+    };
+    let strategy_status = format!(
+        "strategy: {}",
+        settings::execution_strategy_name(app.execution_strategy)
+    );
     let approval_status = if app.pending_approval.is_some() {
-        Some("approval: pending")
+        Some("approval: pending".to_string())
     } else {
         None
     };
     let activity_status = app.activity_status.as_ref().map(|status| {
-        let spinner = activity_spinner_frame(app);
         format!(
             "activity: {} {}",
-            spinner,
+            activity_spinner_frame(app),
             truncate_chat_summary(status, 32)
         )
     });
-    let agents_panel_status = if chat_state.agents_panel_expanded {
-        Some("agents panel: open")
-    } else {
-        None
-    };
     let last_action = latest_action_summary(app, chat_state);
     let last_rule_source = latest_rule_source(chat_state);
 
-    let mut spans = vec![
-        Span::styled("session ", theme.muted_style()),
-        Span::styled(
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    if header_widget_enabled(app, super::app::HeaderWidget::Session) {
+        spans.push(Span::styled("session ", theme.muted_style()));
+        spans.push(Span::styled(
             truncate_chat_summary(&chat_state.session_id, 12),
             Style::default()
                 .fg(theme.foreground)
                 .add_modifier(Modifier::BOLD),
-        ),
-        Span::raw("  "),
-        Span::styled(plan_status, theme.muted_style()),
-        Span::raw("  "),
-        Span::styled(agents_status, theme.muted_style()),
-        Span::raw("  "),
-        Span::styled(web_status, theme.muted_style()),
-        Span::raw("  "),
-        Span::styled(auth_status, theme.muted_style()),
-        Span::raw("  "),
-        Span::styled(focus_status, theme.muted_style()),
-    ];
-    if let Some(status) = approval_status {
-        spans.push(Span::raw("  "));
+        ));
+    }
+    if header_widget_enabled(app, super::app::HeaderWidget::Plan) {
+        push_header_separator(&mut spans, theme);
+        spans.push(Span::styled(plan_status, theme.muted_style()));
+    }
+    if header_widget_enabled(app, super::app::HeaderWidget::Agents) {
+        push_header_separator(&mut spans, theme);
+        spans.push(Span::styled(agents_status, theme.muted_style()));
+    }
+    if header_widget_enabled(app, super::app::HeaderWidget::Web) {
+        push_header_separator(&mut spans, theme);
+        spans.push(Span::styled(web_status, theme.muted_style()));
+    }
+    if header_widget_enabled(app, super::app::HeaderWidget::Auth) {
+        push_header_separator(&mut spans, theme);
+        spans.push(Span::styled(auth_status, theme.muted_style()));
+    }
+    if header_widget_enabled(app, super::app::HeaderWidget::Focus) {
+        push_header_separator(&mut spans, theme);
+        spans.push(Span::styled(focus_status, theme.muted_style()));
+    }
+    if header_widget_enabled(app, super::app::HeaderWidget::Model) {
+        if let Some(status) = model_status {
+            push_header_separator(&mut spans, theme);
+            spans.push(Span::styled(
+                status,
+                Style::default()
+                    .fg(theme.foreground)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+    }
+    if header_widget_enabled(app, super::app::HeaderWidget::Cwd) {
+        if let Some(status) = cwd_status {
+            push_header_separator(&mut spans, theme);
+            spans.push(Span::styled(status, theme.muted_style()));
+        }
+    }
+    if header_widget_enabled(app, super::app::HeaderWidget::Strategy) {
+        push_header_separator(&mut spans, theme);
         spans.push(Span::styled(
-            status,
+            strategy_status,
             Style::default()
                 .fg(theme.accent)
                 .add_modifier(Modifier::BOLD),
         ));
     }
-    if let Some(status) = activity_status {
-        spans.push(Span::raw("  "));
-        spans.push(Span::styled(
-            status,
-            Style::default()
-                .fg(theme.output)
-                .add_modifier(Modifier::BOLD),
-        ));
+    if header_widget_enabled(app, super::app::HeaderWidget::Approval) {
+        if let Some(status) = approval_status {
+            push_header_separator(&mut spans, theme);
+            spans.push(Span::styled(
+                status,
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
     }
-    if let Some(status) = model_status {
-        spans.push(Span::raw("  "));
-        spans.push(Span::styled(status, theme.muted_style()));
+    if header_widget_enabled(app, super::app::HeaderWidget::Activity) {
+        if let Some(status) = activity_status {
+            push_header_separator(&mut spans, theme);
+            spans.push(Span::styled(
+                status,
+                Style::default()
+                    .fg(theme.output)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
     }
-    if let Some(status) = agents_panel_status {
-        spans.push(Span::raw("  "));
-        spans.push(Span::styled(status, theme.muted_style()));
-    }
+
     let line = Line::from(spans);
     let mut detail_spans = Vec::new();
     if let Some(action) = last_action {
@@ -657,6 +1221,46 @@ fn plan_panel_height(plan: &PlanState) -> u16 {
     lines as u16
 }
 
+fn completion_popup_height(chat_state: &super::app::ChatState) -> u16 {
+    if chat_state.input.starts_with('/') && !chat_state.completion_candidates.is_empty() {
+        (chat_state.completion_candidates.len().min(4) as u16) + 2
+    } else {
+        0
+    }
+}
+
+fn draw_completion_popup(
+    frame: &mut Frame,
+    chat_state: &super::app::ChatState,
+    theme: &Theme,
+    area: Rect,
+) {
+    let items = chat_state
+        .completion_candidates
+        .iter()
+        .take(4)
+        .map(|candidate| {
+            let style = if candidate == &chat_state.input {
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.foreground)
+            };
+            ListItem::new(candidate.clone()).style(style)
+        })
+        .collect::<Vec<_>>();
+
+    let widget = List::new(items).block(
+        Block::default()
+            .title(" Slash Commands ")
+            .borders(Borders::TOP)
+            .border_style(theme.muted_style())
+            .padding(Padding::horizontal(1)),
+    );
+    frame.render_widget(widget, area);
+}
+
 fn command_output_panel_height(output: &CommandOutputState) -> u16 {
     let line_count = output.content.lines().count().clamp(1, 5);
     (line_count + 3) as u16
@@ -684,15 +1288,32 @@ fn draw_command_output_panel(
     } else {
         output.content.trim_end()
     };
-    for line in content
-        .lines()
-        .rev()
-        .take(4)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-    {
-        lines.push(Line::styled(line.to_string(), Style::default().fg(color)));
+    if let Some(language) = detect_command_output_language(&output.command, content) {
+        let code = strip_command_output_prefix(content);
+        let highlighted = if language == "diff" {
+            render_diff_lines(code, theme)
+        } else {
+            highlight_code_lines(
+                &theme.syntax_set,
+                &theme.theme_set,
+                language,
+                code,
+                &theme.syntax_theme,
+            )
+        };
+        let window = highlighted.len().saturating_sub(4);
+        lines.extend(highlighted.into_iter().skip(window));
+    } else {
+        for line in content
+            .lines()
+            .rev()
+            .take(4)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+        {
+            lines.push(Line::styled(line.to_string(), Style::default().fg(color)));
+        }
     }
     let block = Block::default()
         .title(title)
@@ -701,6 +1322,50 @@ fn draw_command_output_panel(
         .padding(Padding::horizontal(1));
     let widget = Paragraph::new(lines).block(block).wrap(Wrap { trim: true });
     frame.render_widget(widget, area);
+}
+
+fn detect_command_output_language(command: &str, content: &str) -> Option<&'static str> {
+    let normalized_command = command.to_ascii_lowercase();
+    if normalized_command.contains("git diff")
+        || content.starts_with("Git diff:\n")
+        || content.contains("diff --git ")
+        || content.contains("\n@@ ")
+    {
+        return Some("diff");
+    }
+
+    if normalized_command.starts_with("cat ") || normalized_command.contains(" read_file ") {
+        if normalized_command.ends_with(".rs") {
+            return Some("rs");
+        }
+        if normalized_command.ends_with(".toml") {
+            return Some("toml");
+        }
+        if normalized_command.ends_with(".py") {
+            return Some("py");
+        }
+        if normalized_command.ends_with(".ts") {
+            return Some("ts");
+        }
+        if normalized_command.ends_with(".js") {
+            return Some("js");
+        }
+        if normalized_command.ends_with(".json") {
+            return Some("json");
+        }
+        if normalized_command.ends_with(".md") {
+            return Some("md");
+        }
+        if normalized_command.ends_with(".sh") {
+            return Some("sh");
+        }
+    }
+
+    detect_code_language(content)
+}
+
+fn strip_command_output_prefix(content: &str) -> &str {
+    content.strip_prefix("Git diff:\n").unwrap_or(content)
 }
 
 fn draw_review_panel(
@@ -1327,7 +1992,11 @@ fn draw_zen_footer(frame: &mut Frame, _app: &TuiApp, theme: &Theme, area: Rect) 
     let area = block.inner(area);
     frame.render_widget(block, frame.area()); // Render border on full area
 
-    let num_cols = FOOTER_SHORTCUTS[0].len().max(1) as u16;
+    let num_cols = FOOTER_SHORTCUTS
+        .iter()
+        .map(|row| row.len())
+        .max()
+        .unwrap_or(1) as u16;
     let col_width = (area.width / num_cols).max(1);
     for (row_idx, row) in FOOTER_SHORTCUTS.iter().enumerate() {
         for (col_idx, (key, label)) in row.iter().enumerate() {
@@ -1595,10 +2264,18 @@ fn draw_execution_policy(
             settings::approval_profile_name(app.approval_profile)
         ),
         format!(
+            "Execution Strategy: {}",
+            settings::execution_strategy_name(app.execution_strategy)
+        ),
+        format!(
             "Sandbox Profile: {}",
             settings::sandbox_profile_name(app.sandbox_profile)
         ),
         format!("Retry Attempts: {}", app.retry_max_attempts),
+        format!(
+            "Header Widgets: {}",
+            settings::header_widgets_summary(&app.header_widgets)
+        ),
         format!("Allowed Commands: {allowed}"),
         format!("Blocked Commands: {blocked}"),
         "Save and Apply".to_string(),
@@ -1624,11 +2301,15 @@ fn draw_execution_policy(
             theme.muted_style(),
         ),
         Line::styled(
+            "Execution strategy controls model-first vs deterministic command/tool routing.",
+            theme.muted_style(),
+        ),
+        Line::styled(
             "Sandbox profiles control workspace/network restrictions for command execution.",
             theme.muted_style(),
         ),
         Line::styled(
-            "Saved values are written to config/local.toml and apply to future commands in this TUI session.",
+            "Saved values are written to config/local.toml and apply to future commands and header rendering.",
             theme.muted_style(),
         ),
         Line::styled(
@@ -1651,7 +2332,7 @@ fn draw_execution_policy(
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(11),
+            Constraint::Length(12),
             Constraint::Min(8),
             Constraint::Length(editor_height),
         ])
@@ -1668,6 +2349,9 @@ fn draw_execution_policy(
     );
     if let Some(editor) = &app.execution_policy_editor {
         let label = match editor.field {
+            super::app::ExecutionPolicyListField::HeaderWidgets => {
+                "Edit Header Widgets (comma-separated)"
+            }
             super::app::ExecutionPolicyListField::AllowedCommands => {
                 "Edit Allowed Commands (comma-separated)"
             }
@@ -1811,41 +2495,7 @@ fn draw_view_session(
     let displayed_messages = &messages[safe_scroll_offset..];
     let mut message_lines: Vec<Line> = Vec::new();
     for msg in displayed_messages.iter().filter(|msg| msg.role != "system") {
-        let label = match msg.role.as_str() {
-            "user" => "User ›",
-            "assistant" => "Harper ›",
-            _ => "System ›",
-        };
-        let label_style = match msg.role.as_str() {
-            "user" => Style::default()
-                .fg(theme.accent)
-                .add_modifier(Modifier::BOLD),
-            "assistant" => Style::default()
-                .fg(theme.title)
-                .add_modifier(Modifier::BOLD),
-            _ => theme.muted_style(),
-        };
-        message_lines.push(Line::from(vec![Span::styled(label, label_style)]));
-        let default_color = if msg.role == "user" {
-            theme.input
-        } else {
-            theme.output
-        };
-        if msg.content.contains("```") {
-            let spans = parse_content_with_code(
-                &theme.syntax_set,
-                &theme.theme_set,
-                &msg.content,
-                default_color,
-                &theme.syntax_theme,
-            );
-            message_lines.push(Line::from(spans));
-        } else {
-            for line in msg.content.lines() {
-                message_lines.push(Line::styled(line, default_color));
-            }
-        }
-        message_lines.push(Line::raw(""));
+        append_rendered_message_lines(&mut message_lines, msg, theme, theme.input, theme.output);
     }
 
     let view = Paragraph::new(message_lines)
@@ -2162,14 +2812,170 @@ mod tests {
     #[test]
     fn test_parse_content_with_code_no_code() {
         let (syntax_set, theme_set) = setup();
-        let spans = parse_content_with_code(
+        let lines = parse_content_with_code(
             &syntax_set,
             &theme_set,
             "Hello",
+            &Theme::default(),
             Color::White,
             "base16-ocean.dark",
         );
-        assert_eq!(spans.len(), 1);
+        assert_eq!(lines.len(), 1);
+    }
+
+    #[test]
+    fn parse_content_with_code_preserves_fenced_diff_lines() {
+        let (syntax_set, theme_set) = setup();
+        let lines = parse_content_with_code(
+            &syntax_set,
+            &theme_set,
+            "Git diff:\n```diff\ndiff --git a/foo.rs b/foo.rs\n@@ -1 +1 @@\n-old\n+new\n```",
+            &Theme::default(),
+            Color::White,
+            "base16-ocean.dark",
+        );
+
+        assert!(lines.len() >= 5);
+        assert_eq!(lines[0].spans[0].content.as_ref(), "Git diff:");
+        assert!(lines.iter().any(|line| {
+            line.spans.iter().any(|span| {
+                span.content
+                    .as_ref()
+                    .contains("diff --git a/foo.rs b/foo.rs")
+            })
+        }));
+        assert!(lines.iter().filter(|line| !line.spans.is_empty()).count() >= 4);
+        let theme = Theme::default();
+        assert!(lines.iter().any(|line| {
+            line.to_string().contains("diff --git a/foo.rs b/foo.rs")
+                && line.style.fg == Some(theme.muted)
+        }));
+        assert!(lines.iter().any(|line| {
+            line.to_string().contains("@@ -1 +1 @@") && line.style.fg == Some(theme.accent)
+        }));
+        assert!(lines.iter().any(|line| {
+            line.to_string().contains("-old") && line.style.fg == Some(theme.error)
+        }));
+        assert!(lines.iter().any(|line| {
+            line.to_string().contains("+new") && line.style.fg == Some(theme.success)
+        }));
+    }
+
+    #[test]
+    fn normalize_plain_message_lines_reflows_wrapped_prose() {
+        let theme = Theme::default();
+        let lines = normalize_plain_message_lines(
+            "I am a large language model.\nI do not have direct access to repositories.\n\nBut I can explain general behavior.",
+            Color::White,
+            &theme,
+        );
+
+        assert_eq!(lines.len(), 3);
+        assert_eq!(
+            lines[0].spans[0].content.as_ref(),
+            "I am a large language model. I do not have direct access to repositories."
+        );
+        assert!(lines[1].spans.is_empty());
+        assert_eq!(
+            lines[2].spans[0].content.as_ref(),
+            "But I can explain general behavior."
+        );
+    }
+
+    #[test]
+    fn normalize_plain_message_lines_preserves_structured_lines() {
+        let theme = Theme::default();
+        let lines = normalize_plain_message_lines(
+            "- first item\n- second item\n\n1. numbered item",
+            Color::White,
+            &theme,
+        );
+
+        assert_eq!(lines[0].spans[0].content.as_ref(), "- first item");
+        assert_eq!(lines[1].spans[0].content.as_ref(), "- second item");
+        assert_eq!(lines[3].spans[0].content.as_ref(), "1. numbered item");
+    }
+
+    #[test]
+    fn parse_inline_markdown_line_strips_bold_markers() {
+        let line = parse_inline_markdown_line("Hello **world**", Color::White, false);
+
+        assert_eq!(line.to_string(), "Hello world");
+        assert_eq!(line.spans.len(), 2);
+        assert!(line.spans[1].style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn parse_inline_markdown_line_strips_code_markers() {
+        let line = parse_inline_markdown_line("Use `cargo test` now", Color::White, false);
+
+        assert_eq!(line.to_string(), "Use cargo test now");
+        assert_eq!(line.spans.len(), 3);
+        assert!(line.spans[1].style.add_modifier.contains(Modifier::ITALIC));
+    }
+
+    #[test]
+    fn normalize_plain_message_lines_highlights_unfenced_python_code() {
+        let theme = Theme::default();
+        let lines = normalize_plain_message_lines("print(\"Hello Joy\")", Color::White, &theme);
+
+        assert!(!lines.is_empty());
+        assert_eq!(lines[0].to_string(), "print(\"Hello Joy\")");
+    }
+
+    #[test]
+    fn normalize_plain_message_lines_preserves_multiline_unfenced_python_code() {
+        let theme = Theme::default();
+        let lines = normalize_plain_message_lines(
+            "def greet():\n    print(\"Hello Joy\")\n\ngreet()",
+            Color::White,
+            &theme,
+        );
+
+        assert!(lines.len() >= 3);
+        assert!(lines
+            .iter()
+            .any(|line| line.to_string().contains("def greet():")));
+        assert!(lines
+            .iter()
+            .any(|line| line.to_string().contains("print(\"Hello Joy\")")));
+        assert!(lines
+            .iter()
+            .any(|line| line.to_string().contains("greet()")));
+    }
+
+    #[test]
+    fn normalize_plain_message_lines_handles_intro_followed_by_code_block() {
+        let theme = Theme::default();
+        let lines = normalize_plain_message_lines(
+            "Here is the Python script:\ndef greet():\n    print(\"Hello Joy\")",
+            Color::White,
+            &theme,
+        );
+
+        assert!(lines.len() >= 3);
+        assert_eq!(lines[0].to_string(), "Here is the Python script:");
+        assert!(lines
+            .iter()
+            .any(|line| line.to_string().contains("def greet():")));
+        assert!(lines
+            .iter()
+            .any(|line| line.to_string().contains("print(\"Hello Joy\")")));
+    }
+
+    #[test]
+    fn normalize_plain_message_lines_splits_inline_code_paragraph() {
+        let theme = Theme::default();
+        let lines = normalize_plain_message_lines(
+            "Here is the Python script: print(\"Hello Joy\") Save this content into hello_joy.py",
+            Color::White,
+            &theme,
+        );
+
+        assert!(lines.len() >= 3);
+        assert!(lines[0].to_string().contains("Here is the Python script"));
+        assert_eq!(lines[1].to_string(), "print(\"Hello Joy\")");
+        assert!(lines[2].to_string().contains("Save this content"));
     }
 
     #[test]
@@ -2207,6 +3013,7 @@ mod tests {
                     },
                 ],
                 followup: None,
+                authoring: None,
             }),
             updated_at: None,
         };
@@ -2260,6 +3067,7 @@ mod tests {
                 },
             ],
             followup: None,
+            authoring: None,
         };
 
         let lines = plan_job_lines(&runtime, 0, true, &Theme::default());
@@ -2346,5 +3154,24 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert!(lines[0].to_string().contains("checkpoint pending"));
         assert!(lines[1].to_string().contains("next step: Patch handler"));
+    }
+
+    #[test]
+    fn detect_command_output_language_identifies_git_diff() {
+        let command = "git diff -- lib/harper-core/src/agent/chat.rs";
+        let content = "Git diff:\ndiff --git a/file.rs b/file.rs\n@@ -1 +1 @@\n-old\n+new\n";
+
+        assert_eq!(
+            detect_command_output_language(command, content),
+            Some("diff")
+        );
+    }
+
+    #[test]
+    fn detect_command_output_language_falls_back_to_content_shape() {
+        let command = "show output";
+        let content = "def greet():\n    print(\"Hello Joy\")";
+
+        assert_eq!(detect_command_output_language(command, content), Some("py"));
     }
 }

--- a/lib/harper-ui/src/main.rs
+++ b/lib/harper-ui/src/main.rs
@@ -305,9 +305,12 @@ async fn main() -> Result<(), HarperError> {
             &api_config,
             &session_service,
             &theme,
-            custom_commands.clone(),
             &exec_policy,
-            server_base_url,
+            &config.ui,
+            harper_ui::interfaces::ui::tui::TuiRunOptions {
+                custom_commands: custom_commands.clone(),
+                server_base_url,
+            },
         )
         .await
         .is_ok()

--- a/lib/harper-ui/src/plugins/syntax/mod.rs
+++ b/lib/harper-ui/src/plugins/syntax/mod.rs
@@ -19,7 +19,7 @@
 // documented in deny.toml and CI configuration.
 
 use ratatui::style::{Color, Style};
-use ratatui::text::Span;
+use ratatui::text::{Line, Span};
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{Style as SynStyle, ThemeSet};
 use syntect::parsing::SyntaxSet;
@@ -32,9 +32,7 @@ pub fn highlight_code(
     code: &str,
     theme_name: &str,
 ) -> Vec<Span<'static>> {
-    let syntax = syntax_set
-        .find_syntax_by_extension(language)
-        .unwrap_or_else(|| syntax_set.find_syntax_plain_text());
+    let syntax = resolve_syntax(syntax_set, language);
 
     let theme = theme_set
         .themes
@@ -58,6 +56,49 @@ pub fn highlight_code(
                 .collect::<Vec<Span>>()
         })
         .collect()
+}
+
+pub fn highlight_code_lines(
+    syntax_set: &SyntaxSet,
+    theme_set: &ThemeSet,
+    language: &str,
+    code: &str,
+    theme_name: &str,
+) -> Vec<Line<'static>> {
+    let syntax = resolve_syntax(syntax_set, language);
+    let theme = theme_set
+        .themes
+        .get(theme_name)
+        .or_else(|| theme_set.themes.get("base16-ocean.dark"))
+        .expect("Could not find the requested theme or the default 'base16-ocean.dark' theme.");
+    let mut highlighter = HighlightLines::new(syntax, theme);
+
+    LinesWithEndings::from(code)
+        .map(|line| {
+            let ranges: Vec<(SynStyle, &str)> = highlighter
+                .highlight_line(line, syntax_set)
+                .unwrap_or_default();
+            let spans = ranges
+                .into_iter()
+                .map(|(style, text)| {
+                    let color = syntect_to_ratatui_color(style.foreground);
+                    Span::styled(text.to_string(), Style::default().fg(color))
+                })
+                .collect::<Vec<_>>();
+            Line::from(spans)
+        })
+        .collect()
+}
+
+fn resolve_syntax<'a>(
+    syntax_set: &'a SyntaxSet,
+    language: &str,
+) -> &'a syntect::parsing::SyntaxReference {
+    syntax_set
+        .find_syntax_by_extension(language)
+        .or_else(|| syntax_set.find_syntax_by_token(language))
+        .or_else(|| syntax_set.find_syntax_by_name(language))
+        .unwrap_or_else(|| syntax_set.find_syntax_plain_text())
 }
 
 fn syntect_to_ratatui_color(color: syntect::highlighting::Color) -> Color {

--- a/tests/command_log_test.rs
+++ b/tests/command_log_test.rs
@@ -41,6 +41,7 @@ async fn test_command_logging() {
 
     let exec_policy = ExecPolicyConfig {
         approval_profile: None,
+        execution_strategy: None,
         allowed_commands: Some(vec!["echo".to_string()]),
         blocked_commands: None,
         sandbox_profile: None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -890,6 +890,7 @@ Full output:
         // Create exec policy
         let exec_policy = ExecPolicyConfig {
             approval_profile: None,
+            execution_strategy: None,
             allowed_commands: None,
             blocked_commands: None,
             sandbox_profile: None,
@@ -976,12 +977,14 @@ Full output:
     #[test]
     fn test_syntax_highlighting_parsing() {
         use harper_workspace::interfaces::ui::widgets::parse_content_with_code;
+        use harper_workspace::interfaces::ui::Theme;
         use ratatui::style::Color;
         use syntect::highlighting::ThemeSet;
         use syntect::parsing::SyntaxSet;
 
         let syntax_set = SyntaxSet::load_defaults_newlines();
         let theme_set = ThemeSet::load_defaults();
+        let theme = Theme::default();
 
         // Test parsing content with code blocks
         let content = "Here is some Rust code:\n```rust\nfn main() {\n    println!(\"Hello!\");\n}\n```\nAnd that's it.";
@@ -989,6 +992,7 @@ Full output:
             &syntax_set,
             &theme_set,
             content,
+            &theme,
             Color::White,
             "base16-ocean.dark",
         );
@@ -996,8 +1000,8 @@ Full output:
         // Should have spans: plain text, highlighted code, plain text
         assert!(spans.len() >= 3, "Should have multiple spans");
 
-        // Check that some spans have different styles (indicating highlighting)
-        let has_highlighted = spans.iter().any(|span| span.style.fg != Some(Color::White));
+        // Check that some rendered lines have different styles (indicating highlighting)
+        let has_highlighted = spans.iter().any(|line| line.style.fg != Some(Color::White));
         assert!(has_highlighted, "Should have highlighted spans");
 
         // Test with multiple code blocks
@@ -1007,6 +1011,7 @@ Full output:
             &syntax_set,
             &theme_set,
             content_multi,
+            &theme,
             Color::White,
             "base16-ocean.dark",
         );
@@ -1015,10 +1020,14 @@ Full output:
             spans_multi.len() >= 3,
             "Should have at least 3 spans for multiple code blocks"
         );
-        // Note: reconstructed content excludes markdown markers (```) as they are not rendered
-        // Check that some spans are highlighted (not white) and some are plain (white)
-        let has_highlighted = spans_multi.iter().any(|s| s.style.fg != Some(Color::White));
-        let has_plain = spans_multi.iter().any(|s| s.style.fg == Some(Color::White));
+        // Note: reconstructed content excludes markdown markers (```) as they are not rendered.
+        // Check that some rendered lines are highlighted and that the plain text line is preserved.
+        let has_highlighted = spans_multi
+            .iter()
+            .any(|line| line.style.fg != Some(Color::White));
+        let has_plain = spans_multi
+            .iter()
+            .any(|line| line.to_string().contains("And"));
         assert!(has_highlighted, "Should have at least one highlighted span");
         assert!(has_plain, "Should have at least one plain text span");
 
@@ -1028,10 +1037,16 @@ Full output:
             &syntax_set,
             &theme_set,
             content_plain,
+            &theme,
             Color::White,
             "base16-ocean.dark",
         );
         assert_eq!(spans_plain.len(), 1, "Plain text should have one span");
-        assert_eq!(spans_plain[0].content, content_plain);
+        let reconstructed = spans_plain[0]
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert_eq!(reconstructed, content_plain);
     }
 }

--- a/website/blog.html
+++ b/website/blog.html
@@ -53,6 +53,13 @@
                     <p>The product implication is straightforward: once plan state is real, the UI can show what is pending, what is active, and what just changed. It also means future automation can attach tool execution and job status to actual steps instead of relying on the model to narrate everything correctly.</p>
                 </article>
 
+
+                <article>
+                    <h2>April 2026 · Execution strategy became explicit</h2>
+                    <p>Harper now exposes execution strategy directly in the TUI and local config. The point is not to turn the product into a classical deterministic router; the point is to make the tradeoff explicit. <code>auto</code> and <code>grounded</code> keep the model in the loop for normal repo work, while <code>deterministic</code> provides a stricter direct-tool mode for smoke checks and operational prompts.</p>
+                    <p>This also cleaned up a real failure mode in local-model sessions. Instead of letting weaker models either invent shell commands or refuse valid repo actions, Harper now feeds grounded repo context into the model first and only falls back to deterministic execution when the model response is empty, low-value, or invalid.</p>
+                </article>
+
                 <article>
                     <h2>April 2026 · <code>AGENTS.md</code> stopped being a flat append</h2>
                     <p>Earlier builds treated <code>AGENTS.md</code> as one static block of prompt text. Harper now resolves applicable files from repo root down to the target path, merges rules with deeper precedence, and keeps both the raw sources and the effective rendered view available to the UI and API.</p>

--- a/website/installation.html
+++ b/website/installation.html
@@ -67,12 +67,18 @@ SUPABASE_ALLOWED_PROVIDERS=github</code></pre>
                 <p>Harper accepts slash commands directly in the chat input. Start a conversation, place focus in the message box, type <code>/</code>, and then enter a command just like a normal message.</p>
                 <div class="code-wrapper">
                     <pre><code>/help
+/strategy
+/strategy auto
+/strategy grounded
+/strategy deterministic
+/strategy model
 /auth login github
 /auth status
 /auth logout</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <p>For auth commands, <code>/auth login github</code> opens the browser, Harper polls the local server for completion, and <code>/auth status</code> reports the currently stored local TUI session.</p>
+                <p><code>/strategy</code> shows the current execution strategy. Use <code>/strategy auto</code>, <code>/strategy grounded</code>, <code>/strategy deterministic</code>, or <code>/strategy model</code> to switch the live chat session without leaving the conversation.</p>
                 <p>When sign-in succeeds, Harper stores the local TUI auth session in the OS credential store (macOS Keychain, Linux keyring, or Windows Credential Manager) instead of writing the active tokens to a JSON file under your home directory.</p>
                 <p>Harper also exposes the same auth state through <code>Settings -&gt; Profile</code>. When signed out, that screen offers login actions for the configured providers. When signed in, it shows the current account, plus <code>Logout</code> and <code>Refresh Session</code>.</p>
                 <p>When you are signed in, Harper scopes session data to that account. <code>History</code>, <code>Export</code>, and <code>Statistics</code> all reflect the signed-in user only. When you are not signed in, those screens continue to use local-only data.</p>
@@ -81,14 +87,19 @@ SUPABASE_ALLOWED_PROVIDERS=github</code></pre>
                 <p>Empty states are explicit now: if the signed-in user has no remote sessions, <code>History</code> says so directly; if there are no exportable sessions, <code>Export</code> shows that state instead of a blank panel.</p>
 
                 <h2>Execution Policy in Settings</h2>
-                <p>Harper now exposes execution policy selection directly in the TUI under <code>Settings -&gt; Execution Policy</code>. That screen lets you choose an approval profile, choose a sandbox profile, tune retry attempts for retry-safe command failures, edit <code>allowed_commands</code> and <code>blocked_commands</code>, then save them back to <code>config/local.toml</code>.</p>
+                <p>Harper now exposes execution policy selection directly in the TUI under <code>Settings -&gt; Execution Policy</code>. That screen lets you choose an approval profile, choose an execution strategy, choose a sandbox profile, tune retry attempts for retry-safe command failures, edit <code>allowed_commands</code> and <code>blocked_commands</code>, choose which header widgets appear in chat, then save them back to <code>config/local.toml</code>.</p>
                 <div class="code-wrapper">
                     <pre><code>approval_profile = "allow_listed"   # strict | allow_listed | allow_all
+execution_strategy = "auto"         # auto | grounded | deterministic | model
 sandbox_profile = "disabled"        # disabled | workspace | networked_workspace
-retry_max_attempts = 1</code></pre>
+retry_max_attempts = 1
+
+[ui]
+header_widgets = ["model", "cwd", "strategy"]</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p>Approval profiles control whether commands always require approval, only allowlisted commands can run automatically, or all commands can run automatically. Under <code>allow_listed</code>, Harper still asks for approval when a command declares network access, or when it declares writes outside the configured sandbox writable roots, even if the command itself is allowlisted. Sandbox profiles control whether command execution is unsandboxed, sandboxed to the workspace, or sandboxed with workspace access plus network enabled.</p>
+                <p>Approval profiles control whether commands always require approval, only allowlisted commands can run automatically, or all commands can run automatically. Under <code>allow_listed</code>, Harper still asks for approval when a command declares network access, or when it declares writes outside the configured sandbox writable roots, even if the command itself is allowlisted. Execution strategy controls whether Harper prefers model-first grounded behavior, deterministic execution, or no deterministic shortcuts. Sandbox profiles control whether command execution is unsandboxed, sandboxed to the workspace, or sandboxed with workspace access plus network enabled.</p>
+                <p><code>header_widgets</code> controls which status items appear in the chat header. You can change that list directly from <code>Settings -&gt; Execution Policy</code>, and when you save, Harper writes the selection back to <code>config/local.toml</code>. Supported values are: <code>session</code>, <code>plan</code>, <code>agents</code>, <code>web</code>, <code>auth</code>, <code>focus</code>, <code>model</code>, <code>cwd</code>, <code>strategy</code>, <code>approval</code>, and <code>activity</code>. Keep only the fields you actually want visible.</p>
                 <p>The same screen also lets you edit <code>allowed_commands</code> and <code>blocked_commands</code> directly as comma-separated lists, so you do not have to hand-edit the local config for simple policy changes.</p>
                 <p><code>retry_max_attempts</code> controls bounded automatic retries for retry-safe commands. Network retries and write retries are still gated by command class and declared command intent.</p>
                 <div class="code-wrapper">
@@ -107,6 +118,18 @@ writable_dirs = ["./tmp", "./build"]</code></pre>
                 </div>
                 <p><code>allowed_dirs</code> defines paths the sandbox may read. <code>writable_dirs</code> defines the subset of paths the sandbox may mutate. If <code>writable_dirs</code> is empty, Harper falls back to the broader profile/default behavior.</p>
                 <p>Saving the profile updates <code>config/local.toml</code> and also applies to future commands in the current TUI session.</p>
+
+                <h2>Repo-aware routing</h2>
+                <p>Harper now uses a model-first grounded path for normal repo work. High-confidence intents still have deterministic grounding and fallback, but repo questions are no longer described as deterministic-only final answers.</p>
+                <ul>
+                    <li><code>which branch am i on</code> → git branch lookup</li>
+                    <li><code>which repo are we working on</code> → repo identity lookup</li>
+                    <li><code>read Cargo.toml</code> → direct file read with workspace grounding</li>
+                    <li><code>find where X is rendered in this repo</code> → structured codebase search</li>
+                    <li><code>tell me the codebase</code> → structured workspace overview</li>
+                    <li><code>create hello.rs with ...</code> → direct file creation/write flow</li>
+                </ul>
+                <p>For open-ended repo questions, Harper feeds the model grounded codebase and authoring context first, then validates tool use against runtime constraints. Deterministic summaries stay as fallback only when the model returns an empty, low-value, or invalid answer.</p>
 
                 <h2>File references and Tab completion</h2>
                 <p>Type <code>@</code> in the chat input to start a file or directory reference. Press <code>Tab</code> to autocomplete matching paths and keep pressing <code>Tab</code> to cycle through candidates.</p>

--- a/website/server.html
+++ b/website/server.html
@@ -38,15 +38,20 @@ host = "127.0.0.1"
 port = 8081</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p>Execution approval and sandbox behavior are configured separately under <code>[exec_policy]</code>. You can edit them directly in config or select them from <code>Settings -&gt; Execution Policy</code> in the TUI, including the command allow/block lists.</p>
+                <p>Execution approval, execution strategy, and sandbox behavior are configured under <code>[exec_policy]</code>. You can edit them directly in config or select them from <code>Settings -&gt; Execution Policy</code> in the TUI, including the command allow/block lists.</p>
                 <div class="code-wrapper">
                     <pre><code>[exec_policy]
 approval_profile = "allow_listed"   # strict | allow_listed | allow_all
+execution_strategy = "auto"         # auto | grounded | deterministic | model
 sandbox_profile = "disabled"        # disabled | workspace | networked_workspace
-retry_max_attempts = 1</code></pre>
+retry_max_attempts = 1
+
+[ui]
+header_widgets = ["model", "cwd", "strategy"]</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p><code>allow_listed</code> preserves the existing default behavior for safe commands, but Harper still asks for approval when the command declares network access or writes outside the configured writable roots. <code>strict</code> requires approval for every command. <code>allow_all</code> skips approval checks. <code>workspace</code> enables sandboxing with workspace access and network disabled. <code>networked_workspace</code> enables the same workspace sandbox but allows network access.</p>
+                <p><code>allow_listed</code> preserves the existing default behavior for safe commands, but Harper still asks for approval when the command declares network access or writes outside the configured writable roots. <code>strict</code> requires approval for every command. <code>allow_all</code> skips approval checks. <code>auto</code> and <code>grounded</code> keep the model in the loop for normal repo work, while <code>deterministic</code> prefers direct grounded tool execution for supported intents and <code>model</code> disables deterministic shortcuts. <code>workspace</code> enables sandboxing with workspace access and network disabled. <code>networked_workspace</code> enables the same workspace sandbox but allows network access.</p>
+                <p><code>header_widgets</code> controls the persistent chat header. You can edit it from <code>Settings -&gt; Execution Policy</code>, and saving that screen writes the selected widgets back to <code>config/local.toml</code>. Supported values are <code>session</code>, <code>plan</code>, <code>agents</code>, <code>web</code>, <code>auth</code>, <code>focus</code>, <code>model</code>, <code>cwd</code>, <code>strategy</code>, <code>approval</code>, and <code>activity</code>.</p>
                 <p><code>retry_max_attempts</code> controls bounded automatic retries for retry-safe commands. You can also tune which command classes qualify:</p>
                 <div class="code-wrapper">
                     <pre><code>[exec_policy]
@@ -63,6 +68,16 @@ writable_dirs = ["./tmp", "./build"]</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <p><code>allowed_dirs</code> are readable roots. <code>writable_dirs</code> are writable roots. This lets you keep most of the workspace readable while only allowing writes in specific subpaths.</p>
+
+                <h2>Deterministic repo routes</h2>
+                <p>Harper now uses a model-first grounded strategy for repo work:</p>
+                <ul>
+                    <li>Structured codebase and authoring helpers gather grounded context.</li>
+                    <li>The model reasons on top of that context for agentic repo questions.</li>
+                    <li>Deterministic routing and summaries remain available as fallback or explicit strategy choices.</li>
+                </ul>
+                <p>Examples of grounded routes include <code>git status</code>, <code>git diff</code>, repo identity, branch lookup, direct file reads, and simple create/write prompts. Codebase prompts such as <code>find where X is rendered</code> use a structured search helper first, then let the model summarize from that grounded result. Open-ended authoring prompts build authoring context, require plan/inspection before edits, and use deterministic fallback only when the model fails.</p>
+                <p>This keeps the execution path explicit and safe, while avoiding the older failure mode where a weaker local model would answer with generic prose instead of using the repo tools.</p>
 
                 <h2>Run Harper with the server enabled</h2>
                 <p>Start Harper normally after enabling the server in config. If you only want the TUI, disable server startup with the flag below.</p>


### PR DESCRIPTION
## Changes

- Refined routing and execution strategy behavior across chat and tool flows:
  - added configurable execution strategies: `auto`, `grounded`, `deterministic`, and `model`
  - added `/strategy` chat command handling and persisted strategy config in `config/local.toml`
  - shifted several command/file/codebase paths toward model-first grounded behavior with deterministic fallback
- Strengthened authoring and codebase investigation flows:
  - added persisted authoring runtime phases and structured authoring plan state
  - improved codebase investigator context, semantic graph extraction, and compiler-aware workspace signals
  - added edit-scope and inspection/plan gating before open-ended edits
- Hardened file and command handling:
  - improved workspace path grounding for `read_file` and `search_replace`
  - improved deterministic command/file follow-up formatting for git status, git diff, write-file, and run-command cases
  - added safer placeholder-path handling for synthetic model-generated paths
- Updated TUI behavior and configuration:
  - added configurable header widgets and persisted header widget settings to `config/local.toml`
  - updated chat header to show model, cwd, and strategy with live status indicators
  - improved chat scrolling, slash-command completion, diff rendering, and unfenced code rendering/highlighting
  - removed the `Delete` footer shortcut label while leaving delete behavior intact
- Updated tests and docs:
  - fixed integration and UI event tests for the current execution policy/settings layout and rendered-line contracts
  - added `docs/testing/tui-routing-smoke.md` and linked it from development docs
  - updated website and user-guide documentation for execution strategy, header widgets, and settings persistence
- Repinned Bazel crate metadata:
  - updated `cargo-bazel-lock.json` after adding the new Rust semantic parsing dependency set

## Validation

- `cargo check -p harper-core`
- `cargo clippy -p harper-core -- -D warnings`
- `cargo check -p harper-ui`
- `cargo clippy -p harper-ui -- -D warnings`
- `cargo test -p harper-core routes_am_changing_phrase -- --nocapture`
- `cargo test -p harper-core extracts_rust_semantic_file_symbols_and_calls -- --nocapture`
- `cargo test -p harper-ui test_enter_execution_policy_save_returns_async_event -- --nocapture`
- `cargo test -p harper-ui test_enter_execution_policy_allowed_commands_opens_editor -- --nocapture`
- `cargo test -p harper-ui test_enter_execution_policy_retry_attempts_cycles_value -- --nocapture`
- `cargo test -p harper-workspace --test integration test_syntax_highlighting_parsing -- --nocapture`
- `make all` (progressively fixed failing checks and tests during iteration)
- manual verification of:
  - strategy switching via `/strategy ...`
  - header widget persistence via `Settings -> Execution Policy`
  - cwd and strategy visibility in the chat header
  - improved git status / command fallback behavior in chat
