### PR TITLE
[fix] sanitize followup paths on windows

### DIFF
--- a/lib/harper-core/src/agent/chat.rs
+++ b/lib/harper-core/src/agent/chat.rs
@@ -1981,13 +1981,27 @@ impl<'a> ChatService<'a> {
         segments
     }
 
+    fn looks_like_absolute_followup_path(path: &str) -> bool {
+        let normalized = path.replace('\\', "/");
+        normalized.starts_with('/')
+            || normalized.starts_with("~/")
+            || normalized.starts_with("//")
+            || normalized
+                .as_bytes()
+                .get(1)
+                .is_some_and(|byte| *byte == b':')
+    }
+
     fn sanitize_followup_write_path(path: &str) -> Option<String> {
         let trimmed = path.trim();
         if trimmed.is_empty() {
             return None;
         }
         let candidate = std::path::Path::new(trimmed);
-        let sanitized = if candidate.is_absolute() || trimmed.contains("..") {
+        let sanitized = if candidate.is_absolute()
+            || Self::looks_like_absolute_followup_path(trimmed)
+            || trimmed.contains("..")
+        {
             candidate.file_name()?.to_str()?.to_string()
         } else {
             trimmed.to_string()


### PR DESCRIPTION
## Changes

- Hardened follow-up file creation path sanitization for Windows CI behavior.
- Treated Unix-style and drive-style absolute-like paths consistently when extracting follow-up file targets from assistant content.
- Prevented `/home/user/...`-style paths from bypassing filename sanitization on Windows.

## Validation

- `cargo test -p harper-core infer_followup_write_file_intent_sanitizes_absolute_filename -- --nocapture`
- pre-commit hooks: `fmt`, `clippy`, `cargo check`
