### PR TITLE
[ci] include windows bazel smoke

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | --- | --- | --- | --- |
 | Apply Rulesets | `apply-rulesets.yml` | Applies branch ruleset definitions from `.github/rulesets/*.json` to GitHub. Edit `main-branch-protection.json` to change rules; the workflow syncs them on push. | Push to `main` touching rulesets, manual dispatch |
 | Auto Merge | `auto-merge.yml` | Three jobs via `libnudget/auto-merge@v1`: `auto-merge` enables GitHub's built-in auto-merge (waits for `CI (ubuntu-latest)` + 1 review); `auto-merge-now` merges immediately via `BYPASS_TOKEN` bypassing ruleset checks; `cancel-auto-merge` disables queued auto-merge when the `auto-merge` label is removed. | `labeled`/`unlabeled`/PR events |
-| Bazel CI | `build-bazel.yml` | Builds `:harper_bin` with Bazel on Linux and macOS (including lockfile repinning fallback). | Push/PR to `main`, Bazel branches |
+| Bazel CI | `build-bazel.yml` | Builds `:harper_bin` with Bazel on Linux and macOS, plus a scoped Windows smoke build/test for `harper-core` (including lockfile repinning fallback). | Push/PR to `main`, Bazel branches |
 | Bazel Smoke | `bazel-smoke.yml` | Daily `bazel test //...` to catch dependency drift outside PRs. | Daily cron, manual dispatch |
 | Rust Benchmarks | `benchmarks.yml` | Runs `cargo bench` nightly and stores results as artifacts. | Daily cron, manual dispatch |
 | Integration Tests | `integration.yml` | Executes `cargo test -- --include-ignored` against real services (requires secrets). | PRs touching app code, manual dispatch (with environment input) |
@@ -72,4 +72,4 @@ Current rules:
 Feel free to expand this file with additional details (matrix descriptions, secrets used, etc.) as workflows evolve.
 
 ## Last Updated
-2026-04-26
+2026-04-29

--- a/.github/workflows/build-bazel.yml
+++ b/.github/workflows/build-bazel.yml
@@ -64,3 +64,32 @@ jobs:
       run: bazel test //...
     - name: Test Bazel build
       run: bazel run :harper_bin -- --version
+
+  build-windows-smoke:
+    runs-on: windows-latest
+    if: github.repository_owner == 'harpertoken'
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Bazel
+      uses: bazel-contrib/setup-bazel@0.19.0
+    - name: Clear stale Bazel cache and regenerate lock
+      shell: pwsh
+      run: |
+        bazel shutdown 2>$null
+        Remove-Item -Recurse -Force "$env:USERPROFILE\\.cache\\bazel","$env:USERPROFILE\\.cache\\bazelisk","$env:USERPROFILE\\.bazel" -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force ".bazelrc",".bazeliskrc" -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force "$env:TEMP\\*bazel*" -ErrorAction SilentlyContinue
+        Remove-Item -Force "cargo-bazel-lock.json" -ErrorAction SilentlyContinue
+    - name: Build with Bazel
+      shell: pwsh
+      run: |
+        $env:CARGO_BAZEL_REPIN = "true"
+        bazel build :harper_bin
+    - name: Test harper-core with Bazel
+      shell: pwsh
+      run: |
+        $env:CARGO_BAZEL_REPIN = "true"
+        bazel test //lib/harper-core:harper_core_test
+    - name: Test Bazel build
+      shell: pwsh
+      run: bazel run :harper_bin -- --version


### PR DESCRIPTION
## Changes
- Included a scoped Windows Bazel smoke job in `.github/workflows/build-bazel.yml`.
  - clears stale Bazel state on `windows-latest`
  - repins and builds `:harper_bin`
  - runs `bazel test //lib/harper-core:harper_core_test`
  - runs `bazel run :harper_bin -- --version`
- Updated `.github/workflows/README.md` to document the new Windows Bazel smoke coverage.
- Refreshed the workflow README `Last Updated` date.

## Validation
- `git diff --check -- .github/workflows/build-bazel.yml .github/workflows/README.md`
- commit hooks:
  - `trim trailing whitespace`
  - `fix end of files`
  - `check yaml`
  - `check for merge conflicts`
  - `fmt`
  - `clippy`
  - `cargo check`
