### PR TITLE
[fix] restore ratatui imports for bazel

### DIFF
--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ratatui::layout::Constraint;
 use ratatui::prelude::*;
 use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Padding, Paragraph, Wrap};
 
 use super::app::{


### PR DESCRIPTION
## Changes
- Restored explicit `ratatui` imports in `lib/harper-ui/src/interfaces/ui/widgets.rs` for types used by the TUI renderer.
- Added explicit imports for:
  - `Constraint`
  - `Line`
  - `Span`
- Fixes the Windows Bazel smoke failure where `//lib/harper-ui:harper` could not resolve these types during build.

## Validation
- `cargo check -p harper-ui`
- pre-push checks:
  - `fmt`
  - `clippy`
  - `cargo check`
