### PR TITLE
[fix] restore ratatui frame imports for bazel

### DIFF
--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::prelude::*;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::prelude::Frame;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Padding, Paragraph, Wrap};


### PR DESCRIPTION
## Changes
- Restored explicit `ratatui` imports in `lib/harper-ui/src/interfaces/ui/widgets.rs` for additional renderer types used by the TUI.
- Added explicit imports for:
  - `Frame`
  - `Alignment`
- Fixes the next Windows Bazel smoke failure where `//lib/harper-ui:harper` could not resolve these types during build.

## Validation
- `cargo check -p harper-ui`
- pre-push checks:
  - `fmt`
  - `clippy`
  - `cargo check`
