### PR TITLE
[fix] set explicit bazel crate roots

### DIFF
--- a/lib/harper-ui/BUILD
+++ b/lib/harper-ui/BUILD
@@ -5,6 +5,7 @@ exports_files(glob(["src/**/*.rs"]))
 
 rust_library(
     name = "harper_ui",
+    crate_root = "src/lib.rs",
     srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs", "src/bin/batch.rs"]),
     deps = [
         "//lib/harper-core:harper_core",
@@ -17,6 +18,7 @@ rust_library(
 
 rust_binary(
     name = "harper",
+    crate_root = "src/main.rs",
     srcs = glob(["src/**/*.rs"]),
     deps = [
         ":harper_ui",
@@ -36,6 +38,7 @@ rust_binary(
 
 rust_binary(
     name = "harper_batch",
+    crate_root = "src/bin/batch.rs",
     srcs = ["src/bin/batch.rs"],
     deps = [
         ":harper_ui",


### PR DESCRIPTION
## Changes
- Set explicit Bazel crate roots in `lib/harper-ui/BUILD`.
- Added:
  - `crate_root = "src/lib.rs"` for `harper_ui`
  - `crate_root = "src/main.rs"` for `harper`
  - `crate_root = "src/bin/batch.rs"` for `harper_batch`
- Fixes the Windows Bazel smoke path where `harper_ui` was being compiled with ambiguous crate-root inference.

## Validation
- pre-push checks:
  - `fmt`
  - `clippy`
  - `cargo check`
- attempted narrow Bazel validation:
  - `bazel build //lib/harper-ui:harper_ui`
  - blocked locally by Bazelisk network resolution in this environment
