### PR TITLE
[fix] wire bazel crate aliases

### DIFF
--- a/lib/harper-ui/BUILD
+++ b/lib/harper-ui/BUILD
@@ -1,5 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_binary")
-load("@crates//:defs.bzl", "all_crate_deps")
+load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 
 exports_files(glob(["src/**/*.rs"]))
 
@@ -7,6 +7,7 @@ rust_library(
     name = "harper_ui",
     crate_root = "src/lib.rs",
     srcs = glob(["src/**/*.rs"], exclude = ["src/main.rs", "src/bin/batch.rs"]),
+    aliases = aliases(),
     deps = [
         "//lib/harper-core:harper_core",
     ] + all_crate_deps(normal = True),
@@ -20,6 +21,7 @@ rust_binary(
     name = "harper",
     crate_root = "src/main.rs",
     srcs = glob(["src/**/*.rs"]),
+    aliases = aliases(),
     deps = [
         ":harper_ui",
         "//lib/harper-core:harper_core",
@@ -40,6 +42,7 @@ rust_binary(
     name = "harper_batch",
     crate_root = "src/bin/batch.rs",
     srcs = ["src/bin/batch.rs"],
+    aliases = aliases(),
     deps = [
         ":harper_ui",
         "//lib/harper-core:harper_core",


### PR DESCRIPTION
## Changes
- Updated `lib/harper-ui/BUILD` to load `aliases` from `@crates//:defs.bzl`.
- Added `aliases = aliases()` to:
  - `harper_ui`
  - `harper`
  - `harper_batch`
- Fixes the Windows Bazel smoke path where `harper_ui` could not resolve external Rust crates during Bazel compilation.

## Validation
- `cargo check -p harper-ui`
- pre-push checks:
  - `fmt`
  - `clippy`
  - `cargo check`
- local Bazel validation remains blocked by Bazelisk network resolution in this environment
