### PR TITLE
[feat] followup history, semantic type links, and command output fallback

### DIFF
--- a/PLANNER_NEXT_STEPS.md
+++ b/PLANNER_NEXT_STEPS.md
@@ -1,95 +1,48 @@
 # Harper Planner Next Steps
 
-This file captures the remaining planner/runtime work after the current planning, job, follow-up, retry, scoped `AGENTS.md`, cross-process delivery, deterministic repo routing, structured codebase helper changes, and persisted authoring-manager workflow.
+This file captured the remaining planner/runtime polish after planning, jobs, follow-up handling, scoped `AGENTS.md`, cross-process delivery, deterministic repo routing, structured codebase helpers, and the persisted authoring-manager workflow were in place.
+
+## Current State
+
+The previously tracked planner/runtime items are now implemented:
+
+1. **Live command output polish**
+   - Command output falls back to planner/runtime job output when the live stream is absent.
+   - The command-output panel shows clearer truncation and richer status labels.
+
+2. **Semantic authoring depth**
+   - The grounded semantic graph now carries stronger type-alias and trait-implementation links.
+   - Multi-file authoring candidates are decomposed into primary and supporting edit files.
+
+3. **Planner follow-up history polish**
+   - `PlanRuntime` now persists bounded follow-up history.
+   - The plan panel shows recent follow-up entries without replacing the active follow-up model.
 
 ## Count
 
-There are **3 real next steps** left without changing direction.
+There are **0 remaining items** in this specific planner/runtime polish pass.
 
-## Next Steps
+## What This File Is Now
 
-1. **Live command output polish**
-   - Refine the existing command output panel and active runtime display.
-   - Add clearer truncation controls, richer status summaries, and better failure surfacing.
+This file is now a completion marker for the planner/runtime polish workstream, not an active backlog.
 
-2. **Semantic authoring depth**
-   - Extend the current authoring manager beyond the lightweight semantic graph.
-   - Improve Rust symbol/type/trait resolution and richer multi-file edit planning.
+## If New Planner Work Starts
 
-3. **Planner follow-up history polish**
-   - Extend the current single follow-up state into richer visible history if needed.
-   - Make retry/checkpoint review easier without losing the current lightweight UI.
+Open a new focused plan instead of appending more unrelated items here. The next likely planner-adjacent work would be one of:
 
-## Recommended Order
+1. richer planner browsing UX
+2. deeper authoring sequencing
+3. planner/runtime observability
 
-1. Live command output polish
-2. Semantic authoring depth
-3. Planner follow-up history polish
-
-## Suggested Milestones
-
-### Milestone 1: Runtime polish
-- Live command output polish
-
-### Milestone 2: Semantic authoring depth
-- Improve compiler-backed candidate ownership
-- Deepen symbol/reference-aware repo understanding
-- Improve multi-file authoring decomposition quality
-
-### Milestone 3: Follow-up history
-- Add richer checkpoint/retry review history
-- Keep active follow-up state easy to understand
-
-## Harper `update_plan` Seeds
-
-### Seed 1: Runtime polish
+## Final Completed `update_plan` Shape
 
 ```json
 {
-  "explanation": "Refine planner runtime visibility now that plan/job/follow-up state and cross-process delivery are in place.",
+  "explanation": "Planner/runtime polish is complete for the originally scoped workstream.",
   "items": [
-    { "step": "Clarify active command status", "status": "pending" },
-    { "step": "Improve output truncation", "status": "pending" },
-    { "step": "Surface failures more clearly", "status": "pending" }
-  ]
-}
-```
-
-### Seed 2: Semantic authoring depth
-
-```json
-{
-  "explanation": "Deepen the authoring helper so repo changes rely on grounded semantic context instead of shallow candidate matching.",
-  "items": [
-    { "step": "Improve trait and type links", "status": "pending" },
-    { "step": "Strengthen multi-file decomposition", "status": "pending" },
-    { "step": "Keep authoring reasoning grounded", "status": "pending" }
-  ]
-}
-```
-
-### Seed 3: Follow-up history
-
-```json
-{
-  "explanation": "Improve visibility of completed checkpoints and recovery actions after the active follow-up model is already in place.",
-  "items": [
-    { "step": "Design follow-up history view", "status": "pending" },
-    { "step": "Store checkpoint history", "status": "pending" },
-    { "step": "Render retry/checkpoint review", "status": "pending" }
-  ]
-}
-```
-
-## Single Master Plan
-
-```json
-{
-  "explanation": "Finish the remaining planner/runtime polish after core orchestration, scoped AGENTS resolution, retry handling, codebase helpers, and authoring-manager workflow are in place.",
-  "items": [
-    { "step": "Polish live command output", "status": "pending" },
-    { "step": "Deepen semantic authoring context", "status": "pending" },
-    { "step": "Improve follow-up history UX", "status": "pending" }
+    { "step": "Polish live command output", "status": "completed" },
+    { "step": "Deepen semantic authoring context", "status": "completed" },
+    { "step": "Improve follow-up history UX", "status": "completed" }
   ]
 }
 ```

--- a/lib/harper-core/src/core/plan.rs
+++ b/lib/harper-core/src/core/plan.rs
@@ -140,6 +140,8 @@ pub struct PlanRuntime {
     #[serde(default)]
     pub followup: Option<PlanFollowup>,
     #[serde(default)]
+    pub followup_history: Vec<PlanFollowup>,
+    #[serde(default)]
     pub authoring: Option<AuthoringRuntime>,
 }
 
@@ -153,6 +155,7 @@ impl PlanRuntime {
             && self.active_job_id.is_none()
             && self.jobs.is_empty()
             && self.followup.is_none()
+            && self.followup_history.is_empty()
             && self.authoring.is_none()
     }
 
@@ -188,7 +191,7 @@ impl PlanRuntime {
             output_preview: None,
             has_error_output: false,
         });
-        self.followup = None;
+        self.archive_active_followup();
         job_id
     }
 
@@ -262,10 +265,14 @@ impl PlanRuntime {
     }
 
     pub fn set_checkpoint_followup(&mut self, step: impl Into<String>, next_step: Option<String>) {
-        self.followup = Some(PlanFollowup::Checkpoint {
+        let next_followup = PlanFollowup::Checkpoint {
             step: step.into(),
             next_step,
-        });
+        };
+        if self.followup.as_ref() != Some(&next_followup) {
+            self.archive_active_followup();
+        }
+        self.followup = Some(next_followup);
     }
 
     pub fn set_retry_or_replan_followup(
@@ -282,15 +289,36 @@ impl PlanRuntime {
             }) if existing_step == &step => retry_count.saturating_add(1),
             _ => 1,
         };
-        self.followup = Some(PlanFollowup::RetryOrReplan {
+        let next_followup = PlanFollowup::RetryOrReplan {
             step,
             command,
             retry_count,
-        });
+        };
+        let should_archive_existing = !matches!(
+            self.followup.as_ref(),
+            Some(PlanFollowup::RetryOrReplan { step: existing_step, .. })
+                if existing_step == followup_step(&next_followup)
+        );
+        if should_archive_existing {
+            self.archive_active_followup();
+        }
+        self.followup = Some(next_followup);
     }
 
     pub fn clear_followup(&mut self) {
-        self.followup = None;
+        self.archive_active_followup();
+    }
+
+    fn archive_active_followup(&mut self) {
+        const MAX_FOLLOWUP_HISTORY: usize = 8;
+
+        if let Some(current) = self.followup.take() {
+            self.followup_history.push(current);
+            if self.followup_history.len() > MAX_FOLLOWUP_HISTORY {
+                let overflow = self.followup_history.len() - MAX_FOLLOWUP_HISTORY;
+                self.followup_history.drain(0..overflow);
+            }
+        }
     }
 
     pub fn seed_authoring_context(
@@ -452,6 +480,13 @@ fn job_status_label(status: &PlanJobStatus) -> &'static str {
     }
 }
 
+fn followup_step(followup: &PlanFollowup) -> &str {
+    match followup {
+        PlanFollowup::Checkpoint { step, .. } => step.as_str(),
+        PlanFollowup::RetryOrReplan { step, .. } => step.as_str(),
+    }
+}
+
 fn preview_text(text: &str, max_chars: usize) -> Option<String> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
@@ -530,6 +565,37 @@ mod tests {
                 command: Some("cargo test".to_string()),
                 retry_count: 2,
             })
+        );
+    }
+
+    #[test]
+    fn runtime_archives_followup_history_on_clear_and_replace() {
+        let mut runtime = PlanRuntime::default();
+
+        runtime.set_checkpoint_followup("Inspect output", Some("Patch handler".to_string()));
+        runtime.clear_followup();
+        runtime
+            .set_retry_or_replan_followup("Retry failing command", Some("cargo test".to_string()));
+
+        assert_eq!(runtime.followup_history.len(), 1);
+        assert_eq!(
+            runtime.followup_history[0],
+            PlanFollowup::Checkpoint {
+                step: "Inspect output".to_string(),
+                next_step: Some("Patch handler".to_string())
+            }
+        );
+
+        runtime.set_checkpoint_followup("Review failure", Some("Apply fix".to_string()));
+
+        assert_eq!(runtime.followup_history.len(), 2);
+        assert_eq!(
+            runtime.followup_history[1],
+            PlanFollowup::RetryOrReplan {
+                step: "Retry failing command".to_string(),
+                command: Some("cargo test".to_string()),
+                retry_count: 1
+            }
         );
     }
 

--- a/lib/harper-core/src/tools/codebase_investigator.rs
+++ b/lib/harper-core/src/tools/codebase_investigator.rs
@@ -130,6 +130,7 @@ struct RustSemanticFile {
     path: String,
     module_path: String,
     defines: Vec<String>,
+    type_aliases: BTreeMap<String, String>,
     imports: Vec<String>,
     import_map: BTreeMap<String, String>,
     modules: Vec<String>,
@@ -1206,42 +1207,115 @@ fn infer_edit_plan_candidates(
     graph: Option<&WorkspaceGraph>,
     compiler: Option<&CompilerContext>,
 ) -> Vec<String> {
-    matches
-        .iter()
-        .take(5)
-        .map(|entry| {
-            let crate_name = workspace_member_for_path(Path::new(&entry.path), graph)
-                .map(|member| member.name.as_str())
-                .unwrap_or("<unknown>");
-            let role = match entry.role.as_str() {
-                "ui_widget_rendering" | "ui" => "primary_edit_or_render_validation",
-                "runtime" => "runtime_state_or_config_support",
-                "tooling" => "tool_or_execution_support",
-                "agent" => "agent_or_prompt_support",
-                _ => "supporting_file",
-            };
-            let validation_hint = compiler
-                .and_then(|ctx| {
-                    ctx.target_ownership
-                        .iter()
-                        .find(|(owned, _)| {
-                            entry.path.trim_start_matches("./") == owned.as_str()
-                                || entry.path.ends_with(owned.as_str())
-                                || owned.ends_with(entry.path.trim_start_matches("./"))
-                        })
-                        .map(|(_, kinds)| format!("validate_with={}", kinds.join("/")))
+    let Some(primary) = matches.first() else {
+        return Vec::new();
+    };
+
+    let primary_crate = workspace_member_for_path(Path::new(&primary.path), graph)
+        .map(|member| member.name.clone())
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let primary_validation = validation_hint_for_path(&primary.path, compiler);
+    let mut plan = vec![format!(
+        "- PRIMARY: {} [crate={}] role={} ({}, {})",
+        primary.path,
+        primary_crate,
+        authoring_edit_role(&primary.role, true),
+        primary.reasons.join(", "),
+        primary_validation
+    )];
+
+    for entry in matches.iter().skip(1).take(4) {
+        let crate_name = workspace_member_for_path(Path::new(&entry.path), graph)
+            .map(|member| member.name.clone())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let support_reason = support_relation_reason(primary, entry, graph, compiler);
+        let validation_hint = validation_hint_for_path(&entry.path, compiler);
+        plan.push(format!(
+            "- SUPPORTING: {} [crate={}] role={} ({}, {}, {})",
+            entry.path,
+            crate_name,
+            authoring_edit_role(&entry.role, false),
+            support_reason,
+            entry.reasons.join(", "),
+            validation_hint
+        ));
+    }
+
+    plan
+}
+
+fn authoring_edit_role(role: &str, primary: bool) -> &'static str {
+    match (role, primary) {
+        ("ui_widget_rendering" | "ui", true) => "primary_edit_or_render_validation",
+        ("runtime", true) => "primary_runtime_edit",
+        ("tooling", true) => "primary_tooling_edit",
+        ("agent", true) => "primary_agent_or_prompt_edit",
+        ("ui_widget_rendering" | "ui", false) => "ui_or_render_support",
+        ("runtime", false) => "runtime_state_or_config_support",
+        ("tooling", false) => "tool_or_execution_support",
+        ("agent", false) => "agent_or_prompt_support",
+        _ if primary => "primary_edit_file",
+        _ => "supporting_file",
+    }
+}
+
+fn validation_hint_for_path(path: &str, compiler: Option<&CompilerContext>) -> String {
+    compiler
+        .and_then(|ctx| {
+            ctx.target_ownership
+                .iter()
+                .find(|(owned, _)| {
+                    path.trim_start_matches("./") == owned.as_str()
+                        || path.ends_with(owned.as_str())
+                        || owned.ends_with(path.trim_start_matches("./"))
                 })
-                .unwrap_or_else(|| "validate_with=source-check".to_string());
-            format!(
-                "- {} [crate={}] => {} ({}, {})",
-                entry.path,
-                crate_name,
-                role,
-                entry.reasons.join(", "),
-                validation_hint
-            )
+                .map(|(_, kinds)| format!("validate_with={}", kinds.join("/")))
         })
-        .collect()
+        .unwrap_or_else(|| "validate_with=source-check".to_string())
+}
+
+fn support_relation_reason(
+    primary: &SearchMatch,
+    candidate: &SearchMatch,
+    graph: Option<&WorkspaceGraph>,
+    compiler: Option<&CompilerContext>,
+) -> String {
+    let primary_path = Path::new(&primary.path);
+    let candidate_path = Path::new(&candidate.path);
+
+    if workspace_member_for_path(primary_path, graph).map(|member| member.name.as_str())
+        == workspace_member_for_path(candidate_path, graph).map(|member| member.name.as_str())
+    {
+        return "same_crate".to_string();
+    }
+
+    if primary_path.parent() == candidate_path.parent() {
+        return "same_directory".to_string();
+    }
+
+    let primary_target = compiler.and_then(|ctx| target_kinds_for_path(&primary.path, ctx));
+    let candidate_target = compiler.and_then(|ctx| target_kinds_for_path(&candidate.path, ctx));
+    if primary_target.is_some() && primary_target == candidate_target {
+        return "same_target_kind".to_string();
+    }
+
+    if primary.role == candidate.role {
+        return "same_role_family".to_string();
+    }
+
+    "ranked_candidate_context".to_string()
+}
+
+fn target_kinds_for_path<'a>(path: &str, compiler: &'a CompilerContext) -> Option<&'a [String]> {
+    compiler
+        .target_ownership
+        .iter()
+        .find(|(owned, _)| {
+            path.trim_start_matches("./") == owned.as_str()
+                || path.ends_with(owned.as_str())
+                || owned.ends_with(path.trim_start_matches("./"))
+        })
+        .map(|(_, kinds)| kinds.as_slice())
 }
 
 fn build_semantic_graph(matches: &[SearchMatch]) -> String {
@@ -1264,10 +1338,26 @@ fn build_semantic_graph(matches: &[SearchMatch]) -> String {
         .iter()
         .map(|file| {
             format!(
-                "FILE: {}\nMODULE: {}\nDEFINES: {}\nIMPORTS: {}\nCALLS: {}",
+                "FILE: {}\nMODULE: {}\nDEFINES: {}\nTYPE_LINKS: {}\nTRAIT_IMPLS: {}\nIMPORTS: {}\nCALLS: {}",
                 file.path,
                 file.module_path,
                 join_or_none(&file.defines),
+                join_or_none(
+                    &file
+                        .type_aliases
+                        .iter()
+                        .map(|(alias, target)| format!("{alias} -> {target}"))
+                        .collect::<Vec<_>>(),
+                ),
+                join_or_none(
+                    &file
+                        .method_traits
+                        .iter()
+                        .flat_map(|(method, traits)| {
+                            traits.iter().map(move |trait_name| format!("{method} via {trait_name}"))
+                        })
+                        .collect::<Vec<_>>(),
+                ),
                 join_or_none(&file.imports),
                 join_or_none(&file.calls),
             )
@@ -1322,6 +1412,21 @@ fn build_semantic_graph(matches: &[SearchMatch]) -> String {
                 }
             }
         }
+        for target in file.type_aliases.values() {
+            for resolved_symbol in resolve_symbol_candidates(file, target) {
+                if let Some(target_files) = definition_to_file.get(&resolved_symbol) {
+                    for target_file in target_files {
+                        if target_file == &file.path {
+                            continue;
+                        }
+                        linked.insert(format!(
+                            "- {} -> {} via type {}",
+                            file.path, target_file, resolved_symbol
+                        ));
+                    }
+                }
+            }
+        }
         relationships.extend(linked);
     }
 
@@ -1345,6 +1450,7 @@ fn extract_rust_semantic_file(path: &Path) -> Option<RustSemanticFile> {
         path: path.display().to_string(),
         module_path: rust_module_path(path),
         defines: visitor.defines.into_iter().collect(),
+        type_aliases: visitor.type_aliases,
         imports: visitor.imports.into_iter().collect(),
         import_map: visitor.import_map,
         modules: visitor.modules.into_iter().collect(),
@@ -1522,6 +1628,7 @@ fn rust_module_path(path: &Path) -> String {
 #[derive(Default)]
 struct RustSemanticVisitor {
     defines: BTreeSet<String>,
+    type_aliases: BTreeMap<String, String>,
     imports: BTreeSet<String>,
     import_map: BTreeMap<String, String>,
     modules: BTreeSet<String>,
@@ -1564,6 +1671,14 @@ impl<'ast> Visit<'ast> for RustSemanticVisitor {
         syn::visit::visit_item_trait(self, node);
     }
 
+    fn visit_item_type(&mut self, node: &'ast syn::ItemType) {
+        self.defines.insert(node.ident.to_string());
+        if let Some(target) = rust_type_symbol(&node.ty) {
+            self.type_aliases.insert(node.ident.to_string(), target);
+        }
+        syn::visit::visit_item_type(self, node);
+    }
+
     fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
         if node.content.is_none() {
             self.modules.insert(node.ident.to_string());
@@ -1574,9 +1689,10 @@ impl<'ast> Visit<'ast> for RustSemanticVisitor {
     fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
         let previous_trait = self.current_impl_trait.take();
         if let Some((_, path, _)) = &node.trait_ {
+            let trait_path = rust_path_name(path);
             if let Some(segment) = path.segments.last() {
                 self.imports.insert(segment.ident.to_string());
-                self.current_impl_trait = Some(segment.ident.to_string());
+                self.current_impl_trait = Some(trait_path);
             }
         }
         let previous_owner = self.current_impl_owner.take();
@@ -1689,6 +1805,24 @@ fn rust_type_name(ty: &syn::Type) -> Option<String> {
         syn::Type::Paren(paren) => rust_type_name(&paren.elem),
         _ => None,
     }
+}
+
+fn rust_type_symbol(ty: &syn::Type) -> Option<String> {
+    match ty {
+        syn::Type::Path(type_path) => Some(rust_path_name(&type_path.path)),
+        syn::Type::Reference(reference) => rust_type_symbol(&reference.elem),
+        syn::Type::Group(group) => rust_type_symbol(&group.elem),
+        syn::Type::Paren(paren) => rust_type_symbol(&paren.elem),
+        _ => None,
+    }
+}
+
+fn rust_path_name(path: &syn::Path) -> String {
+    path.segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
 }
 
 fn rust_expr_owner_name(
@@ -1903,11 +2037,11 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::{
-        authoring_search_query, build_workspace_definition_index, classify_member_role,
-        extract_rust_semantic_file, format_workspace_graph, infer_query_focus, is_searchable_file,
-        path_relative_to_root, resolve_symbol_candidates, rust_module_path,
-        workspace_member_for_path, QueryFocus, RustSemanticFile, WorkspaceGraph,
-        WorkspaceMemberOverview,
+        authoring_search_query, build_semantic_graph, build_workspace_definition_index,
+        classify_member_role, extract_rust_semantic_file, format_workspace_graph,
+        infer_edit_plan_candidates, infer_query_focus, is_searchable_file, path_relative_to_root,
+        resolve_symbol_candidates, rust_module_path, workspace_member_for_path, QueryFocus,
+        RustSemanticFile, SearchMatch, WorkspaceGraph, WorkspaceMemberOverview,
     };
     use std::path::Path;
 
@@ -2000,6 +2134,7 @@ pub fn authoring_context() {
             path: "src/tools/example.rs".to_string(),
             module_path: "tools::example".to_string(),
             defines: vec!["search_text".to_string()],
+            type_aliases: BTreeMap::new(),
             imports: Vec::new(),
             import_map: BTreeMap::new(),
             modules: Vec::new(),
@@ -2053,6 +2188,7 @@ fn run() {
             path: "lib/harper-core/src/tools/example.rs".to_string(),
             module_path: "tools::example".to_string(),
             defines: vec!["run".to_string()],
+            type_aliases: BTreeMap::new(),
             imports: vec!["searcher".to_string()],
             import_map,
             modules: Vec::new(),
@@ -2109,6 +2245,7 @@ fn run(planner: Planner) {
                 "Planner::replan".to_string(),
                 "Planner::Refactorable::replan".to_string(),
             ],
+            type_aliases: BTreeMap::new(),
             imports: Vec::new(),
             import_map: BTreeMap::new(),
             modules: Vec::new(),
@@ -2165,6 +2302,123 @@ fn execute() {
             Some(&["Runner".to_string()][..])
         );
         assert!(semantic.calls.iter().any(|c| c == "Planner::run"));
+    }
+
+    #[test]
+    fn extracts_type_alias_links_and_full_trait_identity() {
+        let src = r#"
+use crate::runtime::Runner as RuntimeRunner;
+
+type SharedRunner = RuntimeRunner;
+
+struct Planner;
+
+impl RuntimeRunner for Planner {
+    fn run(&self) {}
+}
+"#;
+        let temp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(temp.path(), src).unwrap();
+        let semantic = extract_rust_semantic_file(temp.path()).unwrap();
+        assert_eq!(
+            semantic
+                .type_aliases
+                .get("SharedRunner")
+                .map(String::as_str),
+            Some("RuntimeRunner")
+        );
+        assert!(semantic
+            .defines
+            .iter()
+            .any(|d| d == "Planner::RuntimeRunner::run"));
+        assert_eq!(
+            semantic
+                .method_traits
+                .get("run")
+                .map(|traits| traits.as_slice()),
+            Some(&["RuntimeRunner".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn semantic_graph_surfaces_type_links() {
+        let temp = tempfile::Builder::new().suffix(".rs").tempfile().unwrap();
+        std::fs::write(
+            temp.path(),
+            r#"
+type SharedPlanner = Planner;
+
+struct Planner;
+"#,
+        )
+        .unwrap();
+        let matches = vec![SearchMatch {
+            score: 10,
+            path: temp.path().display().to_string(),
+            role: "runtime".to_string(),
+            reasons: vec!["candidate".to_string()],
+            snippets: Vec::new(),
+        }];
+
+        let graph = build_semantic_graph(&matches);
+
+        assert!(graph.contains("TYPE_LINKS: SharedPlanner -> Planner"));
+    }
+
+    #[test]
+    fn edit_plan_candidates_distinguish_primary_and_supporting_files() {
+        let matches = vec![
+            SearchMatch {
+                score: 100,
+                path: "lib/harper-ui/src/interfaces/ui/widgets.rs".to_string(),
+                role: "ui_widget_rendering".to_string(),
+                reasons: vec!["matches_ui_render_focus".to_string()],
+                snippets: Vec::new(),
+            },
+            SearchMatch {
+                score: 90,
+                path: "lib/harper-ui/src/interfaces/ui/app.rs".to_string(),
+                role: "ui".to_string(),
+                reasons: vec!["contains_all_terms".to_string()],
+                snippets: Vec::new(),
+            },
+            SearchMatch {
+                score: 80,
+                path: "lib/harper-core/src/tools/plan.rs".to_string(),
+                role: "tooling".to_string(),
+                reasons: vec!["matches_tooling_focus".to_string()],
+                snippets: Vec::new(),
+            },
+        ];
+        let graph = WorkspaceGraph {
+            root: "/repo".to_string(),
+            package_name: Some("harper-workspace".to_string()),
+            members: vec![
+                WorkspaceMemberOverview {
+                    name: "harper-ui".to_string(),
+                    role: "lib".to_string(),
+                    root: "lib/harper-ui".to_string(),
+                    entrypoints: Vec::new(),
+                    notable_files: Vec::new(),
+                },
+                WorkspaceMemberOverview {
+                    name: "harper-core".to_string(),
+                    role: "lib".to_string(),
+                    root: "lib/harper-core".to_string(),
+                    entrypoints: Vec::new(),
+                    notable_files: Vec::new(),
+                },
+            ],
+        };
+
+        let plan = infer_edit_plan_candidates(&matches, Some(&graph), None);
+
+        assert_eq!(plan.len(), 3);
+        assert!(plan[0].contains("PRIMARY: lib/harper-ui/src/interfaces/ui/widgets.rs"));
+        assert!(plan[0].contains("primary_edit_or_render_validation"));
+        assert!(plan[1].contains("SUPPORTING: lib/harper-ui/src/interfaces/ui/app.rs"));
+        assert!(plan[1].contains("same_crate"));
+        assert!(plan[2].contains("SUPPORTING: lib/harper-core/src/tools/plan.rs"));
     }
 
     #[test]

--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -18,9 +18,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Padding, Paragraph, Wrap};
 
-use super::app::{
-    AppState, ApprovalState, CommandOutputState, ReviewState, SessionInfo, TuiApp, UiMessage,
-};
+use super::app::{AppState, ApprovalState, ReviewState, SessionInfo, TuiApp, UiMessage};
 use super::settings;
 use super::theme::Theme;
 use harper_core::core::plan::{PlanFollowup, PlanJobRecord, PlanJobStatus};
@@ -255,14 +253,14 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                     .as_ref()
                     .is_some_and(|agents| !agents.sources.is_empty());
             let has_review = chat_state.active_review.is_some();
-            let has_command_output = chat_state.command_output.is_some();
+            let command_output_display = derive_command_output_display(chat_state);
+            let has_command_output = command_output_display.is_some();
             let plan_height = chat_state
                 .active_plan
                 .as_ref()
                 .map(plan_panel_height)
                 .unwrap_or(0);
-            let command_output_height = chat_state
-                .command_output
+            let command_output_height = command_output_display
                 .as_ref()
                 .map(command_output_panel_height)
                 .unwrap_or(0);
@@ -366,7 +364,7 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 next_panel_index += 1;
             }
             if has_command_output {
-                if let Some(output) = &chat_state.command_output {
+                if let Some(output) = command_output_display.as_ref() {
                     draw_command_output_panel(frame, output, theme, chunks[next_panel_index]);
                 }
                 next_panel_index += 1;
@@ -1335,6 +1333,9 @@ fn plan_panel_height(plan: &PlanState) -> u16 {
         if runtime.followup.is_some() {
             lines += 2;
         }
+        if !runtime.followup_history.is_empty() {
+            lines += runtime.followup_history.len().min(2) + 1;
+        }
         lines += runtime.jobs.len().min(3);
         if runtime.jobs.len() > 3 {
             lines += 1;
@@ -1395,19 +1396,97 @@ fn draw_completion_popup(
     frame.render_widget(widget, area);
 }
 
-fn command_output_panel_height(output: &CommandOutputState) -> u16 {
-    let line_count = output.content.lines().count().clamp(1, 5);
-    (line_count + 3) as u16
+const MAX_COMMAND_OUTPUT_LINES: usize = 6;
+
+#[derive(Clone)]
+struct CommandOutputDisplay {
+    command: String,
+    content: String,
+    has_error: bool,
+    status_label: String,
+    total_line_count: usize,
+}
+
+fn derive_command_output_display(
+    chat_state: &super::app::ChatState,
+) -> Option<CommandOutputDisplay> {
+    if let Some(output) = &chat_state.command_output {
+        let trimmed = output.content.trim_end();
+        let content = if trimmed.trim().is_empty() {
+            "No output yet".to_string()
+        } else {
+            trimmed.to_string()
+        };
+        let status_label = chat_state
+            .active_plan
+            .as_ref()
+            .and_then(|plan| plan.runtime.as_ref())
+            .and_then(|runtime| runtime.active_status.clone())
+            .unwrap_or_else(|| {
+                if output.done {
+                    "done".to_string()
+                } else {
+                    "live".to_string()
+                }
+            });
+        let total_line_count = content.lines().count().max(1);
+        return Some(CommandOutputDisplay {
+            command: output.command.clone(),
+            content,
+            has_error: output.has_error,
+            status_label,
+            total_line_count,
+        });
+    }
+
+    let runtime = chat_state
+        .active_plan
+        .as_ref()
+        .and_then(|plan| plan.runtime.as_ref())?;
+    let job = runtime
+        .active_job_id
+        .as_deref()
+        .and_then(|job_id| runtime.jobs.iter().rev().find(|job| job.job_id == job_id))
+        .or_else(|| runtime.jobs.last())?;
+
+    let transcript = job.output_transcript.trim_end();
+    let preview = job.output_preview.as_deref().unwrap_or_default().trim_end();
+    let (content, total_line_count) = if transcript.trim().is_empty() {
+        let preview_content = if preview.trim().is_empty() {
+            "No output recorded yet".to_string()
+        } else {
+            preview.to_string()
+        };
+        let preview_lines = preview_content.lines().count().max(1);
+        (preview_content, preview_lines)
+    } else {
+        let transcript_content = transcript.to_string();
+        let transcript_lines = transcript_content.lines().count().max(1);
+        (transcript_content, transcript_lines)
+    };
+
+    Some(CommandOutputDisplay {
+        command: job.command.clone().unwrap_or_else(|| job.tool.clone()),
+        content,
+        has_error: job.has_error_output,
+        status_label: format!("{:?}", job.status).to_ascii_lowercase(),
+        total_line_count,
+    })
+}
+
+fn command_output_panel_height(output: &CommandOutputDisplay) -> u16 {
+    let visible_lines = output.total_line_count.clamp(1, MAX_COMMAND_OUTPUT_LINES);
+    let truncation_line = usize::from(output.total_line_count > MAX_COMMAND_OUTPUT_LINES);
+    (visible_lines + truncation_line + 4) as u16
 }
 
 fn draw_command_output_panel(
     frame: &mut Frame,
-    output: &CommandOutputState,
+    output: &CommandOutputDisplay,
     theme: &Theme,
     area: Rect,
 ) {
-    let status = if output.done { "done" } else { "live" };
-    let title = format!(" Command Output ({}) ", status);
+    let title = format!(" Command Output ({}) ", output.status_label);
     let color = if output.has_error {
         Color::Rgb(245, 158, 11)
     } else {
@@ -1422,6 +1501,16 @@ fn draw_command_output_panel(
     } else {
         output.content.trim_end()
     };
+    let total_lines = content.lines().count().max(1);
+    if total_lines > MAX_COMMAND_OUTPUT_LINES {
+        lines.push(Line::styled(
+            format!(
+                "showing last {} of {} lines",
+                MAX_COMMAND_OUTPUT_LINES, total_lines
+            ),
+            theme.muted_style(),
+        ));
+    }
     if let Some(language) = detect_command_output_language(&output.command, content) {
         let code = strip_command_output_prefix(content);
         let highlighted = if language == "diff" {
@@ -1435,13 +1524,13 @@ fn draw_command_output_panel(
                 &theme.syntax_theme,
             )
         };
-        let window = highlighted.len().saturating_sub(4);
+        let window = highlighted.len().saturating_sub(MAX_COMMAND_OUTPUT_LINES);
         lines.extend(highlighted.into_iter().skip(window));
     } else {
         for line in content
             .lines()
             .rev()
-            .take(4)
+            .take(MAX_COMMAND_OUTPUT_LINES)
             .collect::<Vec<_>>()
             .into_iter()
             .rev()
@@ -1600,6 +1689,7 @@ fn draw_plan_panel(
     }
     if let Some(runtime) = &plan.runtime {
         lines.extend(plan_followup_lines(runtime, theme));
+        lines.extend(plan_followup_history_lines(runtime, theme));
         lines.extend(plan_job_lines(
             runtime,
             selected_job,
@@ -1904,6 +1994,44 @@ fn plan_followup_lines(runtime: &PlanRuntime, theme: &Theme) -> Vec<Line<'static
                 theme.muted_style(),
             ),
         ],
+    }
+}
+
+fn plan_followup_history_lines(runtime: &PlanRuntime, theme: &Theme) -> Vec<Line<'static>> {
+    if runtime.followup_history.is_empty() {
+        return vec![];
+    }
+
+    let mut lines = vec![Line::styled(
+        "recent followups",
+        theme.muted_style().add_modifier(Modifier::ITALIC),
+    )];
+    for followup in runtime.followup_history.iter().rev().take(2) {
+        lines.push(format_followup_history_line(followup, theme));
+    }
+    lines
+}
+
+fn format_followup_history_line(followup: &PlanFollowup, theme: &Theme) -> Line<'static> {
+    match followup {
+        PlanFollowup::Checkpoint { step, next_step } => {
+            let summary = if let Some(next_step) = next_step {
+                format!(
+                    "checkpoint: {} → {}",
+                    truncate_chat_summary(step, 28),
+                    truncate_chat_summary(next_step, 28)
+                )
+            } else {
+                format!("checkpoint: {}", truncate_chat_summary(step, 60))
+            };
+            Line::styled(summary, theme.muted_style())
+        }
+        PlanFollowup::RetryOrReplan {
+            step, retry_count, ..
+        } => Line::styled(
+            format!("retry {}: {}", retry_count, truncate_chat_summary(step, 60)),
+            Style::default().fg(Color::Rgb(245, 158, 11)),
+        ),
     }
 }
 
@@ -3279,7 +3407,8 @@ fn plan_job_transcript_lines(job: &PlanJobRecord, theme: &Theme) -> Vec<Line<'st
 #[cfg(test)]
 mod tests {
     use super::*;
-    use harper_core::PlanItem;
+    use crate::interfaces::ui::app;
+    use harper_core::{core::Message, PlanItem};
     use ratatui::style::Color;
 
     fn setup() -> (SyntaxSet, ThemeSet) {
@@ -3287,6 +3416,39 @@ mod tests {
             SyntaxSet::load_defaults_newlines(),
             ThemeSet::load_defaults(),
         )
+    }
+
+    fn empty_chat_state() -> app::ChatState {
+        app::ChatState {
+            session_id: "session-1".to_string(),
+            messages: Vec::<Message>::new(),
+            awaiting_response: false,
+            active_plan: None,
+            active_agents: None,
+            active_review: None,
+            review_selected: 0,
+            plan_step_selected: 0,
+            plan_steps_expanded: false,
+            plan_job_selected: 0,
+            plan_jobs_expanded: false,
+            plan_job_output_scroll: 0,
+            navigation_focus: app::NavigationFocus::Messages,
+            command_output: None,
+            agents_panel_expanded: false,
+            agents_scroll_offset: 0,
+            input: String::new(),
+            web_search: false,
+            web_search_enabled: false,
+            completion_candidates: Vec::new(),
+            completion_index: 0,
+            scroll_offset: 0,
+            completion_prefix: None,
+            sidebar_visible: false,
+            sidebar_sections: Vec::new(),
+            rendered_message_cache: Vec::new(),
+            rendered_transcript_lines: Vec::new(),
+            render_cache_theme_key: String::new(),
+        }
     }
 
     #[test]
@@ -3493,6 +3655,7 @@ mod tests {
                     },
                 ],
                 followup: None,
+                followup_history: Vec::new(),
                 authoring: None,
             }),
             updated_at: None,
@@ -3547,6 +3710,7 @@ mod tests {
                 },
             ],
             followup: None,
+            followup_history: Vec::new(),
             authoring: None,
         };
 
@@ -3608,6 +3772,7 @@ mod tests {
                 command: Some("cargo test".to_string()),
                 retry_count: 2,
             }),
+            followup_history: Vec::new(),
             ..Default::default()
         };
 
@@ -3625,6 +3790,7 @@ mod tests {
                 step: "Inspect server file".to_string(),
                 next_step: Some("Patch handler".to_string()),
             }),
+            followup_history: Vec::new(),
             ..Default::default()
         };
 
@@ -3653,5 +3819,71 @@ mod tests {
         let content = "def greet():\n    print(\"Hello Joy\")";
 
         assert_eq!(detect_command_output_language(command, content), Some("py"));
+    }
+
+    #[test]
+    fn derive_command_output_display_falls_back_to_plan_runtime_job_output() {
+        let mut chat_state = empty_chat_state();
+        chat_state.active_plan = Some(PlanState {
+            explanation: None,
+            items: Vec::new(),
+            runtime: Some(PlanRuntime {
+                active_tool: Some("run_command".to_string()),
+                active_command: Some("cargo test".to_string()),
+                active_status: Some("running".to_string()),
+                active_job_id: Some("job-1".to_string()),
+                jobs: vec![PlanJobRecord {
+                    job_id: "job-1".to_string(),
+                    tool: "run_command".to_string(),
+                    command: Some("cargo test".to_string()),
+                    status: PlanJobStatus::Running,
+                    output_transcript: "line one\nline two\nline three".to_string(),
+                    output_preview: Some("line two\nline three".to_string()),
+                    has_error_output: false,
+                }],
+                followup: None,
+                followup_history: Vec::new(),
+                authoring: None,
+            }),
+            updated_at: None,
+        });
+
+        let output = derive_command_output_display(&chat_state).expect("derived output");
+
+        assert_eq!(output.command, "cargo test");
+        assert_eq!(output.status_label, "running");
+        assert_eq!(output.total_line_count, 3);
+        assert!(output.content.contains("line one"));
+        assert!(output.content.contains("line three"));
+    }
+
+    #[test]
+    fn plan_followup_history_lines_render_recent_entries() {
+        let runtime = PlanRuntime {
+            followup: None,
+            followup_history: vec![
+                PlanFollowup::Checkpoint {
+                    step: "Inspect output".to_string(),
+                    next_step: Some("Patch handler".to_string()),
+                },
+                PlanFollowup::RetryOrReplan {
+                    step: "Retry failing command".to_string(),
+                    command: Some("cargo test".to_string()),
+                    retry_count: 2,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let lines = plan_followup_history_lines(&runtime, &Theme::default());
+
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].to_string().contains("recent followups"));
+        assert!(lines[1]
+            .to_string()
+            .contains("retry 2: Retry failing command"));
+        assert!(lines[2]
+            .to_string()
+            .contains("checkpoint: Inspect output → Patch handler"));
     }
 }

--- a/plans/README.md
+++ b/plans/README.md
@@ -11,9 +11,11 @@ This directory contains ready-to-use planner payloads for Harper's `update_plan`
 - `milestone-4-planner-maturity.json`
 - `agents-md-improvement.json` - dedicated plan for improving `AGENTS.md` handling
 - `routing-improvement.json` - dedicated plan for strengthening deterministic and grounded routing
+- `../PLANNER_NEXT_STEPS.md` - completed planner/runtime polish record for the last focused workstream
 
 ## Notes
 
 - All files use the same shape: `explanation` plus ordered `items`
 - Every item starts as `pending`
 - These plans are intended to be copied into Harper's `update_plan` tool flow
+- `PLANNER_NEXT_STEPS.md` is the exception: it now records a completed workstream rather than an active plan seed


### PR DESCRIPTION
## Changes

- Polished planner/runtime command output in the TUI:
  - command output now falls back to active or recent planner job output when the live stream is absent
  - the command output panel shows clearer status labels and explicit truncation summaries
  - the panel shows the last 6 lines instead of 4
- Deepened semantic authoring context in lib/harper-core/src/tools/codebase_investigator.rs:
  - added Rust type-alias links to the semantic graph
  - preserved stronger trait-implementation identity in the semantic graph
  - decomposed authoring edit candidates into one PRIMARY file and supporting files with explicit support reasons
- Added bounded planner follow-up history:
  - PlanRuntime now persists followup_history
  - follow-ups are archived when cleared, replaced, or superseded by a new job
  - the plan panel now shows recent follow-ups alongside the active follow-up and recent jobs
- Updated planner docs:
  - PLANNER_NEXT_STEPS.md now marks the tracked planner/runtime polish workstream as completed
  - plans/README.md now documents that PLANNER_NEXT_STEPS.md is a completed record rather than an active seed

## Validation

- cargo test -p harper-core extracts_type_alias_links_and_full_trait_identity -- --nocapture
- cargo test -p harper-core semantic_graph_surfaces_type_links -- --nocapture
- cargo test -p harper-core edit_plan_candidates_distinguish_primary_and_supporting_files -- --nocapture
- cargo test -p harper-core runtime_archives_followup_history_on_clear_and_replace -- --nocapture
- cargo test -p harper-ui derive_command_output_display_falls_back_to_plan_runtime_job_output -- --nocapture
- cargo test -p harper-ui plan_followup_history_lines_render_recent_entries -- --nocapture
- cargo check -p harper-core
- cargo check -p harper-ui
- cargo clippy --all-targets --all-features --workspace -- -A clippy::pedantic -D warnings