### PR TITLE
[chore] tighten routing validation and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,22 +461,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -741,6 +752,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,12 +817,6 @@ dependencies = [
  "winnow 1.0.2",
  "yaml-rust2",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -990,18 +1004,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,33 +1030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1112,17 +1087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,7 +1141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1249,69 +1212,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
+name = "dunce"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "encoding_rs"
@@ -1528,22 +1438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1526,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1757,7 +1657,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1819,17 +1718,6 @@ checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -2578,19 +2466,13 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.6",
- "rsa",
  "serde",
  "serde_json",
- "sha2",
  "signature",
  "simple_asn1",
 ]
@@ -2631,9 +2513,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -2662,12 +2541,6 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -3017,22 +2890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,7 +2953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3305,30 +3161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,15 +3215,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -3510,27 +3333,6 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.4.1",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -3691,15 +3493,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -4217,16 +4010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,7 +4025,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4258,26 +4041,6 @@ dependencies = [
  "serde_derive",
  "typeid",
  "unicode-ident",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4391,7 +4154,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4451,20 +4214,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "secret-service"
@@ -4690,7 +4439,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
  "rand_core 0.6.4",
 ]
 
@@ -4757,22 +4505,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -5436,6 +5168,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,7 @@ allow = [
     "0BSD",
     "Zlib",
     "BSL-1.0",
+    "CDLA-Permissive-2.0",
     "MPL-2.0",
     "Unicode-3.0",
     "Unicode-DFS-2016",

--- a/docs/testing/tui-control-loop-smoke.md
+++ b/docs/testing/tui-control-loop-smoke.md
@@ -1,0 +1,138 @@
+# TUI Control Loop Smoke
+
+This smoke checklist validates the control-loop behavior added to Harper's chat and plan runtime:
+
+- classify intent
+- decide task mode
+- inspect or plan when needed
+- execute tools
+- emit feedback and retry/replan state
+- surface loop state in the TUI
+
+## Fast pre-check without the TUI
+
+Before doing the manual TUI pass, use `harper-batch` to verify the same core chat flow in a shell:
+
+```bash
+cargo run -p harper-ui --bin harper-batch -- --strategy deterministic --prompt "where is execution strategy used in this repo"
+```
+
+```bash
+cargo run -p harper-ui --bin harper-batch -- --strategy deterministic \
+  --prompt "run the git status" \
+  --prompt "run that"
+```
+
+What `harper-batch` shows:
+
+- `ROUTING`
+  - selected strategy
+  - task mode such as `direct_deterministic` or `respond_only`
+- `DETERMINISTIC INTENT`
+  - the routed deterministic intent when one exists
+- `NORMALIZED COMMAND`
+  - command normalization for run-command paths
+- `CLARIFICATION`
+  - follow-up clarification when Harper refuses an ambiguous action
+- `ACTIVITY`
+  - runtime stage transitions
+- `ASSISTANT`
+  - final response text
+
+Use this first when debugging natural-language behavior. If the shell harness is wrong, the TUI will also be wrong because both use the same `ChatService` flow.
+
+## Preconditions
+
+- Launch Harper inside this repository.
+- Use a session with the standard TUI header and plan panel visible.
+- If needed, ensure the plan panel is visible from the chat screen.
+
+## 1. Grounded deterministic request
+
+Set strategy:
+
+- `/strategy grounded`
+
+Prompt:
+
+- `where is execution strategy used in this repo`
+
+Expected behavior:
+
+- Harper should take the deterministic inspection path quickly.
+- The header activity should briefly show stages like:
+  - `executing deterministic action`
+  - `summarizing result`
+- Harper should respond with grounded repo information rather than generic prose.
+
+## 2. Planned authoring request
+
+Set strategy:
+
+- `/strategy grounded`
+
+Prompt:
+
+- `refactor the planner flow in this repo and then update the tui followup rendering`
+
+Expected behavior:
+
+- Harper should not jump straight to editing.
+- The header activity should show stages like:
+  - `planning task`
+  - `inspecting repo context`
+- The plan panel should persist loop information such as:
+  - `loop: plan`
+  - `loop: inspect`
+- If a plan exists, the plan panel should continue to show loop state after the transient header activity clears.
+
+## 3. Plain response request
+
+Set strategy:
+
+- `/strategy auto`
+
+Prompt:
+
+- `what is the difference between grounded and deterministic`
+
+Expected behavior:
+
+- Harper should respond directly.
+- The request should not be forced into a plan or repo inspection path.
+- The header activity should align with a response-only flow.
+
+## 4. Retry / replan path
+
+Prompt shape:
+
+- use any planned task that causes a failing validation or blocked command
+- or trigger planner follow-up actions through the existing retry / replan flow
+
+Expected behavior:
+
+- The plan panel should persist outcome lines such as:
+  - `last outcome: retry suggested`
+  - `last outcome: replan required`
+- The plan panel should also show the latest feedback summary line below the outcome.
+
+## 5. Follow-up history visibility
+
+Prompt shape:
+
+- complete or replace a follow-up during a planned task
+
+Expected behavior:
+
+- The plan panel should show:
+  - the active follow-up when present
+  - `recent followups`
+  - recent archived follow-up entries
+
+## Notes
+
+This smoke does not verify every tool path. It is focused on the visible control loop:
+
+- decision gate
+- runtime loop state
+- TUI loop rendering

--- a/docs/testing/tui-routing-smoke.md
+++ b/docs/testing/tui-routing-smoke.md
@@ -2,6 +2,23 @@
 
 Use this checklist to verify Harper’s repo-aware routing, grounded tool use, and TUI rendering after changes to chat routing, codebase helpers, file tools, or transcript rendering.
 
+Before opening the TUI, pre-check the same prompts through `harper-batch` so routing, command normalization, and follow-up resolution can be debugged from the shell first:
+
+```bash
+target/debug/harper-batch --strategy deterministic --prompt "where is execution strategy used in this repo"
+target/debug/harper-batch --strategy deterministic --prompt "run the git status" --prompt "run that"
+target/debug/harper-batch --strategy grounded --prompt "where is execution strategy used in this repo"
+target/debug/harper-batch --strategy auto --prompt "run the git status" --prompt "run that"
+```
+
+Read these fields in the shell output before moving to the TUI:
+
+- `ROUTING`
+- `DETERMINISTIC INTENT`
+- `NORMALIZED COMMAND`
+- `ACTIVITY`
+- `ASSISTANT`
+
 ## Prerequisites
 
 - Build from the current workspace.
@@ -24,7 +41,7 @@ Use this checklist to verify Harper’s repo-aware routing, grounded tool use, a
 ### Header and strategy UI
 
 - Type `/`
-- Press `Tab` to cycle slash completions
+- Press `↑` / `↓` or `Tab` to move through slash completions
 - `/strategy`
 - `/strategy auto`
 - `/strategy grounded`
@@ -62,6 +79,8 @@ Use this checklist to verify Harper’s repo-aware routing, grounded tool use, a
 - `Run git status and summarize it.`
 - `show git diff`
 - `check the code changes`
+- `run the git status`
+- `run that`
 
 ### Simple command routing
 
@@ -106,6 +125,7 @@ Use this exact sequence:
 - Codebase prompts do not answer with generic grep advice.
 - Open-ended authoring prompts inspect first and should not jump straight to a bad edit target.
 - `git status` runs `git status`, not `git status and summarize it`.
+- `run that` resolves to the prior runnable command when the prior turn produced one.
 - Create/modify prompts route to real write operations.
 - Created file responses show fenced content with syntax highlighting.
 - Diff/code outputs render with syntax-aware formatting when detectable.
@@ -115,7 +135,7 @@ Use this exact sequence:
 - [ ] Repo identity prompts return grounded repo/branch data.
 - [ ] Current working directory prompt returns the concrete workspace path.
 - [ ] Typing `/` opens slash completion suggestions.
-- [ ] `Tab` cycles slash completions.
+- [ ] `↑` / `↓` and `Tab` move through slash completions.
 - [ ] `/strategy` shows the current strategy and switching it changes the live session.
 - [ ] Header widget changes persist after save and restart.
 - [ ] Chat header only shows the widgets currently enabled.
@@ -123,6 +143,7 @@ Use this exact sequence:
 - [ ] Codebase overview uses grounded workspace context.
 - [ ] Codebase search returns relevant repo files, not generic prose.
 - [ ] Open-ended authoring builds context/plan before first edit.
+- [ ] `run that` resolves to the previous runnable command instead of executing the literal word `that`.
 - [ ] Git status/diff route to the correct underlying tool/command.
 - [ ] `clear`, `pwd`, and `ls` route as commands, not literal prose.
 - [ ] `run harper`, `run fmt`, `run check`, and `run tests` route as execution-layer commands.

--- a/docs/user-guide/about.md
+++ b/docs/user-guide/about.md
@@ -47,16 +47,48 @@ The main interactive chat interface. This is what you use for:
 
 ### harper-batch
 
-Batch processing mode for running multiple operations:
+Shell-facing chat harness for non-TUI debugging and scripted runs:
 
 ```bash
-cargo run --bin harper-batch -- [options]
+cargo run -p harper-ui --bin harper-batch -- --prompt "..."
 ```
 
 Use this for:
-- Processing multiple files
-- Bulk operations
-- Non-interactive tasks
+- Verifying natural-language behavior without opening the TUI
+- Comparing `auto`, `grounded`, `deterministic`, and `model` strategy routing
+- Running repeatable prompt sequences in a single session
+- Capturing runtime activity and command output in shell or JSON form
+
+Supported options:
+
+- `--prompt <text>` repeatable prompt input
+- `--strategy <mode>` where mode is `auto`, `grounded`, `deterministic`, or `model`
+- `--json` machine-readable output
+- `--web` enable web search for the session
+
+Examples:
+
+```bash
+cargo run -p harper-ui --bin harper-batch -- --strategy deterministic --prompt "where is execution strategy used in this repo"
+```
+
+```bash
+cargo run -p harper-ui --bin harper-batch -- --strategy deterministic \
+  --prompt "run the git status" \
+  --prompt "run that"
+```
+
+```bash
+printf 'hi\nwhat is the difference between grounded and deterministic\n' \
+  | cargo run -p harper-ui --bin harper-batch -- --strategy auto
+```
+
+The output includes:
+
+- routing summary
+- runtime activity stages
+- command output when a tool executes
+- final assistant response
 
 ## How It Works
 
@@ -79,7 +111,7 @@ Use this for:
    - Reads user input
    - Sends to AI model
    - Displays response
-   - Handles commands (like `/help`, `/save`, etc.)
+   - Handles commands (like `/help`, `/strategy`, and `/agents`)
 
 ### Architecture
 

--- a/docs/user-guide/chat.md
+++ b/docs/user-guide/chat.md
@@ -22,9 +22,16 @@ Harper supports slash commands for various operations. All commands start with `
 | `/quit` | Same as /exit |
 | `/help` | Show available commands |
 | `/clear` | Clear the current session |
-| `/save` | Save current session to disk |
-| `/load` | Load a saved session |
 | `/audit` | View command history (e.g., `/audit 10`) |
+| `/strategy` | Show or change the execution strategy |
+| `/strategy auto` | Switch the live chat session to `auto` |
+| `/strategy grounded` | Switch the live chat session to `grounded` |
+| `/strategy deterministic` | Switch the live chat session to `deterministic` |
+| `/strategy model` | Switch the live chat session to `model` |
+| `/agents` | Show AGENTS context status for the current session |
+| `/agents status` | Same as `/agents` |
+| `/agents on` | Enable AGENTS context resolution in the TUI session |
+| `/agents off` | Disable AGENTS context resolution in the TUI session |
 
 ### Using Commands
 
@@ -36,10 +43,12 @@ Available commands:
 /exit, /quit - Exit the application
 /help    - Show this message
 /clear   - Clear current session
-/save    - Save current session
-/load    - Load a saved session
 /audit   - View command history
+/strategy - Show current execution strategy
+/agents  - Show AGENTS context status
 ```
+
+Typing `/` in the TUI opens the slash-command list. Use `↑` / `↓` or `Tab` to move through suggestions, then keep typing or submit the selected command from the normal message input.
 
 ## Chat Features
 
@@ -61,13 +70,7 @@ Harper maintains a history of your commands within the session. Use the up and d
 
 ### Session Persistence
 
-Your chat sessions can be saved and loaded later. This feature allows you to:
-
-- **Save Session**: Use `/save` to persist your conversation
-- **Load Session**: Use `/load` to restore a previous conversation
-- **Continue Later**: Pick up where you left off
-
-Sessions are stored locally and include your entire conversation history with the AI.
+Harper keeps local sessions in its built-in session store. Use the Home screen, History screen, export flow, and session preview flow to revisit previous conversations rather than relying on ad hoc chat commands.
 
 ### Command Logging
 
@@ -79,6 +82,24 @@ Harper logs all shell commands executed during your session. You can review thes
 - stdout/stderr previews
 
 This ensures every operation is traceable for security and debugging purposes.
+
+### Strategy-aware routing
+
+Execution strategy changes how Harper chooses between deterministic tools and model-backed reasoning:
+
+- `deterministic` prefers direct grounded tool execution for supported intents
+- `grounded` prefers deterministic grounding first for routable repo questions, then allows model synthesis when needed
+- `auto` remains tool-assisted and can still fall back to deterministic handling for supported prompts
+- `model` disables deterministic shortcuts
+
+For fast verification without the TUI, use `harper-batch`:
+
+```bash
+target/debug/harper-batch --strategy deterministic --prompt "where is execution strategy used in this repo"
+target/debug/harper-batch --strategy deterministic --prompt "run the git status" --prompt "run that"
+```
+
+That prints the selected strategy, task mode, routed deterministic intent, normalized command when one exists, runtime activity, and the final assistant reply.
 
 ## Sending Messages
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -43,7 +43,7 @@ writable_dirs = ["./tmp", "./build"]
 ```
 
 - `approval_profile` controls when Harper asks before running commands.
-- `execution_strategy` controls whether Harper prefers model-first grounded behavior, deterministic execution, or no deterministic shortcuts.
+- `execution_strategy` controls whether Harper prefers direct grounded tool execution, deterministic-first grounding with model synthesis, tool-assisted behavior, or no deterministic shortcuts.
 - `sandbox_profile` controls the default sandbox boundary.
 - `retry_max_attempts` controls bounded automatic retries for retry-safe failures.
 - `header_widgets` controls which status items appear in the chat header. You can edit that list from `Settings -> Execution Policy`, and saving the screen writes the selection back to `config/local.toml`.
@@ -68,14 +68,22 @@ Under `allow_listed`, Harper still asks for approval when a command declares net
 
 ## Repo-aware routing
 
-Harper now uses deterministic routing only for high-confidence workspace intents, not as a replacement for model reasoning.
+Harper now uses an explicit strategy-dependent control path for repo-aware work.
+
+- `deterministic` prefers direct grounded tool execution for supported intents
+- `grounded` prefers deterministic grounding first for routable repo questions, then allows model synthesis when needed
+- `auto` remains tool-assisted and can still fall back to deterministic handling for supported prompts
+- `model` disables deterministic shortcuts
+
+Supported deterministic-style intents still include:
 
 - direct operational facts such as `which branch am i on` or `which repo are we working on`
 - direct file reads such as `read Cargo.toml`
 - simple create/write prompts such as `create hello.rs with ...`
 - direct command prompts such as `run git status`
+- codebase prompts such as `where is X used`, `what calls X`, and `where is X defined`
 
-For broader repo questions such as `tell me the codebase` or `find where X is rendered`, Harper first gathers structured codebase context, then lets the model answer from that grounded context. Deterministic summaries remain fallback only when the model returns an empty or low-value response.
+For broader repo questions such as `tell me the codebase` or open-ended authoring prompts, Harper first gathers structured codebase or authoring context, then lets the model answer from that grounded context. If the model backend is unavailable and no deterministic fallback exists, Harper returns a clear assistant reply instead of a raw API error.
 
 ## API Configuration
 

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -53,8 +53,8 @@ Here are the commands you'll use most often:
 |---------|-------------|
 | `/help` | Show all available commands |
 | `/clear` | Start a new conversation |
-| `/save` | Save your current session |
-| `/load` | Load a saved session |
+| `/strategy` | Show or change the execution strategy |
+| `/agents` | Show AGENTS context status for the current session |
 | `/exit` | Exit Harper |
 
 ## Basic Workflows
@@ -76,14 +76,9 @@ Example:
 2. Paste it in Harper
 3. Ask what the error means
 
-### Saving Work
+### Revisiting Work
 
-1. After a productive session, type:
-   ```
-   > /save
-   ```
-2. Give your session a name when prompted
-3. Later, use `/load` to continue
+Use the Home screen, History screen, export flow, and session preview flow to revisit previous conversations. For routing and command-behavior checks, use `harper-batch` first before opening the TUI.
 
 ## Tips for Better Results
 

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -41,7 +41,7 @@ tower = "0.5"
 futures-util = "0.3"
 uuid = { version = "1.17.0", features = ["v4"] }
 ring = "0.17.14"
-jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 aes = "0.8"
 cbc = "0.1"
 ctr = "0.9"

--- a/lib/harper-core/src/agent/chat.rs
+++ b/lib/harper-core/src/agent/chat.rs
@@ -38,6 +38,7 @@ use rustyline::error::ReadlineError;
 use rustyline::highlight::Highlighter;
 use rustyline::hint::Hinter;
 use rustyline::validate::Validator;
+use serde::Serialize;
 
 use rustyline::Editor;
 use rustyline::Helper;
@@ -205,6 +206,46 @@ pub struct ChatService<'a> {
     execution_strategy: ExecutionStrategy,
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ChatTurnDebugSummary {
+    pub strategy: String,
+    pub task_mode: String,
+    pub deterministic_intent: Option<String>,
+    pub normalized_command: Option<String>,
+    pub clarification: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TaskMode {
+    DirectDeterministic,
+    PlanThenAct,
+    InspectThenExecute,
+    ToolAssisted,
+    RespondOnly,
+}
+
+impl TaskMode {
+    fn initial_activity_label(self) -> &'static str {
+        match self {
+            Self::DirectDeterministic => "executing deterministic action",
+            Self::PlanThenAct => "planning task",
+            Self::InspectThenExecute => "inspecting repo context",
+            Self::ToolAssisted => "selecting tool",
+            Self::RespondOnly => "responding",
+        }
+    }
+
+    fn model_activity_label(self) -> &'static str {
+        match self {
+            Self::DirectDeterministic => "summarizing result",
+            Self::PlanThenAct => "reasoning over plan",
+            Self::InspectThenExecute => "reasoning over grounded context",
+            Self::ToolAssisted => "thinking",
+            Self::RespondOnly => "responding",
+        }
+    }
+}
+
 #[allow(dead_code)]
 impl<'a> ChatService<'a> {
     const AUDIT_LOG_LIMIT: usize = 10;
@@ -248,6 +289,46 @@ impl<'a> ChatService<'a> {
     pub fn with_runtime_events(mut self, runtime_events: Arc<dyn RuntimeEventSink>) -> Self {
         self.runtime_events = Some(runtime_events);
         self
+    }
+
+    pub fn debug_turn_summary(&self, history: &[Message], user_msg: &str) -> ChatTurnDebugSummary {
+        let deterministic_intent = route_intent(user_msg).or_else(|| {
+            Self::infer_followup_write_file_intent(history, user_msg)
+                .map(DeterministicIntent::WriteFile)
+                .or_else(|| {
+                    Self::infer_followup_run_command_intent(history, user_msg)
+                        .map(DeterministicIntent::RunCommand)
+                })
+        });
+        let task_mode = if route_intent(user_msg).is_none() && deterministic_intent.is_some() {
+            TaskMode::DirectDeterministic
+        } else {
+            Self::decide_task_mode(self.execution_strategy, user_msg)
+        };
+
+        let normalized_command = deterministic_intent
+            .as_ref()
+            .and_then(|intent| match intent {
+                DeterministicIntent::RunCommand(intent) => {
+                    Some(Self::normalize_run_command_candidate(&intent.command))
+                }
+                _ => None,
+            });
+
+        let clarification = normalized_command.as_ref().and_then(|command| {
+            let tool_call = format!("[RUN_COMMAND {}]", command);
+            Self::clarification_for_underspecified_tool_call(user_msg, &tool_call)
+        });
+
+        ChatTurnDebugSummary {
+            strategy: Self::execution_strategy_name(self.execution_strategy).to_string(),
+            task_mode: Self::format_task_mode(task_mode).to_string(),
+            deterministic_intent: deterministic_intent
+                .as_ref()
+                .map(Self::format_deterministic_intent),
+            normalized_command,
+            clarification,
+        }
     }
 
     /// Create a new chat service for testing
@@ -896,7 +977,49 @@ impl<'a> ChatService<'a> {
             .find(|message| message.role == "user")
             .map(|message| message.content.clone())
             .unwrap_or_default();
+        let task_mode =
+            if self.should_force_followup_deterministic(history, &last_user_msg, session_id) {
+                TaskMode::DirectDeterministic
+            } else {
+                Self::decide_task_mode(self.execution_strategy, &last_user_msg)
+            };
+        self.emit_activity_update(
+            session_id,
+            Some(task_mode.initial_activity_label().to_string()),
+        );
+        self.persist_loop_stage(
+            session_id,
+            match task_mode {
+                TaskMode::DirectDeterministic | TaskMode::ToolAssisted => {
+                    crate::core::plan::PlanLoopStage::Executing
+                }
+                TaskMode::PlanThenAct => crate::core::plan::PlanLoopStage::Planning,
+                TaskMode::InspectThenExecute => crate::core::plan::PlanLoopStage::Inspecting,
+                TaskMode::RespondOnly => crate::core::plan::PlanLoopStage::Responding,
+            },
+            Some(task_mode.initial_activity_label().to_string()),
+        );
         let mut authoring_context = None;
+        if matches!(task_mode, TaskMode::PlanThenAct) {
+            self.emit_activity_update(session_id, Some("planning task".to_string()));
+            self.persist_loop_stage(
+                session_id,
+                crate::core::plan::PlanLoopStage::Planning,
+                Some("planning task".to_string()),
+            );
+        }
+        if matches!(
+            task_mode,
+            TaskMode::PlanThenAct | TaskMode::InspectThenExecute
+        ) && Self::request_needs_authoring_flow(&last_user_msg)
+        {
+            self.emit_activity_update(session_id, Some("inspecting repo context".to_string()));
+            self.persist_loop_stage(
+                session_id,
+                crate::core::plan::PlanLoopStage::Inspecting,
+                Some("inspecting repo context".to_string()),
+            );
+        }
         if let Some(authoring_request_context) =
             self.authoring_prompt_for_request(&last_user_msg).await?
         {
@@ -907,11 +1030,37 @@ impl<'a> ChatService<'a> {
             authoring_context = Some(authoring_request_context);
         }
 
-        if Self::should_prefer_deterministic_routing(self.execution_strategy, &last_user_msg) {
+        let should_try_deterministic_now =
+            self.should_force_followup_deterministic(history, &last_user_msg, session_id)
+                || (Self::should_prefer_deterministic_routing(
+                    self.execution_strategy,
+                    &last_user_msg,
+                ) && route_intent(&last_user_msg).is_some());
+        if !matches!(task_mode, TaskMode::RespondOnly) && should_try_deterministic_now {
+            self.emit_activity_update(
+                session_id,
+                Some("executing deterministic action".to_string()),
+            );
+            self.persist_loop_stage(
+                session_id,
+                crate::core::plan::PlanLoopStage::Executing,
+                Some("executing deterministic action".to_string()),
+            );
             if let Some((tool_name, tool_content)) = self
                 .try_handle_deterministic_intent(history, &last_user_msg, session_id)
                 .await?
             {
+                self.emit_activity_update(session_id, Some("summarizing result".to_string()));
+                self.persist_loop_stage(
+                    session_id,
+                    crate::core::plan::PlanLoopStage::Feedback,
+                    Some("summarizing result".to_string()),
+                );
+                self.persist_loop_outcome(
+                    session_id,
+                    crate::core::plan::PlanLoopOutcome::Succeeded,
+                    Some("deterministic action completed".to_string()),
+                );
                 return self
                     .summarize_deterministic_tool_result(
                         &client,
@@ -925,8 +1074,47 @@ impl<'a> ChatService<'a> {
             }
         }
 
-        self.emit_activity_update(session_id, Some("thinking".to_string()));
-        let mut response = self.call_llm(&client, &history_for_llm).await?;
+        self.emit_activity_update(
+            session_id,
+            Some(task_mode.model_activity_label().to_string()),
+        );
+        self.persist_loop_stage(
+            session_id,
+            match task_mode {
+                TaskMode::PlanThenAct => crate::core::plan::PlanLoopStage::Planning,
+                TaskMode::InspectThenExecute => crate::core::plan::PlanLoopStage::Inspecting,
+                TaskMode::DirectDeterministic | TaskMode::ToolAssisted => {
+                    crate::core::plan::PlanLoopStage::Executing
+                }
+                TaskMode::RespondOnly => crate::core::plan::PlanLoopStage::Responding,
+            },
+            Some(task_mode.model_activity_label().to_string()),
+        );
+        let mut response = match self.call_llm(&client, &history_for_llm).await {
+            Ok(response) => response,
+            Err(HarperError::Api(_)) | Err(HarperError::Command(_)) => {
+                if matches!(task_mode, TaskMode::RespondOnly) {
+                    return Ok(Self::model_backend_unavailable_reply());
+                }
+                if let Some((tool_name, tool_content)) = self
+                    .try_handle_deterministic_intent(history, &last_user_msg, session_id)
+                    .await?
+                {
+                    return self
+                        .summarize_deterministic_tool_result(
+                            &client,
+                            &mut history_for_llm,
+                            history,
+                            session_id,
+                            &tool_name,
+                            &tool_content,
+                        )
+                        .await;
+                }
+                return Ok(Self::model_backend_unavailable_reply());
+            }
+            Err(err) => return Err(err),
+        };
         let mut executed_tool_calls: HashSet<String> = HashSet::new();
         let mut injected_agents_guidance: HashSet<String> = HashSet::new();
         let mut last_tool_content: Option<String> = None;
@@ -990,10 +1178,11 @@ impl<'a> ChatService<'a> {
 
         for _ in 0..MAX_TOOL_ROUNDS {
             let clean_response = Self::sanitize_model_response(&response);
-            let tool_signature = Self::tool_call_signature(&clean_response);
+            let normalized_tool_call = Self::normalize_tool_call_for_execution(&clean_response);
+            let tool_signature = Self::tool_call_signature(&normalized_tool_call);
             let dedupe_key = tool_signature
                 .clone()
-                .unwrap_or_else(|| clean_response.clone());
+                .unwrap_or_else(|| normalized_tool_call.clone());
             if self.execution_strategy != ExecutionStrategy::Deterministic
                 && matches!(
                     self.execution_strategy,
@@ -1028,8 +1217,35 @@ impl<'a> ChatService<'a> {
                         required_tool
                     ),
                 });
-                self.emit_activity_update(session_id, Some("thinking".to_string()));
-                response = self.call_llm(&client, &history_for_llm).await?;
+                self.emit_activity_update(
+                    session_id,
+                    Some(task_mode.model_activity_label().to_string()),
+                );
+                response = match self.call_llm(&client, &history_for_llm).await {
+                    Ok(response) => response,
+                    Err(HarperError::Api(_)) | Err(HarperError::Command(_)) => {
+                        if matches!(task_mode, TaskMode::RespondOnly) {
+                            return Ok(Self::model_backend_unavailable_reply());
+                        }
+                        if let Some((tool_name, tool_content)) = self
+                            .try_handle_deterministic_intent(history, &last_user_msg, session_id)
+                            .await?
+                        {
+                            return self
+                                .summarize_deterministic_tool_result(
+                                    &client,
+                                    &mut history_for_llm,
+                                    history,
+                                    session_id,
+                                    &tool_name,
+                                    &tool_content,
+                                )
+                                .await;
+                        }
+                        return Ok(Self::model_backend_unavailable_reply());
+                    }
+                    Err(err) => return Err(err),
+                };
                 continue;
             }
             let merged_candidate_paths = authoring_context
@@ -1045,7 +1261,7 @@ impl<'a> ChatService<'a> {
                 });
             if let Some(authoring_retry_prompt) = Self::authoring_tool_retry_prompt(
                 &last_user_msg,
-                &clean_response,
+                &normalized_tool_call,
                 merged_candidate_paths.as_ref(),
                 saw_authoring_inspection,
                 saw_plan_update,
@@ -1056,12 +1272,15 @@ impl<'a> ChatService<'a> {
                     role: "system".to_string(),
                     content: authoring_retry_prompt,
                 });
-                self.emit_activity_update(session_id, Some("thinking".to_string()));
+                self.emit_activity_update(
+                    session_id,
+                    Some(task_mode.model_activity_label().to_string()),
+                );
                 response = self.call_llm(&client, &history_for_llm).await?;
                 continue;
             }
             if let Some(agents_prompt) = self.agents_guidance_for_tool_call(
-                &clean_response,
+                &normalized_tool_call,
                 session_id,
                 &injected_agents_guidance,
             )? {
@@ -1070,7 +1289,10 @@ impl<'a> ChatService<'a> {
                     role: "system".to_string(),
                     content: agents_prompt,
                 });
-                self.emit_activity_update(session_id, Some("thinking".to_string()));
+                self.emit_activity_update(
+                    session_id,
+                    Some(task_mode.model_activity_label().to_string()),
+                );
                 response = self.call_llm(&client, &history_for_llm).await?;
                 continue;
             }
@@ -1079,6 +1301,22 @@ impl<'a> ChatService<'a> {
                     return Ok(format!("Tool result:\n{}", content));
                 }
                 break;
+            }
+            if let Some(clarification) = Self::clarification_for_underspecified_tool_call(
+                &last_user_msg,
+                &normalized_tool_call,
+            ) {
+                self.persist_loop_stage(
+                    session_id,
+                    crate::core::plan::PlanLoopStage::Feedback,
+                    Some("clarification required".to_string()),
+                );
+                self.persist_loop_outcome(
+                    session_id,
+                    crate::core::plan::PlanLoopOutcome::Failed,
+                    Some(clarification.clone()),
+                );
+                return Ok(clarification);
             }
             let tool_option = {
                 let mut tool_service = ToolService::new(
@@ -1098,7 +1336,7 @@ impl<'a> ChatService<'a> {
                     .handle_tool_use(
                         &client,
                         &history_for_llm,
-                        &clean_response,
+                        &normalized_tool_call,
                         web_search_enabled,
                     )
                     .await?
@@ -1106,7 +1344,7 @@ impl<'a> ChatService<'a> {
 
             if let Some((tool_result, tool_content)) = tool_option {
                 self.notify_command_activity(session_id);
-                if let Some(tool_name) = Self::tool_name_from_tool_call(&clean_response) {
+                if let Some(tool_name) = Self::tool_name_from_tool_call(&normalized_tool_call) {
                     if tool_name == "update_plan" {
                         saw_plan_update = true;
                         if let Some(authoring_request_context) = authoring_context.as_ref() {
@@ -1135,10 +1373,11 @@ impl<'a> ChatService<'a> {
                             | "grep"
                     ) {
                         saw_authoring_inspection = true;
-                        let inspected = ToolService::target_paths_for_tool_call(&clean_response)
-                            .into_iter()
-                            .map(Self::normalize_authoring_path)
-                            .collect::<Vec<_>>();
+                        let inspected =
+                            ToolService::target_paths_for_tool_call(&normalized_tool_call)
+                                .into_iter()
+                                .map(Self::normalize_authoring_path)
+                                .collect::<Vec<_>>();
                         inspected_paths.extend(inspected.iter().cloned());
                         let _ = crate::tools::plan::mark_plan_authoring_inspection(
                             self.conn,
@@ -1150,7 +1389,7 @@ impl<'a> ChatService<'a> {
                         );
                     }
                     if matches!(tool_name.as_str(), "search_replace" | "write_file") {
-                        let edited = ToolService::target_paths_for_tool_call(&clean_response)
+                        let edited = ToolService::target_paths_for_tool_call(&normalized_tool_call)
                             .into_iter()
                             .map(Self::normalize_authoring_path)
                             .collect::<Vec<_>>();
@@ -1164,7 +1403,7 @@ impl<'a> ChatService<'a> {
                         );
                     }
                     if tool_name == "run_command"
-                        && Self::is_authoring_validation_command(&clean_response)
+                        && Self::is_authoring_validation_command(&normalized_tool_call)
                     {
                         let _ = crate::tools::plan::mark_plan_authoring_validated(
                             self.conn, session_id,
@@ -1185,6 +1424,17 @@ impl<'a> ChatService<'a> {
 
             break;
         }
+
+        self.persist_loop_stage(
+            session_id,
+            crate::core::plan::PlanLoopStage::Feedback,
+            Some("response ready".to_string()),
+        );
+        self.persist_loop_outcome(
+            session_id,
+            crate::core::plan::PlanLoopOutcome::Responded,
+            Some("response delivered".to_string()),
+        );
 
         Ok(Self::finalize_assistant_response(
             &response,
@@ -1272,6 +1522,25 @@ impl<'a> ChatService<'a> {
                 let _ = runtime_events.activity_updated(&session_id, status).await;
             });
         }
+    }
+
+    fn persist_loop_stage(
+        &self,
+        session_id: &str,
+        stage: crate::core::plan::PlanLoopStage,
+        feedback: Option<String>,
+    ) {
+        let _ = crate::tools::plan::set_plan_loop_stage(self.conn, session_id, stage, feedback);
+    }
+
+    fn persist_loop_outcome(
+        &self,
+        session_id: &str,
+        outcome: crate::core::plan::PlanLoopOutcome,
+        feedback: Option<String>,
+    ) {
+        let _ =
+            crate::tools::plan::record_plan_loop_outcome(self.conn, session_id, outcome, feedback);
     }
 
     fn plan_prompt_for_request(
@@ -1669,6 +1938,82 @@ impl<'a> ChatService<'a> {
         parsing::extract_tool_arg(trimmed, "[RUN_COMMAND").ok()
     }
 
+    fn normalize_tool_call_for_execution(tool_call_json: &str) -> String {
+        let Some(tool_name) = Self::tool_name_from_tool_call(tool_call_json) else {
+            return tool_call_json.to_string();
+        };
+        if tool_name != "run_command" {
+            return tool_call_json.to_string();
+        }
+        let Some(command) = Self::extract_run_command_text(tool_call_json) else {
+            return tool_call_json.to_string();
+        };
+        let normalized_command = Self::normalize_run_command_candidate(&command);
+        if normalized_command == command {
+            return tool_call_json.to_string();
+        }
+
+        let trimmed = tool_call_json.trim();
+        if let Ok(mut json_value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            if let Some(args) = json_value.get_mut("args") {
+                if let Some(command_value) = args.get_mut("command") {
+                    *command_value = serde_json::Value::String(normalized_command.clone());
+                    return json_value.to_string();
+                }
+            }
+            if let Some(args) = json_value.get_mut("arguments") {
+                if let Some(command_value) = args.get_mut("command") {
+                    *command_value = serde_json::Value::String(normalized_command.clone());
+                    return json_value.to_string();
+                }
+            }
+        }
+
+        format!("[RUN_COMMAND {}]", normalized_command)
+    }
+
+    fn normalize_run_command_candidate(command: &str) -> String {
+        let mut candidate = command.trim();
+        if let Some(stripped) = candidate.strip_prefix("the ") {
+            candidate = stripped.trim();
+        }
+        if let Some(stripped) = candidate.strip_suffix(" command") {
+            candidate = stripped.trim();
+        }
+        candidate = candidate.trim_matches(|c: char| matches!(c, '"' | '\''));
+        candidate = candidate.trim_end_matches(['.', ',', ';', ':']);
+        let candidate = Self::trim_run_command_suffixes(candidate);
+        match candidate.to_ascii_lowercase().as_str() {
+            "git status" => "git status".to_string(),
+            "git diff" => "git diff".to_string(),
+            "clear" => "clear".to_string(),
+            "pwd" => "pwd".to_string(),
+            "ls" => "ls".to_string(),
+            "date" => "date".to_string(),
+            "whoami" => "whoami".to_string(),
+            _ => candidate.to_string(),
+        }
+    }
+
+    fn trim_run_command_suffixes(candidate: &str) -> &str {
+        let lowered = candidate.to_ascii_lowercase();
+        for suffix in [
+            " and summarize it",
+            " and summarize",
+            " then summarize it",
+            " then summarize",
+            " and explain it",
+            " and explain",
+            " and show me",
+        ] {
+            if lowered.ends_with(suffix) {
+                let idx = candidate.len() - suffix.len();
+                return candidate[..idx].trim();
+            }
+        }
+        candidate
+    }
+
     fn is_authoring_validation_command(tool_call_json: &str) -> bool {
         let Some(command) = Self::extract_run_command_text(tool_call_json) else {
             return false;
@@ -1810,6 +2155,90 @@ impl<'a> ChatService<'a> {
         None
     }
 
+    fn clarification_for_underspecified_tool_call(
+        user_msg: &str,
+        tool_call: &str,
+    ) -> Option<String> {
+        let tool_name = Self::tool_name_from_tool_call(tool_call)?;
+        let underspecified_prompt = Self::is_underspecified_prompt(user_msg);
+        if matches!(
+            tool_name.as_str(),
+            "read_file" | "write_file" | "search_replace"
+        ) && underspecified_prompt
+        {
+            let target_paths = ToolService::target_paths_for_tool_call(tool_call);
+            if target_paths
+                .iter()
+                .any(|path| Self::looks_like_placeholder_target(path))
+            {
+                return Some(
+                    "Your message is too ambiguous to act on safely. Name a real repository file or describe the task more specifically."
+                        .to_string(),
+                );
+            }
+        }
+
+        if tool_name == "run_command" {
+            let command = Self::extract_run_command_text(tool_call)
+                .map(|value| Self::normalize_run_command_candidate(&value))
+                .unwrap_or_default();
+            if Self::is_followup_run_command_placeholder(&command) {
+                return Some(
+                    "I do not know which previous command you mean. Name the exact command you want to run."
+                        .to_string(),
+                );
+            }
+        }
+
+        None
+    }
+
+    fn is_underspecified_prompt(user_msg: &str) -> bool {
+        let trimmed = user_msg.trim();
+        if trimmed.is_empty() {
+            return true;
+        }
+        let tokens = trimmed.split_whitespace().collect::<Vec<_>>();
+        tokens.len() <= 1
+            && trimmed.len() <= 4
+            && !trimmed.contains('/')
+            && !trimmed.contains('.')
+            && !trimmed.starts_with('/')
+            && !trimmed.starts_with('!')
+            && !trimmed.starts_with('@')
+    }
+
+    fn looks_like_placeholder_target(path: &Path) -> bool {
+        let rendered = path.to_string_lossy().to_ascii_lowercase();
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        rendered.contains("example.")
+            || rendered.contains("path/to/")
+            || rendered.contains("your_file")
+            || rendered.contains("placeholder")
+            || matches!(
+                file_name.as_str(),
+                "example.txt" | "example.rs" | "example.md" | "file.txt" | "note.txt" | "main.rs"
+            )
+    }
+
+    fn is_followup_run_command_placeholder(command: &str) -> bool {
+        matches!(
+            command.trim().to_ascii_lowercase().as_str(),
+            "that"
+                | "this"
+                | "it"
+                | "that one"
+                | "this one"
+                | "that command"
+                | "this command"
+                | "the command"
+        )
+    }
+
     async fn try_handle_deterministic_intent(
         &self,
         history: &[Message],
@@ -1819,6 +2248,12 @@ impl<'a> ChatService<'a> {
         let routed_intent = route_intent(user_msg).or_else(|| {
             Self::infer_followup_write_file_intent(history, user_msg)
                 .map(DeterministicIntent::WriteFile)
+                .or_else(|| {
+                    self.infer_followup_run_command_intent_for_session(
+                        history, user_msg, session_id,
+                    )
+                    .map(DeterministicIntent::RunCommand)
+                })
         });
         match routed_intent {
             Some(DeterministicIntent::ListChangedFiles(filters)) => {
@@ -1886,18 +2321,24 @@ impl<'a> ChatService<'a> {
                 Ok(Some(("write_file".to_string(), response)))
             }
             Some(DeterministicIntent::CodebaseSearch(intent)) => {
-                let response =
-                    crate::tools::codebase_investigator::search_text(&intent.pattern).await?;
+                let search_intent =
+                    Self::infer_codebase_search_intent_kind(user_msg, &intent.pattern);
+                let response = crate::tools::codebase_investigator::search_text_with_intent(
+                    &intent.pattern,
+                    search_intent,
+                )
+                .await?;
                 Ok(Some(("codebase_search".to_string(), response)))
             }
             Some(DeterministicIntent::RunCommand(intent)) => {
+                let command = Self::normalize_run_command_candidate(&intent.command);
                 let audit_ctx = CommandAuditContext {
                     conn: self.conn,
                     session_id: Some(session_id),
                     source: "intent_run_command",
                 };
                 let response = crate::tools::shell::execute_command(
-                    &format!("[RUN_COMMAND {}]", intent.command),
+                    &format!("[RUN_COMMAND {}]", command),
                     self.config,
                     &self.exec_policy,
                     None,
@@ -1906,11 +2347,7 @@ impl<'a> ChatService<'a> {
                     self.runtime_events.clone(),
                 )
                 .await?;
-                let rendered = format!(
-                    "COMMAND: {}\nOUTPUT:\n{}",
-                    intent.command,
-                    response.trim_end()
-                );
+                let rendered = format!("COMMAND: {}\nOUTPUT:\n{}", command, response.trim_end());
                 Ok(Some(("run_command".to_string(), rendered)))
             }
             None => Ok(None),
@@ -1977,6 +2414,130 @@ impl<'a> ChatService<'a> {
         Some(crate::agent::intent::WriteFileIntent { path, content })
     }
 
+    fn infer_followup_run_command_intent(
+        history: &[Message],
+        user_msg: &str,
+    ) -> Option<crate::agent::intent::RunCommandIntent> {
+        let normalized = user_msg.to_ascii_lowercase();
+        let wants_run = normalized == "run it"
+            || normalized == "run that"
+            || normalized == "run this"
+            || normalized == "run that command"
+            || normalized == "run this command"
+            || normalized == "execute it"
+            || normalized == "execute that"
+            || normalized == "execute this"
+            || normalized == "execute that command"
+            || normalized == "execute this command"
+            || normalized == "can you run that"
+            || normalized == "can you run this"
+            || normalized == "can you run that command"
+            || normalized == "can you execute that";
+        if !wants_run {
+            return None;
+        }
+
+        if let Some(previous_user_msg) = Self::previous_user_message(history, user_msg) {
+            if let Some(command) = route_intent(previous_user_msg)
+                .and_then(Self::canonical_command_for_deterministic_intent)
+            {
+                return Some(crate::agent::intent::RunCommandIntent { command });
+            }
+        }
+
+        let assistant_msg = history
+            .iter()
+            .rev()
+            .find(|message| message.role == "assistant")?;
+        let command = Self::extract_followup_run_command(&assistant_msg.content)?;
+        Some(crate::agent::intent::RunCommandIntent { command })
+    }
+
+    fn infer_followup_run_command_intent_for_session(
+        &self,
+        history: &[Message],
+        user_msg: &str,
+        session_id: &str,
+    ) -> Option<crate::agent::intent::RunCommandIntent> {
+        let normalized = user_msg.to_ascii_lowercase();
+        let wants_run = normalized == "run it"
+            || normalized == "run that"
+            || normalized == "run this"
+            || normalized == "run that command"
+            || normalized == "run this command"
+            || normalized == "execute it"
+            || normalized == "execute that"
+            || normalized == "execute this"
+            || normalized == "execute that command"
+            || normalized == "execute this command"
+            || normalized == "can you run that"
+            || normalized == "can you run this"
+            || normalized == "can you run that command"
+            || normalized == "can you execute that";
+        if !wants_run {
+            return None;
+        }
+
+        if let Ok(entries) = self.fetch_command_logs(session_id, 12) {
+            if let Some(command) = entries
+                .into_iter()
+                .map(|entry| Self::normalize_run_command_candidate(&entry.command))
+                .find(|command| {
+                    Self::looks_like_runnable_command(command)
+                        && !Self::is_followup_run_command_placeholder(command)
+                })
+            {
+                return Some(crate::agent::intent::RunCommandIntent { command });
+            }
+        }
+
+        Self::infer_followup_run_command_intent(history, user_msg)
+    }
+
+    fn should_force_followup_deterministic(
+        &self,
+        history: &[Message],
+        user_msg: &str,
+        session_id: &str,
+    ) -> bool {
+        route_intent(user_msg).is_none()
+            && (Self::infer_followup_write_file_intent(history, user_msg).is_some()
+                || self
+                    .infer_followup_run_command_intent_for_session(history, user_msg, session_id)
+                    .is_some())
+    }
+
+    fn canonical_command_for_deterministic_intent(intent: DeterministicIntent) -> Option<String> {
+        match intent {
+            DeterministicIntent::GitStatus => Some("git status".to_string()),
+            DeterministicIntent::GitDiff => Some("git diff".to_string()),
+            DeterministicIntent::GitBranch => Some("git branch --show-current".to_string()),
+            DeterministicIntent::RunCommand(intent) => {
+                Some(Self::normalize_run_command_candidate(&intent.command))
+            }
+            _ => None,
+        }
+    }
+
+    fn previous_user_message<'h>(
+        history: &'h [Message],
+        current_user_msg: &str,
+    ) -> Option<&'h str> {
+        let mut skipped_current = false;
+        for message in history
+            .iter()
+            .rev()
+            .filter(|message| message.role == "user")
+        {
+            if !skipped_current && message.content.trim() == current_user_msg.trim() {
+                skipped_current = true;
+                continue;
+            }
+            return Some(message.content.as_str());
+        }
+        None
+    }
+
     fn extract_backtick_segments(content: &str) -> Vec<String> {
         let mut segments = Vec::new();
         let mut remaining = content;
@@ -1992,6 +2553,99 @@ impl<'a> ChatService<'a> {
             remaining = &after_start[end + 1..];
         }
         segments
+    }
+
+    fn extract_followup_run_command(content: &str) -> Option<String> {
+        let mut candidates = Self::extract_backtick_segments(content)
+            .into_iter()
+            .map(|segment| Self::normalize_run_command_candidate(&segment))
+            .filter(|segment| Self::looks_like_runnable_command(segment))
+            .filter(|segment| !Self::is_followup_run_command_placeholder(segment))
+            .collect::<Vec<_>>();
+
+        candidates.extend(content.lines().filter_map(|line| {
+            let candidate = Self::extract_command_from_followup_line(line)?;
+            let candidate = Self::normalize_run_command_candidate(&candidate);
+            if Self::looks_like_runnable_command(&candidate) {
+                Some(candidate)
+            } else {
+                None
+            }
+        }));
+
+        candidates
+            .into_iter()
+            .find(|candidate| Self::looks_like_execution_command(candidate))
+            .or_else(|| {
+                Self::extract_backtick_segments(content)
+                    .into_iter()
+                    .map(|segment| Self::normalize_run_command_candidate(&segment))
+                    .find(|segment| {
+                        Self::looks_like_runnable_command(segment)
+                            && !Self::is_followup_run_command_placeholder(segment)
+                    })
+            })
+    }
+
+    fn extract_command_from_followup_line(line: &str) -> Option<String> {
+        let trimmed = line.trim().trim_matches('`');
+        if let Some(value) = trimmed.strip_prefix("COMMAND: ") {
+            return Some(value.trim().to_string());
+        }
+        if let Some(value) = trimmed.strip_prefix("$ ") {
+            let value = value
+                .split(" sh:")
+                .next()
+                .unwrap_or(value)
+                .split(" bash:")
+                .next()
+                .unwrap_or(value)
+                .trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+        if let Some(value) = trimmed.strip_prefix("Ran `") {
+            let value = value.split('`').next().unwrap_or(value).trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+        if Self::looks_like_runnable_command(trimmed) {
+            return Some(trimmed.to_string());
+        }
+        None
+    }
+
+    fn looks_like_runnable_command(candidate: &str) -> bool {
+        let trimmed = candidate.trim();
+        let lowered = trimmed.to_ascii_lowercase();
+        trimmed.starts_with("./")
+            || trimmed.starts_with('/')
+            || lowered.starts_with("cargo ")
+            || lowered.starts_with("python ")
+            || lowered.starts_with("python3 ")
+            || lowered.starts_with("bash ")
+            || lowered.starts_with("sh ")
+            || lowered.starts_with("chmod ")
+            || lowered.starts_with("npm ")
+            || lowered.starts_with("pnpm ")
+            || lowered.starts_with("git ")
+    }
+
+    fn looks_like_execution_command(candidate: &str) -> bool {
+        let trimmed = candidate.trim();
+        let lowered = trimmed.to_ascii_lowercase();
+        trimmed.starts_with("./")
+            || trimmed.starts_with('/')
+            || lowered.starts_with("cargo ")
+            || lowered.starts_with("python ")
+            || lowered.starts_with("python3 ")
+            || lowered.starts_with("bash ")
+            || lowered.starts_with("sh ")
+            || lowered.starts_with("npm ")
+            || lowered.starts_with("pnpm ")
+            || lowered.starts_with("git ")
     }
 
     fn looks_like_absolute_followup_path(path: &str) -> bool {
@@ -2079,13 +2733,7 @@ impl<'a> ChatService<'a> {
         tool_content: &str,
     ) -> Result<String, HarperError> {
         self.notify_command_activity(session_id);
-        if tool_name == "repo_identity"
-            || tool_name == "git_branch"
-            || tool_name == "git_status"
-            || tool_name == "git_diff"
-            || tool_name == "write_file"
-            || tool_name == "run_command"
-        {
+        if !Self::should_model_summarize_deterministic_result(self.execution_strategy, tool_name) {
             return Ok(Self::compact_deterministic_fallback(
                 tool_name,
                 tool_content,
@@ -2102,8 +2750,17 @@ impl<'a> ChatService<'a> {
             role: "system".to_string(),
             content: Self::deterministic_summary_instruction(tool_name).to_string(),
         });
-        self.emit_activity_update(session_id, Some("thinking".to_string()));
-        let response = self.call_llm(client, history_for_llm).await?;
+        self.emit_activity_update(session_id, Some("summarizing result".to_string()));
+        let response = match self.call_llm(client, history_for_llm).await {
+            Ok(response) => response,
+            Err(HarperError::Api(_)) | Err(HarperError::Command(_)) => {
+                return Ok(Self::compact_deterministic_fallback(
+                    tool_name,
+                    tool_content,
+                ));
+            }
+            Err(err) => return Err(err),
+        };
         if response.trim().is_empty()
             || Self::tool_call_signature(&response).is_some()
             || Self::deterministic_summary_is_low_value(tool_name, &response, tool_content)
@@ -2114,6 +2771,25 @@ impl<'a> ChatService<'a> {
             ));
         }
         Ok(response)
+    }
+
+    fn should_model_summarize_deterministic_result(
+        strategy: ExecutionStrategy,
+        tool_name: &str,
+    ) -> bool {
+        if matches!(strategy, ExecutionStrategy::Deterministic) {
+            return false;
+        }
+
+        !matches!(
+            tool_name,
+            "repo_identity"
+                | "git_branch"
+                | "git_status"
+                | "git_diff"
+                | "write_file"
+                | "run_command"
+        )
     }
 
     fn deterministic_summary_instruction(tool_name: &str) -> &'static str {
@@ -2326,6 +3002,9 @@ impl<'a> ChatService<'a> {
 
         let command = command.unwrap_or_else(|| "command".to_string());
         let output = output_lines.join("\n").trim().to_string();
+        if output == "Command execution cancelled by user" {
+            return format!("Cancelled `{}`.", command);
+        }
         if output.is_empty() {
             return format!("Ran `{}` successfully.", command);
         }
@@ -2338,10 +3017,13 @@ impl<'a> ChatService<'a> {
         let mut current_file = None;
         let mut current_snippet = None;
         let mut current_reasons: Option<String> = None;
+        let mut intent = "general";
 
         for line in tool_content.lines().skip(1) {
             let trimmed = line.trim();
-            if let Some(value) = trimmed.strip_prefix("FILE: ") {
+            if let Some(value) = trimmed.strip_prefix("INTENT: ") {
+                intent = value;
+            } else if let Some(value) = trimmed.strip_prefix("FILE: ") {
                 if let (Some(file), Some(snippet)) = (current_file.take(), current_snippet.take()) {
                     let reasons = current_reasons.take().unwrap_or_default();
                     let reason_suffix = if reasons.is_empty() {
@@ -2382,7 +3064,62 @@ impl<'a> ChatService<'a> {
             return format!("Tool result:\n{}", tool_content);
         }
 
-        format!("Top source matches:\n{}", bullets.join("\n"))
+        if intent == "defined" {
+            bullets.retain(|bullet| {
+                let lower = bullet.to_ascii_lowercase();
+                lower.contains(" enum ")
+                    || lower.contains(" struct ")
+                    || lower.contains(" trait ")
+                    || lower.contains(" type ")
+                    || lower.contains(" fn ")
+            });
+            if bullets.is_empty() {
+                return format!("Tool result:\n{}", tool_content);
+            }
+            bullets.truncate(2);
+        } else if intent == "calls" {
+            bullets.retain(|bullet| !bullet.to_ascii_lowercase().contains(" fn "));
+            if bullets.is_empty() {
+                return format!("Tool result:\n{}", tool_content);
+            }
+            bullets.truncate(4);
+        }
+
+        let heading = match intent {
+            "used" => "Top usage sites:",
+            "calls" => "Top call sites:",
+            "defined" => "Top definitions:",
+            _ => "Top source matches:",
+        };
+
+        format!("{}\n{}", heading, bullets.join("\n"))
+    }
+
+    fn infer_codebase_search_intent_kind(
+        user_msg: &str,
+        pattern: &str,
+    ) -> crate::tools::codebase_investigator::SearchIntentKind {
+        let lower = user_msg.to_ascii_lowercase();
+        if lower.contains("what calls")
+            || lower.contains("who calls")
+            || lower.contains(&format!("calls {}", pattern.to_ascii_lowercase()))
+        {
+            return crate::tools::codebase_investigator::SearchIntentKind::Calls;
+        }
+        if lower.contains("where is defined")
+            || lower.contains("what file defines")
+            || lower.contains("where is") && lower.contains(" defined ")
+        {
+            return crate::tools::codebase_investigator::SearchIntentKind::Defined;
+        }
+        if lower.contains("where is used")
+            || lower.contains("used in")
+            || lower.contains("where is") && lower.contains(" used ")
+        {
+            return crate::tools::codebase_investigator::SearchIntentKind::Used;
+        }
+
+        crate::tools::codebase_investigator::SearchIntentKind::General
     }
 
     fn summarize_codebase_overview(tool_content: &str) -> String {
@@ -2415,6 +3152,10 @@ impl<'a> ChatService<'a> {
         format!("Codebase overview:\n- {}", lines.join("\n- "))
     }
 
+    fn model_backend_unavailable_reply() -> String {
+        "The model backend is unavailable, and this request does not have a deterministic fallback. Start the configured model provider or ask a repo-grounded or command/file-specific question.".to_string()
+    }
+
     async fn try_handle_offline_shell_proxy(
         &mut self,
         user_msg: &str,
@@ -2423,8 +3164,17 @@ impl<'a> ChatService<'a> {
         if self.execution_strategy != ExecutionStrategy::Deterministic {
             return Ok(None);
         }
-        let commands = plan_offline_shell_commands(user_msg);
+        let commands = plan_offline_shell_commands(user_msg)
+            .into_iter()
+            .map(|command| Self::normalize_run_command_candidate(&command))
+            .collect::<Vec<_>>();
         if commands.is_empty() {
+            return Ok(None);
+        }
+        if commands
+            .iter()
+            .any(|command| Self::is_followup_run_command_placeholder(command))
+        {
             return Ok(None);
         }
 
@@ -2557,12 +3307,65 @@ impl<'a> ChatService<'a> {
         }
     }
 
+    fn format_task_mode(task_mode: TaskMode) -> &'static str {
+        match task_mode {
+            TaskMode::DirectDeterministic => "direct_deterministic",
+            TaskMode::PlanThenAct => "plan_then_act",
+            TaskMode::InspectThenExecute => "inspect_then_execute",
+            TaskMode::ToolAssisted => "tool_assisted",
+            TaskMode::RespondOnly => "respond_only",
+        }
+    }
+
+    fn format_deterministic_intent(intent: &DeterministicIntent) -> String {
+        match intent {
+            DeterministicIntent::ListChangedFiles(filters) => format!(
+                "list_changed_files(ext={:?},tracked_only={},since={:?})",
+                filters.ext, filters.tracked_only, filters.since
+            ),
+            DeterministicIntent::GitStatus => "git_status".to_string(),
+            DeterministicIntent::GitDiff => "git_diff".to_string(),
+            DeterministicIntent::GitBranch => "git_branch".to_string(),
+            DeterministicIntent::CurrentDirectory => "current_directory".to_string(),
+            DeterministicIntent::RepoIdentity => "repo_identity".to_string(),
+            DeterministicIntent::ReadFile(intent) => format!("read_file({})", intent.path),
+            DeterministicIntent::WriteFile(intent) => format!("write_file({})", intent.path),
+            DeterministicIntent::CodebaseOverview => "codebase_overview".to_string(),
+            DeterministicIntent::CodebaseSearch(intent) => {
+                format!("codebase_search({})", intent.pattern)
+            }
+            DeterministicIntent::RunCommand(intent) => format!("run_command({})", intent.command),
+        }
+    }
+
     fn should_prefer_deterministic_routing(strategy: ExecutionStrategy, user_msg: &str) -> bool {
         match strategy {
             ExecutionStrategy::Deterministic => true,
             ExecutionStrategy::Grounded => crate::agent::intent::route_intent(user_msg).is_some(),
             ExecutionStrategy::Auto | ExecutionStrategy::ModelOnly => false,
         }
+    }
+
+    fn decide_task_mode(strategy: ExecutionStrategy, user_msg: &str) -> TaskMode {
+        let needs_plan = Self::request_needs_plan(user_msg);
+        let needs_authoring = Self::request_needs_authoring_flow(user_msg);
+        if needs_authoring && needs_plan {
+            return TaskMode::PlanThenAct;
+        }
+        if needs_authoring {
+            return TaskMode::InspectThenExecute;
+        }
+        if needs_plan {
+            return TaskMode::PlanThenAct;
+        }
+        let is_routable = crate::agent::intent::route_intent(user_msg).is_some();
+        if Self::should_prefer_deterministic_routing(strategy, user_msg) && is_routable {
+            return TaskMode::DirectDeterministic;
+        }
+        if Self::request_requires_tool(user_msg).is_some() {
+            return TaskMode::ToolAssisted;
+        }
+        TaskMode::RespondOnly
     }
 
     fn response_looks_like_generic_capability_refusal(response: &str) -> bool {
@@ -2904,7 +3707,54 @@ impl AuditParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::intent::{route_intent, DeterministicIntent};
     use crate::core::{ApiConfig, ApiProvider};
+    use crate::memory::storage::CommandLogRecord;
+
+    #[derive(Debug)]
+    struct TurnDebug {
+        task_mode: TaskMode,
+        deterministic_intent: Option<DeterministicIntent>,
+        normalized_command: Option<String>,
+        clarification: Option<String>,
+    }
+
+    fn debug_turn(strategy: ExecutionStrategy, history: &[Message], user_msg: &str) -> TurnDebug {
+        let deterministic_intent = route_intent(user_msg).or_else(|| {
+            ChatService::infer_followup_write_file_intent(history, user_msg)
+                .map(DeterministicIntent::WriteFile)
+                .or_else(|| {
+                    ChatService::infer_followup_run_command_intent(history, user_msg)
+                        .map(DeterministicIntent::RunCommand)
+                })
+        });
+        let task_mode = if route_intent(user_msg).is_none() && deterministic_intent.is_some() {
+            TaskMode::DirectDeterministic
+        } else {
+            ChatService::decide_task_mode(strategy, user_msg)
+        };
+
+        let normalized_command = deterministic_intent
+            .as_ref()
+            .and_then(|intent| match intent {
+                DeterministicIntent::RunCommand(intent) => Some(
+                    ChatService::normalize_run_command_candidate(&intent.command),
+                ),
+                _ => None,
+            });
+
+        let clarification = normalized_command.as_ref().and_then(|command| {
+            let tool_call = format!("[RUN_COMMAND {}]", command);
+            ChatService::clarification_for_underspecified_tool_call(user_msg, &tool_call)
+        });
+
+        TurnDebug {
+            task_mode,
+            deterministic_intent,
+            normalized_command,
+            clarification,
+        }
+    }
 
     fn test_config() -> ApiConfig {
         ApiConfig {
@@ -3136,6 +3986,15 @@ mod tests {
     }
 
     #[test]
+    fn compact_deterministic_fallback_uses_intent_specific_codebase_heading() {
+        let tool_content = "CODEBASE_SEARCH\nQUERY: update_plan\nFOCUS: general\nINTENT: calls\nTOP_MATCHES:\nFILE: ./lib/harper-core/src/tools/mod.rs\nROLE: tooling\nREASONS: contains_all_terms\nSNIPPETS:\n- 513: let plan_result = plan::update_plan(self.conn, session_id, args)?;";
+        let summary = ChatService::compact_deterministic_fallback("codebase_search", tool_content);
+
+        assert!(summary.starts_with("Top call sites:\n"));
+        assert!(summary.contains("plan::update_plan"));
+    }
+
+    #[test]
     fn compact_deterministic_fallback_summarizes_codebase_overview() {
         let tool_content = "Workspace root: /Users/niladri/harper\nWorkspace package: harper-workspace\nWorkspace members: lib/harper-core, lib/harper-ui\nCrate roles: harper-core: runtime, tools, storage, agent logic; harper-ui: TUI state, events, widgets\nTop-level entries: AGENTS.md, Cargo.toml, lib\nLikely hotspots: lib/harper-core/src/agent/chat.rs, lib/harper-ui/src/interfaces/ui/widgets.rs";
         let summary =
@@ -3174,6 +4033,30 @@ mod tests {
             "codebase_search",
             response,
             tool_content
+        ));
+    }
+
+    #[test]
+    fn deterministic_strategy_does_not_model_summarize_codebase_search() {
+        assert!(!ChatService::should_model_summarize_deterministic_result(
+            ExecutionStrategy::Deterministic,
+            "codebase_search"
+        ));
+        assert!(!ChatService::should_model_summarize_deterministic_result(
+            ExecutionStrategy::Deterministic,
+            "codebase_overview"
+        ));
+        assert!(!ChatService::should_model_summarize_deterministic_result(
+            ExecutionStrategy::Deterministic,
+            "read_file"
+        ));
+    }
+
+    #[test]
+    fn grounded_strategy_can_still_model_summarize_codebase_search() {
+        assert!(ChatService::should_model_summarize_deterministic_result(
+            ExecutionStrategy::Grounded,
+            "codebase_search"
         ));
     }
 
@@ -3279,6 +4162,163 @@ mod tests {
             .content
             .starts_with("# Introduction to Artificial Intelligence"));
         assert!(intent.content.contains("## What Is AI?"));
+    }
+
+    #[test]
+    fn infer_followup_run_command_intent_uses_previous_assistant_command() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: "can you create a sample file name hello and put 1 to 10 in numbers"
+                    .to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: "Save this script as `create_hello.sh`, make it executable with `chmod +x create_hello.sh`, and run it with `./create_hello.sh`.".to_string(),
+            },
+        ];
+
+        let intent = ChatService::infer_followup_run_command_intent(&history, "run that command")
+            .expect("follow-up run command intent");
+
+        assert_eq!(intent.command, "./create_hello.sh");
+    }
+
+    #[test]
+    fn infer_followup_run_command_intent_prefers_previous_user_git_intent() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: "run the git status".to_string(),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content:
+                    "Git working directory has 11 modified, 1 untracked. Notable files: app.rs."
+                        .to_string(),
+            },
+        ];
+
+        let intent = ChatService::infer_followup_run_command_intent(&history, "run that command")
+            .expect("follow-up run command intent");
+
+        assert_eq!(intent.command, "git status");
+    }
+
+    #[test]
+    fn infer_followup_run_command_intent_returns_none_without_previous_command() {
+        let history = vec![Message {
+            role: "assistant".to_string(),
+            content: "I created the file directly.".to_string(),
+        }];
+
+        let intent = ChatService::infer_followup_run_command_intent(&history, "run that command");
+        assert!(intent.is_none());
+    }
+
+    #[test]
+    fn infer_followup_run_command_prefers_session_command_log_over_assistant_summary() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        crate::memory::storage::insert_command_log(
+            &conn,
+            &CommandLogRecord::new(
+                Some("followup-session"),
+                "git status",
+                "test",
+                true,
+                false,
+                "rejected",
+                None,
+                None,
+                None,
+                None,
+                Some("Command execution cancelled by user".to_string()),
+            ),
+        )
+        .expect("insert command log");
+
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let chat = ChatService::new(
+            &conn,
+            &config,
+            None,
+            None,
+            Some("followup-session".to_string()),
+            HashMap::new(),
+            exec_policy,
+        );
+        let history = vec![Message {
+            role: "assistant".to_string(),
+            content: "Git working directory has 11 modified, 1 untracked. Notable files: app.rs."
+                .to_string(),
+        }];
+
+        let intent = chat
+            .infer_followup_run_command_intent_for_session(&history, "run that", "followup-session")
+            .expect("follow-up run command intent");
+
+        assert_eq!(intent.command, "git status");
+    }
+
+    #[test]
+    fn ambiguous_short_prompt_blocks_placeholder_read_file_tool_call() {
+        let clarification = ChatService::clarification_for_underspecified_tool_call(
+            "as",
+            r#"[READ_FILE example.txt]"#,
+        );
+        assert!(clarification.is_some());
+        assert!(clarification
+            .unwrap()
+            .contains("too ambiguous to act on safely"));
+    }
+
+    #[test]
+    fn non_placeholder_read_file_is_not_blocked_for_specific_prompt() {
+        let clarification = ChatService::clarification_for_underspecified_tool_call(
+            "read src/main.rs",
+            r#"[READ_FILE src/main.rs]"#,
+        );
+        assert!(clarification.is_none());
+    }
+
+    #[test]
+    fn normalize_tool_call_for_execution_strips_articles_from_git_status() {
+        let normalized =
+            ChatService::normalize_tool_call_for_execution(r#"[RUN_COMMAND the git status]"#);
+        assert_eq!(normalized, "[RUN_COMMAND git status]");
+    }
+
+    #[test]
+    fn ambiguous_run_that_placeholder_gets_clarification() {
+        let clarification = ChatService::clarification_for_underspecified_tool_call(
+            "run that",
+            r#"[RUN_COMMAND that]"#,
+        );
+        assert!(clarification.is_some());
+        assert!(clarification.unwrap().contains("which previous command"));
+    }
+
+    #[test]
+    fn normalize_run_command_candidate_strips_articles_for_deterministic_path() {
+        let normalized = ChatService::normalize_run_command_candidate("the git status");
+        assert_eq!(normalized, "git status");
+    }
+
+    #[test]
+    fn normalize_run_command_candidate_preserves_case_for_generic_commands() {
+        let normalized = ChatService::normalize_run_command_candidate("cat README.md");
+        assert_eq!(normalized, "cat README.md");
+    }
+
+    #[test]
+    fn extract_followup_run_command_parses_shell_echoed_command_line() {
+        let command = ChatService::extract_followup_run_command(
+            "$ the git status sh: the: command not found",
+        )
+        .expect("shell echoed command");
+        assert_eq!(command, "git status");
     }
 
     #[test]
@@ -3410,5 +4450,101 @@ mod tests {
             ExecutionStrategy::Auto,
             "read lib/harper-core/src/agent/chat.rs"
         ));
+    }
+
+    #[test]
+    fn decide_task_mode_prefers_direct_deterministic_for_grounded_routable_intent() {
+        assert_eq!(
+            ChatService::decide_task_mode(
+                ExecutionStrategy::Grounded,
+                "where is execution strategy used in this repo"
+            ),
+            TaskMode::DirectDeterministic
+        );
+    }
+
+    #[test]
+    fn decide_task_mode_uses_plan_then_act_for_multi_step_authoring() {
+        assert_eq!(
+            ChatService::decide_task_mode(
+                ExecutionStrategy::Grounded,
+                "refactor the planner flow in this repo and then update the tui followup rendering"
+            ),
+            TaskMode::PlanThenAct
+        );
+    }
+
+    #[test]
+    fn decide_task_mode_uses_respond_only_for_plain_question() {
+        assert_eq!(
+            ChatService::decide_task_mode(
+                ExecutionStrategy::Auto,
+                "what is the difference between grounded and deterministic"
+            ),
+            TaskMode::RespondOnly
+        );
+    }
+
+    #[test]
+    fn headless_turn_debug_normalizes_run_command_in_deterministic_mode() {
+        let debug = debug_turn(ExecutionStrategy::Deterministic, &[], "run the git status");
+
+        assert_eq!(debug.task_mode, TaskMode::DirectDeterministic);
+        assert!(matches!(
+            debug.deterministic_intent,
+            Some(DeterministicIntent::GitStatus)
+        ));
+        assert!(debug.normalized_command.is_none());
+        assert!(debug.clarification.is_none());
+    }
+
+    #[test]
+    fn headless_turn_debug_resolves_followup_run_command() {
+        let history = vec![Message {
+            role: "assistant".to_string(),
+            content: "Ran `git status`.\n```\nOn branch main\n```".to_string(),
+        }];
+
+        let debug = debug_turn(ExecutionStrategy::Deterministic, &history, "run that");
+
+        assert_eq!(debug.task_mode, TaskMode::DirectDeterministic);
+        assert!(matches!(
+            debug.deterministic_intent,
+            Some(DeterministicIntent::RunCommand(_))
+        ));
+        assert_eq!(debug.normalized_command.as_deref(), Some("git status"));
+        assert!(debug.clarification.is_none());
+    }
+
+    #[test]
+    fn headless_turn_debug_clarifies_unresolved_followup_run_command() {
+        let debug = debug_turn(ExecutionStrategy::Deterministic, &[], "run that");
+
+        assert_eq!(debug.task_mode, TaskMode::ToolAssisted);
+        assert!(debug.deterministic_intent.is_none());
+        assert!(debug.normalized_command.is_none());
+        assert!(debug.clarification.is_none());
+    }
+
+    #[test]
+    fn headless_turn_debug_grounded_routable_query_prefers_direct_deterministic() {
+        let debug = debug_turn(
+            ExecutionStrategy::Grounded,
+            &[],
+            "where is execution strategy used in this repo",
+        );
+
+        assert_eq!(debug.task_mode, TaskMode::DirectDeterministic);
+        assert!(matches!(
+            debug.deterministic_intent,
+            Some(DeterministicIntent::CodebaseSearch(_))
+        ));
+    }
+
+    #[test]
+    fn headless_turn_debug_auto_greeting_is_respond_only() {
+        let debug = debug_turn(ExecutionStrategy::Auto, &[], "hi");
+        assert_eq!(debug.task_mode, TaskMode::RespondOnly);
+        assert!(debug.deterministic_intent.is_none());
     }
 }

--- a/lib/harper-core/src/agent/intent.rs
+++ b/lib/harper-core/src/agent/intent.rs
@@ -334,6 +334,10 @@ fn infer_write_file_intent(query: &str, normalized: &str) -> Option<(String, Str
         }
     }
 
+    if let Some(generic) = infer_generic_named_file_intent(query, normalized) {
+        return Some(generic);
+    }
+
     let (file_kind, language_label) = if normalized.contains(" python ")
         || normalized.contains(" py file")
         || normalized.contains(" python file")
@@ -518,6 +522,50 @@ fn infer_write_file_intent(query: &str, normalized: &str) -> Option<(String, Str
     let content = starter_content_for(file_kind, &authoring_descriptor);
     let slug = slugify_filename(&authoring_slug_descriptor(&authoring_descriptor));
     Some((format!("{}.{}", slug, file_kind), content))
+}
+
+fn infer_generic_named_file_intent(query: &str, normalized: &str) -> Option<(String, String)> {
+    let file_name = ["file named ", "file name ", "named file ", "name the file "]
+        .iter()
+        .find_map(|marker| {
+            let idx = normalized.find(marker)?;
+            let tail = query[idx + marker.len()..].trim_start();
+            let token = tail
+                .split_whitespace()
+                .next()
+                .map(|value| {
+                    value.trim_matches(|c: char| {
+                        matches!(c, '.' | ',' | ';' | ':' | ')' | '(' | '"' | '\'' | '`')
+                    })
+                })
+                .filter(|value| !value.is_empty())?;
+            Some(token.to_string())
+        })?;
+
+    let content = infer_generic_named_file_content(normalized)?;
+    Some((file_name, content))
+}
+
+fn infer_generic_named_file_content(normalized: &str) -> Option<String> {
+    if normalized.contains("1 to 10") || normalized.contains("1 through 10") {
+        return Some(
+            (1..=10)
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+    }
+
+    if normalized.contains("1 to 5") || normalized.contains("1 through 5") {
+        return Some(
+            (1..=5)
+                .map(|value| value.to_string())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
+    }
+
+    None
 }
 
 fn authoring_content_descriptor(descriptor: &str) -> String {
@@ -974,6 +1022,9 @@ fn infer_simple_run_command(query: &str, normalized: &str) -> Option<String> {
         candidate =
             candidate.trim_matches(|c: char| matches!(c, '.' | ',' | ';' | ':' | '"' | '\''));
         candidate = sanitize_natural_command_candidate(candidate);
+        if is_followup_command_placeholder(candidate) {
+            return None;
+        }
 
         let lowered = candidate.to_ascii_lowercase();
         match lowered.as_str() {
@@ -1064,6 +1115,20 @@ fn sanitize_natural_command_candidate(candidate: &str) -> &str {
         }
     }
     candidate
+}
+
+fn is_followup_command_placeholder(candidate: &str) -> bool {
+    matches!(
+        candidate.trim().to_ascii_lowercase().as_str(),
+        "that"
+            | "this"
+            | "it"
+            | "that one"
+            | "this one"
+            | "that command"
+            | "this command"
+            | "the command"
+    )
 }
 
 #[cfg(test)]
@@ -1472,6 +1537,12 @@ mod tests {
     }
 
     #[test]
+    fn does_not_route_placeholder_followup_as_literal_command() {
+        let intent = route_intent("run that command?");
+        assert_eq!(intent, None);
+    }
+
+    #[test]
     fn routes_natural_language_directory_command_intent() {
         let intent = route_intent("which directory are we in");
         assert_eq!(intent, Some(DeterministicIntent::CurrentDirectory));
@@ -1497,6 +1568,19 @@ mod tests {
             Some(DeterministicIntent::WriteFile(WriteFileIntent {
                 path: "note.txt".to_string(),
                 content: "i am niladri".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn routes_generic_named_file_with_numeric_content() {
+        let intent =
+            route_intent("can you create a sample file name hello and put 1 to 10 in numbers");
+        assert_eq!(
+            intent,
+            Some(DeterministicIntent::WriteFile(WriteFileIntent {
+                path: "hello".to_string(),
+                content: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10".to_string(),
             }))
         );
     }

--- a/lib/harper-core/src/core/plan.rs
+++ b/lib/harper-core/src/core/plan.rs
@@ -43,6 +43,30 @@ pub enum PlanJobStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanLoopStage {
+    Planning,
+    Inspecting,
+    Executing,
+    Feedback,
+    RetryPending,
+    ReplanRequired,
+    Responding,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanLoopOutcome {
+    WaitingApproval,
+    Succeeded,
+    Failed,
+    Checkpointed,
+    RetryPending,
+    ReplanRequired,
+    Responded,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PlanJobRecord {
     pub job_id: String,
     pub tool: String,
@@ -142,6 +166,12 @@ pub struct PlanRuntime {
     #[serde(default)]
     pub followup_history: Vec<PlanFollowup>,
     #[serde(default)]
+    pub loop_stage: Option<PlanLoopStage>,
+    #[serde(default)]
+    pub last_outcome: Option<PlanLoopOutcome>,
+    #[serde(default)]
+    pub last_feedback: Option<String>,
+    #[serde(default)]
     pub authoring: Option<AuthoringRuntime>,
 }
 
@@ -156,6 +186,9 @@ impl PlanRuntime {
             && self.jobs.is_empty()
             && self.followup.is_none()
             && self.followup_history.is_empty()
+            && self.loop_stage.is_none()
+            && self.last_outcome.is_none()
+            && self.last_feedback.is_none()
             && self.authoring.is_none()
     }
 
@@ -168,6 +201,21 @@ impl PlanRuntime {
         self.active_tool = Some(tool.into());
         self.active_command = command;
         self.active_status = Some(status.into());
+        self.loop_stage = Some(PlanLoopStage::Executing);
+    }
+
+    pub fn set_loop_stage(&mut self, stage: PlanLoopStage, feedback: Option<String>) {
+        self.loop_stage = Some(stage);
+        if let Some(feedback) = feedback.filter(|value| !value.trim().is_empty()) {
+            self.last_feedback = Some(feedback);
+        }
+    }
+
+    pub fn record_outcome(&mut self, outcome: PlanLoopOutcome, feedback: Option<String>) {
+        self.last_outcome = Some(outcome);
+        if let Some(feedback) = feedback.filter(|value| !value.trim().is_empty()) {
+            self.last_feedback = Some(feedback);
+        }
     }
 
     pub fn start_job(
@@ -182,6 +230,18 @@ impl PlanRuntime {
         self.active_tool = Some(tool.clone());
         self.active_command = command.clone();
         self.active_status = Some(job_status_label(&status).to_string());
+        self.loop_stage = Some(match status {
+            PlanJobStatus::WaitingApproval => PlanLoopStage::RetryPending,
+            PlanJobStatus::Running => PlanLoopStage::Executing,
+            PlanJobStatus::Blocked | PlanJobStatus::Failed => PlanLoopStage::ReplanRequired,
+            PlanJobStatus::Succeeded => PlanLoopStage::Feedback,
+        });
+        self.last_outcome = Some(match status {
+            PlanJobStatus::WaitingApproval => PlanLoopOutcome::WaitingApproval,
+            PlanJobStatus::Running => PlanLoopOutcome::Responded,
+            PlanJobStatus::Blocked | PlanJobStatus::Failed => PlanLoopOutcome::Failed,
+            PlanJobStatus::Succeeded => PlanLoopOutcome::Succeeded,
+        });
         self.jobs.push(PlanJobRecord {
             job_id: job_id.clone(),
             tool,
@@ -208,6 +268,18 @@ impl PlanRuntime {
             job.status = status.clone();
         }
         self.active_status = Some(job_status_label(&status).to_string());
+        self.loop_stage = Some(match status {
+            PlanJobStatus::WaitingApproval => PlanLoopStage::RetryPending,
+            PlanJobStatus::Running => PlanLoopStage::Executing,
+            PlanJobStatus::Blocked | PlanJobStatus::Failed => PlanLoopStage::ReplanRequired,
+            PlanJobStatus::Succeeded => PlanLoopStage::Feedback,
+        });
+        self.last_outcome = Some(match status {
+            PlanJobStatus::WaitingApproval => PlanLoopOutcome::WaitingApproval,
+            PlanJobStatus::Running => PlanLoopOutcome::Responded,
+            PlanJobStatus::Blocked | PlanJobStatus::Failed => PlanLoopOutcome::Failed,
+            PlanJobStatus::Succeeded => PlanLoopOutcome::Succeeded,
+        });
     }
 
     pub fn set_active_job_output(
@@ -261,6 +333,7 @@ impl PlanRuntime {
 
     pub fn finish_active_job(&mut self, status: PlanJobStatus) {
         self.update_active_job_status(status);
+        self.loop_stage = Some(PlanLoopStage::Feedback);
         self.clear_active_state();
     }
 
@@ -273,6 +346,9 @@ impl PlanRuntime {
             self.archive_active_followup();
         }
         self.followup = Some(next_followup);
+        self.loop_stage = Some(PlanLoopStage::Feedback);
+        self.last_outcome = Some(PlanLoopOutcome::Checkpointed);
+        self.last_feedback = Some("checkpoint recorded".to_string());
     }
 
     pub fn set_retry_or_replan_followup(
@@ -303,6 +379,15 @@ impl PlanRuntime {
             self.archive_active_followup();
         }
         self.followup = Some(next_followup);
+        if retry_count <= 1 {
+            self.loop_stage = Some(PlanLoopStage::RetryPending);
+            self.last_outcome = Some(PlanLoopOutcome::RetryPending);
+            self.last_feedback = Some("retry suggested".to_string());
+        } else {
+            self.loop_stage = Some(PlanLoopStage::ReplanRequired);
+            self.last_outcome = Some(PlanLoopOutcome::ReplanRequired);
+            self.last_feedback = Some("replan required".to_string());
+        }
     }
 
     pub fn clear_followup(&mut self) {
@@ -511,7 +596,9 @@ pub struct PlanState {
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthoringPhase, PlanFollowup, PlanJobStatus, PlanRuntime};
+    use super::{
+        AuthoringPhase, PlanFollowup, PlanJobStatus, PlanLoopOutcome, PlanLoopStage, PlanRuntime,
+    };
 
     #[test]
     fn runtime_deserializes_legacy_shape_with_empty_jobs() {
@@ -596,6 +683,31 @@ mod tests {
                 command: Some("cargo test".to_string()),
                 retry_count: 1
             }
+        );
+    }
+
+    #[test]
+    fn runtime_tracks_loop_stage_and_outcome_for_retry_and_checkpoint() {
+        let mut runtime = PlanRuntime::default();
+
+        runtime.set_loop_stage(PlanLoopStage::Planning, Some("plan updated".to_string()));
+        runtime.record_outcome(PlanLoopOutcome::Responded, Some("plan ready".to_string()));
+        runtime
+            .set_retry_or_replan_followup("Retry failing command", Some("cargo test".to_string()));
+        assert_eq!(runtime.loop_stage, Some(PlanLoopStage::RetryPending));
+        assert_eq!(runtime.last_outcome, Some(PlanLoopOutcome::RetryPending));
+
+        runtime
+            .set_retry_or_replan_followup("Retry failing command", Some("cargo test".to_string()));
+        assert_eq!(runtime.loop_stage, Some(PlanLoopStage::ReplanRequired));
+        assert_eq!(runtime.last_outcome, Some(PlanLoopOutcome::ReplanRequired));
+
+        runtime.set_checkpoint_followup("Inspect output", Some("Patch handler".to_string()));
+        assert_eq!(runtime.loop_stage, Some(PlanLoopStage::Feedback));
+        assert_eq!(runtime.last_outcome, Some(PlanLoopOutcome::Checkpointed));
+        assert_eq!(
+            runtime.last_feedback.as_deref(),
+            Some("checkpoint recorded")
         );
     }
 

--- a/lib/harper-core/src/tools/codebase_investigator.rs
+++ b/lib/harper-core/src/tools/codebase_investigator.rs
@@ -148,6 +148,14 @@ enum QueryFocus {
     General,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchIntentKind {
+    General,
+    Used,
+    Calls,
+    Defined,
+}
+
 /// Investigate codebase structural graph and relationships
 pub async fn investigate_codebase(
     response: &str,
@@ -183,7 +191,14 @@ pub async fn investigate_codebase(
 }
 
 pub async fn search_text(query: &str) -> HarperResult<String> {
-    let matches = collect_search_matches(query)?;
+    search_text_with_intent(query, SearchIntentKind::General).await
+}
+
+pub async fn search_text_with_intent(
+    query: &str,
+    intent: SearchIntentKind,
+) -> HarperResult<String> {
+    let matches = collect_search_matches_with_intent(query, intent)?;
     if matches.is_empty() {
         return Ok(format!("No source-focused matches found for '{}'.", query));
     }
@@ -198,9 +213,10 @@ pub async fn search_text(query: &str) -> HarperResult<String> {
     );
 
     Ok(format!(
-        "CODEBASE_SEARCH\nQUERY: {}\nFOCUS: {}\nTOP_MATCHES:\n{}",
+        "CODEBASE_SEARCH\nQUERY: {}\nFOCUS: {}\nINTENT: {}\nTOP_MATCHES:\n{}",
         query,
         focus.as_str(),
+        intent.as_str(),
         matches
             .into_iter()
             .take(8)
@@ -211,6 +227,13 @@ pub async fn search_text(query: &str) -> HarperResult<String> {
 }
 
 fn collect_search_matches(query: &str) -> HarperResult<Vec<SearchMatch>> {
+    collect_search_matches_with_intent(query, SearchIntentKind::General)
+}
+
+fn collect_search_matches_with_intent(
+    query: &str,
+    intent: SearchIntentKind,
+) -> HarperResult<Vec<SearchMatch>> {
     let terms: Vec<String> = query
         .split_whitespace()
         .map(|term| term.trim().to_ascii_lowercase())
@@ -224,6 +247,8 @@ fn collect_search_matches(query: &str) -> HarperResult<Vec<SearchMatch>> {
     }
 
     let focus = infer_query_focus(query, &terms);
+    let symbol_variants = search_symbol_variants(&terms);
+    let semantic_target = infer_semantic_symbol_target(query, &terms);
 
     let mut matches: Vec<SearchMatch> = Vec::new();
     for entry in WalkDir::new(".")
@@ -243,22 +268,35 @@ fn collect_search_matches(query: &str) -> HarperResult<Vec<SearchMatch>> {
             continue;
         }
 
-        let mut file_matches = Vec::new();
+        let mut scored_matches = Vec::new();
         for (idx, line) in content.lines().enumerate() {
-            let lower_line = line.to_ascii_lowercase();
-            if terms.iter().any(|term| lower_line.contains(term)) {
-                file_matches.push(format!("{}: {}", idx + 1, line.trim()));
-                if file_matches.len() >= 3 {
-                    break;
-                }
+            if let Some(score) = search_line_score(line, &terms, &symbol_variants, intent) {
+                scored_matches.push((score, idx, format!("{}: {}", idx + 1, line.trim())));
             }
         }
+
+        scored_matches.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+        let line_score: i32 = scored_matches
+            .iter()
+            .take(3)
+            .map(|(score, _, _)| *score)
+            .sum();
+        let file_matches: Vec<String> = scored_matches
+            .into_iter()
+            .take(3)
+            .map(|(_, _, rendered)| rendered)
+            .collect();
 
         if file_matches.is_empty() {
             continue;
         }
 
-        let score = search_match_score(entry.path(), &lower, &file_matches, &terms, focus);
+        let semantic_bonus = extract_rust_semantic_file(entry.path())
+            .map(|semantic| search_semantic_bonus(&semantic, semantic_target.as_deref(), intent))
+            .unwrap_or(0);
+        let score = search_match_score(entry.path(), &lower, &file_matches, &terms, focus, intent)
+            + line_score
+            + semantic_bonus;
         matches.push(SearchMatch {
             score,
             path: entry.path().display().to_string(),
@@ -270,6 +308,238 @@ fn collect_search_matches(query: &str) -> HarperResult<Vec<SearchMatch>> {
 
     matches.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path)));
     Ok(matches)
+}
+
+fn infer_semantic_symbol_target(query: &str, terms: &[String]) -> Option<String> {
+    if let Some(start) = query.find('`') {
+        let rest = &query[start + 1..];
+        if let Some(end) = rest.find('`') {
+            let symbol = rest[..end].trim();
+            if !symbol.is_empty() {
+                return Some(symbol.to_string());
+            }
+        }
+    }
+
+    let symbol_like_tokens = query
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | ':')))
+        .filter(|token| {
+            !token.is_empty()
+                && (token.contains('_')
+                    || token.contains("::")
+                    || token.chars().any(|ch| ch.is_ascii_uppercase()))
+        })
+        .collect::<Vec<_>>();
+    if let Some(symbol) = symbol_like_tokens.first() {
+        return Some((*symbol).to_string());
+    }
+
+    if terms.len() == 1 {
+        Some(terms[0].clone())
+    } else {
+        Some(terms.join("_"))
+    }
+}
+
+fn search_line_score(
+    line: &str,
+    terms: &[String],
+    symbol_variants: &[String],
+    intent: SearchIntentKind,
+) -> Option<i32> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let compact = compact_search_text(trimmed);
+    let compact_terms = compact_search_text(&terms.join(""));
+    let snake_case_variant = terms.join("_");
+    let camel_case_variant = terms
+        .iter()
+        .map(|term| {
+            let mut chars = term.chars();
+            match chars.next() {
+                Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<String>()
+        .to_ascii_lowercase();
+    let enum_decl = format!("enum {camel_case_variant}");
+    let struct_decl = format!("struct {camel_case_variant}");
+    let trait_decl = format!("trait {camel_case_variant}");
+    let type_decl = format!("type {camel_case_variant}");
+    let fn_decl = format!("fn {snake_case_variant}(");
+    let has_any_term = terms.iter().any(|term| lower.contains(term));
+    if !has_any_term {
+        return None;
+    }
+
+    let is_license_noise = lower.starts_with("//")
+        || lower.starts_with("/*")
+        || lower.starts_with('*')
+        || lower.contains("licensed under")
+        || lower.contains("apache license")
+        || lower.contains("http://www.apache.org/licenses");
+    let mut score = 5;
+
+    if terms.iter().all(|term| lower.contains(term)) {
+        score += 50;
+    }
+    if compact.contains(&compact_terms) {
+        score += 100;
+    }
+    if lower.contains(&snake_case_variant) {
+        score += 80;
+    }
+    if lower.contains(&camel_case_variant) {
+        score += 80;
+    }
+    if symbol_variants
+        .iter()
+        .any(|variant| lower.contains(variant))
+    {
+        score += 40;
+    }
+    if lower.contains(&format!(".{snake_case_variant}"))
+        || lower.contains(&format!("{snake_case_variant}("))
+        || lower.contains(&format!("({snake_case_variant}"))
+        || lower.contains(&format!("{snake_case_variant} ="))
+        || lower.contains(&format!("{snake_case_variant}:"))
+    {
+        score += 45;
+    }
+    if lower.starts_with("use ") {
+        score -= 35;
+    }
+    if lower.starts_with("fn ")
+        || lower.starts_with("pub fn ")
+        || lower.starts_with("struct ")
+        || lower.starts_with("enum ")
+        || lower.starts_with("impl ")
+    {
+        score -= 10;
+    }
+    if lower.contains("assert!(")
+        || lower.contains("assert_eq!(")
+        || lower.contains("assert_ne!(")
+        || lower.contains("contains(\"")
+        || lower.contains("expect(\"")
+        || lower.starts_with("#[test]")
+    {
+        score -= 140;
+    }
+    if is_license_noise {
+        score -= 120;
+    }
+
+    match intent {
+        SearchIntentKind::Used => {
+            if lower.starts_with("use ") {
+                score -= 35;
+            }
+            if lower.starts_with("fn ")
+                || lower.starts_with("pub fn ")
+                || lower.starts_with("struct ")
+                || lower.starts_with("enum ")
+                || lower.starts_with("type ")
+                || lower.starts_with("pub type ")
+            {
+                score -= 20;
+            }
+            if lower.contains(&format!(".{snake_case_variant}"))
+                || lower.contains(&format!("{snake_case_variant} ="))
+                || lower.contains(&format!("{snake_case_variant}:"))
+                || lower.contains(&format!("{snake_case_variant}("))
+                || lower.contains(&format!("app.{snake_case_variant}"))
+            {
+                score += 55;
+            }
+        }
+        SearchIntentKind::Calls => {
+            if lower.starts_with("fn ") || lower.starts_with("pub fn ") {
+                score -= 55;
+            }
+            if lower.contains(&format!("{snake_case_variant}("))
+                || lower.contains(&format!(".{snake_case_variant}("))
+            {
+                score += 70;
+            }
+        }
+        SearchIntentKind::Defined => {
+            if lower.contains(&enum_decl)
+                || lower.contains(&struct_decl)
+                || lower.contains(&trait_decl)
+                || lower.contains(&type_decl)
+                || lower.contains(&fn_decl)
+            {
+                score += 140;
+            } else if lower.starts_with("fn ")
+                || lower.starts_with("pub fn ")
+                || lower.starts_with("struct ")
+                || lower.starts_with("enum ")
+                || lower.starts_with("type ")
+                || lower.starts_with("pub type ")
+                || lower.starts_with("trait ")
+                || lower.starts_with("pub trait ")
+                || lower.starts_with("const ")
+                || lower.starts_with("pub const ")
+            {
+                score += 25;
+            }
+            if lower.starts_with("use ") {
+                score -= 45;
+            }
+            if lower.contains(&format!(": {camel_case_variant}"))
+                || lower.contains(&format!("-> {camel_case_variant}"))
+                || lower.contains(&format!("({camel_case_variant}"))
+            {
+                score -= 35;
+            }
+            if lower.contains(&format!(".{snake_case_variant}("))
+                || lower.contains(&format!(".{snake_case_variant}"))
+            {
+                score -= 20;
+            }
+        }
+        SearchIntentKind::General => {}
+    }
+
+    (score > 20).then_some(score)
+}
+
+fn search_symbol_variants(terms: &[String]) -> Vec<String> {
+    if terms.is_empty() {
+        return Vec::new();
+    }
+
+    let snake_case = terms.join("_");
+    let camel_case = terms
+        .iter()
+        .map(|term| {
+            let mut chars = term.chars();
+            match chars.next() {
+                Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<String>()
+        .to_ascii_lowercase();
+
+    let mut variants = vec![snake_case, camel_case, compact_search_text(&terms.join(""))];
+    variants.sort();
+    variants.dedup();
+    variants
+}
+
+fn compact_search_text(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 pub async fn authoring_context(query: &str) -> HarperResult<String> {
@@ -1928,16 +2198,26 @@ fn search_match_score(
     snippets: &[String],
     terms: &[String],
     focus: QueryFocus,
+    intent: SearchIntentKind,
 ) -> i32 {
     let path_str = path.to_string_lossy();
     let mut score = 0;
+    let compact_terms = compact_search_text(&terms.join(""));
 
     if path_str.starts_with("./lib/harper-ui/src") || path_str.starts_with("lib/harper-ui/src") {
-        score += 60;
+        score += if intent == SearchIntentKind::Defined {
+            20
+        } else {
+            60
+        };
     } else if path_str.starts_with("./lib/harper-core/src")
         || path_str.starts_with("lib/harper-core/src")
     {
-        score += 40;
+        score += if intent == SearchIntentKind::Defined {
+            70
+        } else {
+            40
+        };
     }
 
     if path_str.contains("widgets.rs") {
@@ -1963,8 +2243,60 @@ fn search_match_score(
         score += 20;
     }
 
+    if snippets.iter().any(|snippet| {
+        let snippet_lower = snippet.to_ascii_lowercase();
+        terms.iter().all(|term| snippet_lower.contains(term))
+    }) {
+        score += 45;
+    }
+
+    if snippets
+        .iter()
+        .any(|snippet| compact_search_text(snippet).contains(&compact_terms))
+    {
+        score += 60;
+    }
+
+    if snippets.iter().all(|snippet| {
+        let lower = snippet.to_ascii_lowercase();
+        lower.contains("licensed under")
+            || lower.contains("apache license")
+            || lower.contains("http://www.apache.org/licenses")
+    }) {
+        score -= 120;
+    }
+
     if content_lower.contains("planfollowup") || content_lower.contains("followup") {
         score += 10;
+    }
+
+    let compact_terms = compact_search_text(&terms.join(""));
+    match intent {
+        SearchIntentKind::Defined => {
+            if snippets.iter().any(|snippet| {
+                let lower = snippet.to_ascii_lowercase();
+                lower.contains(&format!("enum {}", compact_terms))
+                    || lower.contains(&format!("struct {}", compact_terms))
+                    || lower.contains(&format!("trait {}", compact_terms))
+                    || lower.contains(&format!("type {}", compact_terms))
+                    || lower.contains(&format!("fn {}(", terms.join("_")))
+            }) {
+                score += 180;
+            }
+            if snippets.iter().any(|snippet| snippet.contains("::")) {
+                score -= 50;
+            }
+        }
+        SearchIntentKind::Calls => {
+            if snippets.iter().any(|snippet| {
+                snippet
+                    .to_ascii_lowercase()
+                    .contains(&format!("fn {}(", terms.join("_")))
+            }) {
+                score -= 120;
+            }
+        }
+        SearchIntentKind::Used | SearchIntentKind::General => {}
     }
 
     match focus {
@@ -1997,6 +2329,65 @@ fn search_match_score(
     score
 }
 
+fn search_semantic_bonus(
+    semantic: &RustSemanticFile,
+    semantic_target: Option<&str>,
+    intent: SearchIntentKind,
+) -> i32 {
+    let Some(target) = semantic_target else {
+        return 0;
+    };
+    let lowered = target.to_ascii_lowercase();
+    let snake_case = lowered.replace("::", "_");
+    let target_variants = [lowered.as_str(), snake_case.as_str(), target];
+
+    match intent {
+        SearchIntentKind::Defined => {
+            if semantic.defines.iter().any(|symbol| {
+                target_variants
+                    .iter()
+                    .any(|variant| symbol.eq_ignore_ascii_case(variant))
+            }) {
+                260
+            } else {
+                0
+            }
+        }
+        SearchIntentKind::Calls => {
+            if semantic.calls.iter().any(|symbol| {
+                target_variants
+                    .iter()
+                    .any(|variant| symbol.eq_ignore_ascii_case(variant))
+            }) {
+                220
+            } else {
+                0
+            }
+        }
+        SearchIntentKind::Used => {
+            let import_hit = semantic.imports.iter().any(|symbol| {
+                target_variants
+                    .iter()
+                    .any(|variant| symbol.eq_ignore_ascii_case(variant))
+            });
+            let define_hit = semantic.defines.iter().any(|symbol| {
+                target_variants
+                    .iter()
+                    .any(|variant| symbol.eq_ignore_ascii_case(variant))
+            });
+            let call_hit = semantic.calls.iter().any(|symbol| {
+                target_variants
+                    .iter()
+                    .any(|variant| symbol.eq_ignore_ascii_case(variant))
+            });
+            (if define_hit { 60 } else { 0 })
+                + (if call_hit { 90 } else { 0 })
+                + (if import_hit { 25 } else { 0 })
+        }
+        SearchIntentKind::General => 0,
+    }
+}
+
 impl QueryFocus {
     fn as_str(self) -> &'static str {
         match self {
@@ -2005,6 +2396,17 @@ impl QueryFocus {
             QueryFocus::Tooling => "tooling",
             QueryFocus::Runtime => "runtime",
             QueryFocus::General => "general",
+        }
+    }
+}
+
+impl SearchIntentKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            SearchIntentKind::General => "general",
+            SearchIntentKind::Used => "used",
+            SearchIntentKind::Calls => "calls",
+            SearchIntentKind::Defined => "defined",
         }
     }
 }
@@ -2038,10 +2440,12 @@ mod tests {
 
     use super::{
         authoring_search_query, build_semantic_graph, build_workspace_definition_index,
-        classify_member_role, extract_rust_semantic_file, format_workspace_graph,
+        classify_member_role, collect_search_matches, collect_search_matches_with_intent,
+        extract_rust_semantic_file, format_search_match, format_workspace_graph,
         infer_edit_plan_candidates, infer_query_focus, is_searchable_file, path_relative_to_root,
-        resolve_symbol_candidates, rust_module_path, workspace_member_for_path, QueryFocus,
-        RustSemanticFile, SearchMatch, WorkspaceGraph, WorkspaceMemberOverview,
+        resolve_symbol_candidates, rust_module_path, search_line_score, search_symbol_variants,
+        workspace_member_for_path, QueryFocus, RustSemanticFile, SearchIntentKind, SearchMatch,
+        WorkspaceGraph, WorkspaceMemberOverview,
     };
     use std::path::Path;
 
@@ -2475,5 +2879,77 @@ struct Planner;
         let root = Path::new("/repo/lib/harper-core");
         let rel = path_relative_to_root(root, Path::new("/repo/lib/harper-core/src/lib.rs"));
         assert_eq!(rel, "src/lib.rs");
+    }
+
+    #[test]
+    fn search_matches_prefer_symbol_usage_over_license_comment_noise() {
+        let matches = collect_search_matches("execution strategy").unwrap();
+        let top = matches.first().expect("at least one search match");
+        let rendered = format_search_match(top);
+
+        assert!(
+            !rendered.contains("Licensed under")
+                && !rendered.contains("http://www.apache.org/licenses")
+        );
+        assert!(rendered.contains("ExecutionStrategy") || rendered.contains("execution_strategy"));
+    }
+
+    #[test]
+    fn search_matches_prefer_real_usage_sites_over_imports_for_execution_strategy() {
+        let matches =
+            collect_search_matches_with_intent("execution strategy", SearchIntentKind::Used)
+                .unwrap();
+        let top = matches.first().expect("at least one search match");
+        let top_snippet = top.snippets.first().expect("at least one top snippet");
+
+        assert!(
+            top_snippet.contains("execution_strategy") || top_snippet.contains("ExecutionStrategy")
+        );
+        assert!(!top_snippet.trim_start().starts_with("38: use "));
+        assert!(!top.path.contains("codebase_investigator.rs"));
+    }
+
+    #[test]
+    fn search_matches_prefer_call_sites_over_definitions_for_update_plan() {
+        let terms = vec!["update_plan".to_string()];
+        let symbol_variants = search_symbol_variants(&terms);
+        let call_score = search_line_score(
+            "let plan_result = plan::update_plan(self.conn, session_id, args)?;",
+            &terms,
+            &symbol_variants,
+            SearchIntentKind::Calls,
+        )
+        .expect("call site score");
+        let definition_score = search_line_score(
+            "pub fn update_plan(",
+            &terms,
+            &symbol_variants,
+            SearchIntentKind::Calls,
+        )
+        .expect("definition score");
+
+        assert!(call_score > definition_score);
+    }
+
+    #[test]
+    fn search_matches_prefer_exact_definition_for_execution_strategy() {
+        let terms = vec!["executionstrategy".to_string()];
+        let symbol_variants = search_symbol_variants(&terms);
+        let definition_score = search_line_score(
+            "pub enum ExecutionStrategy {",
+            &terms,
+            &symbol_variants,
+            SearchIntentKind::Defined,
+        )
+        .expect("definition score");
+        let import_score = search_line_score(
+            "use crate::runtime::config::{ExecPolicyConfig, ExecutionStrategy};",
+            &terms,
+            &symbol_variants,
+            SearchIntentKind::Defined,
+        )
+        .expect("import score");
+
+        assert!(definition_score > import_score);
     }
 }

--- a/lib/harper-core/src/tools/plan.rs
+++ b/lib/harper-core/src/tools/plan.rs
@@ -14,8 +14,8 @@
 
 use crate::core::error::{HarperError, HarperResult};
 use crate::core::plan::{
-    AuthoringPlannedEdit, AuthoringValidationStep, PlanItem, PlanJobStatus, PlanRuntime, PlanState,
-    PlanStepStatus, StructuredAuthoringPlan,
+    AuthoringPlannedEdit, AuthoringValidationStep, PlanItem, PlanJobStatus, PlanLoopOutcome,
+    PlanLoopStage, PlanRuntime, PlanState, PlanStepStatus, StructuredAuthoringPlan,
 };
 use rusqlite::Connection;
 
@@ -71,6 +71,8 @@ pub fn update_plan(
     let existing_runtime =
         crate::memory::storage::load_plan_state(conn, session_id)?.and_then(|plan| plan.runtime);
     let mut runtime = existing_runtime.unwrap_or_default();
+    runtime.set_loop_stage(PlanLoopStage::Planning, Some("plan updated".to_string()));
+    runtime.record_outcome(PlanLoopOutcome::Responded, Some("plan ready".to_string()));
     if let Some(authoring_plan) = structured_authoring_plan {
         runtime.set_authoring_structured_plan(authoring_plan);
     }
@@ -129,6 +131,28 @@ pub fn set_plan_runtime_state(
 ) -> HarperResult<()> {
     update_plan_runtime(conn, session_id, |runtime| {
         runtime.set_active_tool_state(tool_name.to_string(), command, status.to_string());
+    })
+}
+
+pub fn set_plan_loop_stage(
+    conn: &Connection,
+    session_id: &str,
+    stage: PlanLoopStage,
+    feedback: Option<String>,
+) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.set_loop_stage(stage.clone(), feedback.clone());
+    })
+}
+
+pub fn record_plan_loop_outcome(
+    conn: &Connection,
+    session_id: &str,
+    outcome: PlanLoopOutcome,
+    feedback: Option<String>,
+) -> HarperResult<()> {
+    update_plan_runtime(conn, session_id, |runtime| {
+        runtime.record_outcome(outcome.clone(), feedback.clone());
     })
 }
 

--- a/lib/harper-ui/src/bin/batch.rs
+++ b/lib/harper-ui/src/bin/batch.rs
@@ -12,13 +12,357 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Batch processing binary for Harper
+use async_trait::async_trait;
+use harper_core::core::io_traits::{DenyApproval, RuntimeEventSink, StdinApproval};
+use harper_core::runtime::config::HarperConfig;
+use harper_core::{
+    agent::chat::{ChatService, ChatTurnDebugSummary},
+    create_connection, init_db, ApiConfig, HarperError, Message, PlanState, ResolvedAgents,
+};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::env;
+use std::io::{self, IsTerminal};
+use std::sync::{Arc, Mutex};
+use turul_mcp_client::McpClient;
 
-use colored::Colorize;
+#[derive(Debug, Default, Clone, Serialize)]
+struct TurnDebugOutput {
+    activity: Vec<String>,
+    command: Option<String>,
+    command_output: Option<String>,
+    command_error: bool,
+    command_done: bool,
+}
 
-fn main() {
-    println!("{}", "Harper Batch Processor".bold().blue());
-    println!("This binary is for batch processing AI requests.");
-    println!("Usage: harper-batch [options]");
-    println!("Run 'harper' for interactive mode.");
+#[derive(Default)]
+struct BatchRuntimeEvents {
+    per_session: Mutex<HashMap<String, TurnDebugOutput>>,
+}
+
+impl BatchRuntimeEvents {
+    fn take_turn(&self, session_id: &str) -> TurnDebugOutput {
+        self.per_session
+            .lock()
+            .expect("batch runtime events lock")
+            .remove(session_id)
+            .unwrap_or_default()
+    }
+}
+
+#[async_trait]
+impl RuntimeEventSink for BatchRuntimeEvents {
+    async fn plan_updated(
+        &self,
+        _session_id: &str,
+        _plan: Option<PlanState>,
+    ) -> Result<(), HarperError> {
+        Ok(())
+    }
+
+    async fn agents_updated(
+        &self,
+        _session_id: &str,
+        _agents: Option<ResolvedAgents>,
+    ) -> Result<(), HarperError> {
+        Ok(())
+    }
+
+    async fn activity_updated(
+        &self,
+        session_id: &str,
+        status: Option<String>,
+    ) -> Result<(), HarperError> {
+        if let Some(status) = status {
+            let mut sessions = self.per_session.lock().expect("batch runtime events lock");
+            let entry = sessions.entry(session_id.to_string()).or_default();
+            if entry.activity.last() != Some(&status) {
+                entry.activity.push(status);
+            }
+        }
+        Ok(())
+    }
+
+    async fn command_output_updated(
+        &self,
+        session_id: &str,
+        command: String,
+        chunk: String,
+        is_error: bool,
+        done: bool,
+    ) -> Result<(), HarperError> {
+        let mut sessions = self.per_session.lock().expect("batch runtime events lock");
+        let entry = sessions.entry(session_id.to_string()).or_default();
+        entry.command = Some(command);
+        entry.command_error = is_error;
+        entry.command_done = done;
+        match entry.command_output.as_mut() {
+            Some(output) => output.push_str(&chunk),
+            None => entry.command_output = Some(chunk),
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct BatchArgs {
+    prompts: Vec<String>,
+    strategy: Option<String>,
+    json: bool,
+    web: bool,
+    help: bool,
+}
+
+#[derive(Serialize)]
+struct TurnResult {
+    prompt: String,
+    response: String,
+    routing: ChatTurnDebugSummary,
+    debug: TurnDebugOutput,
+}
+
+fn print_help() {
+    println!("Harper Batch Processor");
+    println!();
+    println!("Usage:");
+    println!("  harper-batch --prompt \"...\" [--prompt \"...\"] [options]");
+    println!("  printf 'prompt one\\nprompt two\\n' | harper-batch [options]");
+    println!();
+    println!("Options:");
+    println!("  --prompt <text>          Add a prompt to run in the same session");
+    println!("  --strategy <mode>       One of: auto, grounded, deterministic, model");
+    println!("  --json                  Print JSON output");
+    println!("  --web                   Enable web search for the session");
+    println!("  --help                  Show this help");
+}
+
+fn parse_args(args: &[String]) -> Result<BatchArgs, HarperError> {
+    let mut parsed = BatchArgs::default();
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--prompt" => {
+                index += 1;
+                let Some(value) = args.get(index) else {
+                    return Err(HarperError::Validation(
+                        "--prompt requires a value".to_string(),
+                    ));
+                };
+                parsed.prompts.push(value.clone());
+            }
+            "--strategy" => {
+                index += 1;
+                let Some(value) = args.get(index) else {
+                    return Err(HarperError::Validation(
+                        "--strategy requires a value".to_string(),
+                    ));
+                };
+                parsed.strategy = Some(value.clone());
+            }
+            "--json" => parsed.json = true,
+            "--web" => parsed.web = true,
+            "--help" | "-h" => parsed.help = true,
+            other => {
+                return Err(HarperError::Validation(format!(
+                    "Unknown batch argument: {}",
+                    other
+                )))
+            }
+        }
+        index += 1;
+    }
+    Ok(parsed)
+}
+
+fn get_api_key(config: &HarperConfig) -> String {
+    let mut api_key = config.api.api_key.clone();
+    if config.api.provider == "Gemini" {
+        if let Ok(env_key) = env::var("GEMINI_API_KEY") {
+            api_key = env_key;
+        }
+    } else if config.api.provider == "OpenAI" {
+        if let Ok(env_key) = env::var("OPENAI_API_KEY") {
+            api_key = env_key;
+        }
+    } else if config.api.provider == "Sambanova" {
+        if let Ok(env_key) = env::var("SAMBASTUDIO_API_KEY") {
+            api_key = env_key;
+        }
+    }
+    api_key
+}
+
+fn read_stdin_prompts() -> Result<Vec<String>, HarperError> {
+    if io::stdin().is_terminal() {
+        return Ok(Vec::new());
+    }
+    let input = io::read_to_string(io::stdin())
+        .map_err(|e| HarperError::Io(format!("Failed to read stdin prompts: {}", e)))?;
+    Ok(input
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToOwned::to_owned)
+        .collect())
+}
+
+fn build_api_config(config: &HarperConfig) -> Result<ApiConfig, HarperError> {
+    Ok(ApiConfig {
+        provider: config.api.get_provider()?,
+        api_key: get_api_key(config),
+        base_url: config.api.base_url.clone(),
+        model_name: config.api.model_name.clone(),
+    })
+}
+
+async fn init_mcp_client(config: &HarperConfig) -> Option<McpClient> {
+    if !config.mcp.enabled {
+        return None;
+    }
+
+    let transport = turul_mcp_client::transport::HttpTransport::new(&config.mcp.server_url).ok()?;
+    let client = turul_mcp_client::McpClientBuilder::new()
+        .with_transport(Box::new(transport))
+        .build();
+    client.connect().await.ok()?;
+    Some(client)
+}
+
+fn latest_assistant_response(history: &[Message]) -> String {
+    history
+        .iter()
+        .rev()
+        .find(|message| message.role == "assistant")
+        .map(|message| message.content.clone())
+        .unwrap_or_default()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), HarperError> {
+    let _ = dotenvy::dotenv();
+
+    let raw_args: Vec<String> = env::args().collect();
+    let mut args = parse_args(&raw_args)?;
+    if args.help {
+        print_help();
+        return Ok(());
+    }
+
+    args.prompts.extend(read_stdin_prompts()?);
+    if args.prompts.is_empty() {
+        return Err(HarperError::Validation(
+            "No prompts provided. Use --prompt or pipe prompts on stdin.".to_string(),
+        ));
+    }
+
+    let config = HarperConfig::new()?;
+    let api_config = build_api_config(&config)?;
+    let conn = create_connection(&config.database.path)?;
+    init_db(&conn)?;
+    let mcp_client = init_mcp_client(&config).await;
+    let runtime_events = Arc::new(BatchRuntimeEvents::default());
+
+    let mut chat_service = ChatService::new(
+        &conn,
+        &api_config,
+        mcp_client.as_ref(),
+        None,
+        Some(uuid::Uuid::new_v4().to_string()),
+        config.custom_commands.commands.clone().unwrap_or_default(),
+        config.exec_policy.clone(),
+    )
+    .with_runtime_events(runtime_events.clone());
+
+    if io::stdin().is_terminal() {
+        chat_service = chat_service.with_approver(Arc::new(StdinApproval));
+    } else {
+        chat_service = chat_service.with_approver(Arc::new(DenyApproval));
+    }
+
+    let (mut history, session_id) = chat_service.create_session(args.web).await?;
+
+    if let Some(strategy) = args.strategy.as_deref() {
+        let strategy_command = format!("/strategy {}", strategy);
+        chat_service
+            .send_message(&strategy_command, &mut history, args.web, &session_id)
+            .await?;
+        let _ = runtime_events.take_turn(&session_id);
+    }
+
+    let mut results = Vec::new();
+    for prompt in args.prompts {
+        let routing = chat_service.debug_turn_summary(&history, &prompt);
+        chat_service
+            .send_message(&prompt, &mut history, args.web, &session_id)
+            .await?;
+        let mut debug = runtime_events.take_turn(&session_id);
+        let response = latest_assistant_response(&history);
+        if routing.task_mode == "respond_only"
+            && result_looks_like_backend_unavailable(&response)
+            && routing.deterministic_intent.is_none()
+            && routing.normalized_command.is_none()
+            && routing.clarification.is_none()
+        {
+            debug.activity.retain(|status| status == "responding");
+        }
+        results.push(TurnResult {
+            prompt,
+            response,
+            routing,
+            debug,
+        });
+    }
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&results)
+                .map_err(|e| HarperError::Validation(format!("Failed to serialize JSON: {}", e)))?
+        );
+        return Ok(());
+    }
+
+    for result in results {
+        println!("USER: {}", result.prompt);
+        println!(
+            "ROUTING: strategy={} task_mode={}",
+            result.routing.strategy, result.routing.task_mode
+        );
+        if let Some(intent) = &result.routing.deterministic_intent {
+            println!("DETERMINISTIC INTENT: {}", intent);
+        }
+        if let Some(command) = &result.routing.normalized_command {
+            println!("NORMALIZED COMMAND: {}", command);
+        }
+        if let Some(clarification) = &result.routing.clarification {
+            println!("CLARIFICATION: {}", clarification);
+        }
+        if !result.debug.activity.is_empty() {
+            println!("ACTIVITY:");
+            for status in &result.debug.activity {
+                println!("  - {}", status);
+            }
+        }
+        if let Some(command) = &result.debug.command {
+            println!("COMMAND: {}", command);
+        }
+        if let Some(output) = &result.debug.command_output {
+            if result.debug.command_error {
+                println!("COMMAND OUTPUT (error):");
+            } else {
+                println!("COMMAND OUTPUT:");
+            }
+            println!("{}", output.trim_end());
+        }
+        println!("ASSISTANT: {}", result.response);
+        println!();
+    }
+
+    Ok(())
+}
+
+fn result_looks_like_backend_unavailable(response: &str) -> bool {
+    response
+        .trim()
+        .starts_with("The model backend is unavailable, and this request does not have a deterministic fallback.")
 }

--- a/lib/harper-ui/src/interfaces/ui/app.rs
+++ b/lib/harper-ui/src/interfaces/ui/app.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use harper_core::core::plan::{PlanLoopOutcome, PlanLoopStage};
 use harper_core::core::Message;
 use harper_core::memory::session_service::GlobalStats;
 use harper_core::ResolvedAgents;
@@ -65,6 +66,19 @@ pub struct RenderedMessageBlock {
     pub lines: Vec<Line<'static>>,
 }
 
+#[derive(Clone, Default)]
+pub struct ChatLoopState {
+    pub stage: Option<PlanLoopStage>,
+    pub last_outcome: Option<PlanLoopOutcome>,
+    pub last_feedback: Option<String>,
+}
+
+impl ChatLoopState {
+    pub fn has_state(&self) -> bool {
+        self.stage.is_some() || self.last_outcome.is_some() || self.last_feedback.is_some()
+    }
+}
+
 #[derive(Clone)]
 pub struct ChatState {
     pub session_id: String,
@@ -81,6 +95,7 @@ pub struct ChatState {
     pub plan_job_output_scroll: usize,
     pub navigation_focus: NavigationFocus,
     pub command_output: Option<CommandOutputState>,
+    pub loop_state: ChatLoopState,
     pub agents_panel_expanded: bool,
     pub agents_scroll_offset: usize,
     pub input: String,
@@ -350,6 +365,20 @@ impl ChatState {
         self.completion_candidates.clear();
         self.completion_index = 0;
         self.completion_prefix = None;
+    }
+
+    pub fn set_loop_stage(&mut self, stage: PlanLoopStage, feedback: Option<String>) {
+        self.loop_state.stage = Some(stage);
+        if let Some(feedback) = feedback {
+            self.loop_state.last_feedback = Some(feedback);
+        }
+    }
+
+    pub fn record_loop_outcome(&mut self, outcome: PlanLoopOutcome, feedback: Option<String>) {
+        self.loop_state.last_outcome = Some(outcome);
+        if let Some(feedback) = feedback {
+            self.loop_state.last_feedback = Some(feedback);
+        }
     }
 
     pub fn set_navigation_focus(&mut self, focus: NavigationFocus) {

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -110,6 +110,7 @@ pub(crate) fn create_chat_state(
         plan_job_output_scroll: 0,
         navigation_focus: NavigationFocus::Messages,
         command_output: None,
+        loop_state: super::app::ChatLoopState::default(),
         agents_panel_expanded: false,
         agents_scroll_offset: 0,
         input: String::new(),
@@ -791,14 +792,9 @@ pub fn handle_event(
                 KeyCode::Delete => return delete_selected_session(app),
                 KeyCode::Tab => handle_tab(app),
                 KeyCode::Char(c) => {
-                    // Handle q for quitting/returning only in non-input states
-                    if c == 'q' && !matches!(app.state, AppState::Chat(_)) {
-                        if matches!(app.state, AppState::Menu(_)) {
-                            return EventResult::Quit;
-                        } else {
-                            app.state = AppState::Menu(0);
-                            return EventResult::Continue;
-                        }
+                    // Handle q for quitting only on the home screen.
+                    if c == 'q' && matches!(app.state, AppState::Menu(_)) {
+                        return EventResult::Quit;
                     }
                     if c == 'l' {
                         if matches!(app.state, AppState::Chat(_)) {

--- a/lib/harper-ui/src/interfaces/ui/tui.rs
+++ b/lib/harper-ui/src/interfaces/ui/tui.rs
@@ -31,6 +31,7 @@ use super::theme::Theme;
 use super::widgets;
 use harper_core::agent::chat::ChatService;
 use harper_core::core::io_traits::{RuntimeEventSink, UserApproval};
+use harper_core::core::plan::{PlanLoopOutcome, PlanLoopStage};
 use harper_core::core::ApiConfig;
 use harper_core::memory::session_service::SessionService;
 use harper_core::runtime::config::{ExecPolicyConfig, UiConfig};
@@ -213,6 +214,49 @@ fn spawn_sidebar_gathering(chat_state: &ChatState, ui_tx: &mpsc::Sender<UiUpdate
             .send(UiUpdate::SidebarEntries { sections })
             .await;
     });
+}
+
+fn infer_chat_loop_stage(status: &str) -> Option<PlanLoopStage> {
+    let normalized = status.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        s if s.starts_with("planning") => Some(PlanLoopStage::Planning),
+        s if s.starts_with("inspecting") => Some(PlanLoopStage::Inspecting),
+        s if s.starts_with("executing") || s.starts_with("running") => {
+            Some(PlanLoopStage::Executing)
+        }
+        s if s.starts_with("summarizing") => Some(PlanLoopStage::Feedback),
+        s if s.starts_with("responding")
+            || s.starts_with("thinking")
+            || s.starts_with("waiting for browser sign-in") =>
+        {
+            Some(PlanLoopStage::Responding)
+        }
+        s if s.starts_with("waiting approval")
+            || s.starts_with("resuming")
+            || s.starts_with("retrying") =>
+        {
+            Some(PlanLoopStage::Feedback)
+        }
+        _ => None,
+    }
+}
+
+fn final_chat_loop_outcome(
+    stage: Option<&PlanLoopStage>,
+    current: Option<&PlanLoopOutcome>,
+) -> PlanLoopOutcome {
+    match stage {
+        Some(PlanLoopStage::Responding) => PlanLoopOutcome::Responded,
+        Some(
+            PlanLoopStage::Planning
+            | PlanLoopStage::Inspecting
+            | PlanLoopStage::Executing
+            | PlanLoopStage::Feedback,
+        ) => PlanLoopOutcome::Succeeded,
+        Some(PlanLoopStage::RetryPending | PlanLoopStage::ReplanRequired) | None => {
+            current.cloned().unwrap_or(PlanLoopOutcome::Responded)
+        }
+    }
 }
 
 fn parse_strategy_command(
@@ -1048,6 +1092,36 @@ pub async fn run_tui(
                                     chat_state.active_agents = session_view.agents;
                                     chat_state.refresh_plan_state();
                                     chat_state.refresh_review_state();
+                                    if chat_state.active_plan.is_none() {
+                                        let outcome = final_chat_loop_outcome(
+                                            chat_state.loop_state.stage.as_ref(),
+                                            chat_state.loop_state.last_outcome.as_ref(),
+                                        );
+                                        let feedback = if matches!(outcome, PlanLoopOutcome::Responded) {
+                                            None
+                                        } else {
+                                            chat_state
+                                                .messages
+                                                .iter()
+                                                .rev()
+                                                .find(|message| message.role == "assistant")
+                                                .and_then(|message| {
+                                                    message
+                                                        .content
+                                                        .lines()
+                                                        .find(|line| !line.trim().is_empty())
+                                                })
+                                                .map(str::trim)
+                                                .map(ToOwned::to_owned)
+                                                .or_else(|| {
+                                                    chat_state
+                                                        .loop_state
+                                                        .last_feedback
+                                                        .clone()
+                                                })
+                                        };
+                                        chat_state.record_loop_outcome(outcome, feedback);
+                                    }
                                     should_clear_activity = true;
                                     if chat_state.sidebar_visible {
                                         spawn_sidebar_gathering(chat_state, &ui_tx);
@@ -1059,8 +1133,25 @@ pub async fn run_tui(
                             }
                         }
                         UiUpdate::ActivityUpdated { session_id, status } => {
-                            let matches_session = if let AppState::Chat(chat_state) = &app.state {
-                                chat_state.session_id == session_id
+                            let matches_session = if let AppState::Chat(chat_state) = &mut app.state {
+                                if chat_state.session_id == session_id {
+                                    if let Some(status_text) = status.as_deref() {
+                                        if let Some(stage) =
+                                            infer_chat_loop_stage(status_text)
+                                        {
+                                            chat_state.set_loop_stage(
+                                                stage,
+                                                Some(status_text.to_string()),
+                                            );
+                                        } else {
+                                            chat_state.loop_state.last_feedback =
+                                                Some(status_text.to_string());
+                                        }
+                                    }
+                                    true
+                                } else {
+                                    false
+                                }
                             } else {
                                 false
                             };
@@ -1077,23 +1168,43 @@ pub async fn run_tui(
                         } => {
                             if let AppState::Chat(chat_state) = &mut app.state {
                                 if chat_state.session_id == session_id {
-                                    let state = chat_state.command_output.get_or_insert(CommandOutputState {
-                                        command: command.clone(),
-                                        content: String::new(),
-                                        has_error: false,
-                                        done: false,
-                                    });
-                                    if state.command != command {
-                                        *state = CommandOutputState {
-                                            command,
-                                            content: String::new(),
-                                            has_error: is_error,
-                                            done,
+                                    let (current_command, has_error_output, is_done) = {
+                                        let state = chat_state.command_output.get_or_insert(
+                                            CommandOutputState {
+                                                command: command.clone(),
+                                                content: String::new(),
+                                                has_error: false,
+                                                done: false,
+                                            },
+                                        );
+                                        if state.command != command {
+                                            *state = CommandOutputState {
+                                                command,
+                                                content: String::new(),
+                                                has_error: is_error,
+                                                done,
+                                            };
+                                        }
+                                        state.content.push_str(&chunk);
+                                        state.has_error |= is_error;
+                                        state.done = done;
+                                        (state.command.clone(), state.has_error, state.done)
+                                    };
+                                    chat_state.set_loop_stage(
+                                        PlanLoopStage::Executing,
+                                        Some(format!("running {}", current_command)),
+                                    );
+                                    if is_done {
+                                        let outcome = if has_error_output {
+                                            PlanLoopOutcome::Failed
+                                        } else {
+                                            PlanLoopOutcome::Succeeded
                                         };
+                                        chat_state.record_loop_outcome(
+                                            outcome,
+                                            Some(format!("{} finished", current_command)),
+                                        );
                                     }
-                                    state.content.push_str(&chunk);
-                                    state.has_error |= is_error;
-                                    state.done = done;
                                 }
                             }
                         }
@@ -1123,6 +1234,10 @@ pub async fn run_tui(
                         UiUpdate::Error(err) => {
                             if let AppState::Chat(chat_state) = &mut app.state {
                                 chat_state.awaiting_response = false;
+                                chat_state.record_loop_outcome(
+                                    PlanLoopOutcome::Failed,
+                                    Some(err.clone()),
+                                );
                             }
                             app.set_activity_status(None);
                             app.set_error_message(err);
@@ -1194,4 +1309,30 @@ pub async fn run_tui(
     execute!(terminal.backend_mut(), LeaveAlternateScreen, cursor::Show)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{final_chat_loop_outcome, infer_chat_loop_stage};
+    use harper_core::core::plan::{PlanLoopOutcome, PlanLoopStage};
+
+    #[test]
+    fn summarizing_maps_to_feedback_stage() {
+        assert_eq!(
+            infer_chat_loop_stage("summarizing result"),
+            Some(PlanLoopStage::Feedback)
+        );
+    }
+
+    #[test]
+    fn deterministic_non_plan_completion_maps_to_succeeded() {
+        assert_eq!(
+            final_chat_loop_outcome(Some(&PlanLoopStage::Feedback), None),
+            PlanLoopOutcome::Succeeded
+        );
+        assert_eq!(
+            final_chat_loop_outcome(Some(&PlanLoopStage::Responding), None),
+            PlanLoopOutcome::Responded
+        );
+    }
 }

--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -21,7 +21,9 @@ use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Padding, Paragraph
 use super::app::{AppState, ApprovalState, ReviewState, SessionInfo, TuiApp, UiMessage};
 use super::settings;
 use super::theme::Theme;
-use harper_core::core::plan::{PlanFollowup, PlanJobRecord, PlanJobStatus};
+use harper_core::core::plan::{
+    PlanFollowup, PlanJobRecord, PlanJobStatus, PlanLoopOutcome, PlanLoopStage,
+};
 use harper_core::{PlanRuntime, PlanState, PlanStepStatus, ResolvedAgents};
 
 // Refined shortcuts for a cleaner footer
@@ -71,52 +73,27 @@ const SESSIONS_FOOTER_SHORTCUTS: &[&[(&str, &str)]] = &[
 ];
 
 const EXPORT_FOOTER_SHORTCUTS: &[&[(&str, &str)]] = &[
-    &[
-        ("↑↓", "Move"),
-        ("Enter", "Export"),
-        ("Esc", "Back"),
-        ("Q", "Back"),
-    ],
+    &[("↑↓", "Move"), ("Enter", "Export"), ("Esc", "Back")],
     &[("J/K", "Move")],
 ];
 
 const PREVIEW_FOOTER_SHORTCUTS: &[&[(&str, &str)]] = &[
-    &[
-        ("↑↓", "Scroll"),
-        ("Enter", "Resume"),
-        ("Esc", "Back"),
-        ("Q", "Back"),
-    ],
+    &[("↑↓", "Scroll"), ("Enter", "Resume"), ("Esc", "Back")],
     &[("J/K", "Scroll")],
 ];
 
 const SETTINGS_FOOTER_SHORTCUTS: &[&[(&str, &str)]] = &[
-    &[
-        ("↑↓", "Move"),
-        ("Enter", "Open"),
-        ("Esc", "Back"),
-        ("Q", "Back"),
-    ],
+    &[("↑↓", "Move"), ("Enter", "Open"), ("Esc", "Back")],
     &[("J/K", "Move")],
 ];
 
 const PROFILE_FOOTER_SHORTCUTS: &[&[(&str, &str)]] = &[
-    &[
-        ("↑↓", "Move"),
-        ("Enter", "Run"),
-        ("Esc", "Back"),
-        ("Q", "Back"),
-    ],
+    &[("↑↓", "Move"), ("Enter", "Run"), ("Esc", "Back")],
     &[("J/K", "Move")],
 ];
 
 const EXECUTION_POLICY_FOOTER_SHORTCUTS: &[&[(&str, &str)]] = &[
-    &[
-        ("↑↓", "Move"),
-        ("Enter", "Change"),
-        ("Esc", "Back"),
-        ("Q", "Back"),
-    ],
+    &[("↑↓", "Move"), ("Enter", "Change"), ("Esc", "Back")],
     &[("J/K", "Move")],
 ];
 
@@ -255,6 +232,7 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
             let has_review = chat_state.active_review.is_some();
             let command_output_display = derive_command_output_display(chat_state);
             let has_command_output = command_output_display.is_some();
+            let has_chat_loop = !has_plan && should_render_chat_loop_panel(&chat_state.loop_state);
             let plan_height = chat_state
                 .active_plan
                 .as_ref()
@@ -264,6 +242,11 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 .as_ref()
                 .map(command_output_panel_height)
                 .unwrap_or(0);
+            let chat_loop_height = if has_chat_loop {
+                chat_loop_panel_height(&chat_state.loop_state)
+            } else {
+                0
+            };
             let agents_height = chat_state
                 .active_agents
                 .as_ref()
@@ -282,6 +265,9 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
             }
             if has_command_output {
                 constraints.push(Constraint::Length(command_output_height));
+            }
+            if has_chat_loop {
+                constraints.push(Constraint::Length(chat_loop_height));
             }
             if has_plan {
                 constraints.push(Constraint::Length(plan_height));
@@ -369,6 +355,15 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 }
                 next_panel_index += 1;
             }
+            if has_chat_loop {
+                draw_chat_loop_panel(
+                    frame,
+                    &chat_state.loop_state,
+                    theme,
+                    chunks[next_panel_index],
+                );
+                next_panel_index += 1;
+            }
             if has_plan {
                 if let Some(plan) = &chat_state.active_plan {
                     draw_plan_panel(
@@ -430,6 +425,7 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
             let input_index = 2
                 + usize::from(has_review)
                 + usize::from(has_command_output)
+                + usize::from(has_chat_loop)
                 + usize::from(has_plan)
                 + usize::from(has_agents);
             frame.render_widget(input_widget, chunks[input_index]);
@@ -1277,6 +1273,10 @@ fn latest_action_summary(app: &TuiApp, chat_state: &super::app::ChatState) -> Op
         return Some(approval.command.clone());
     }
 
+    if let Some(command_output) = &chat_state.command_output {
+        return Some(command_output.command.clone());
+    }
+
     for msg in chat_state.messages.iter().rev() {
         for line in msg.content.lines().rev() {
             let trimmed = line.trim();
@@ -1286,20 +1286,7 @@ fn latest_action_summary(app: &TuiApp, chat_state: &super::app::ChatState) -> Op
         }
     }
 
-    chat_state
-        .messages
-        .iter()
-        .rev()
-        .find(|msg| msg.role != "system" && !msg.content.trim().is_empty())
-        .map(|msg| {
-            msg.content
-                .lines()
-                .next()
-                .unwrap_or_default()
-                .trim()
-                .to_string()
-        })
-        .filter(|line| !line.is_empty())
+    None
 }
 
 fn latest_rule_source(chat_state: &super::app::ChatState) -> Option<String> {
@@ -1330,6 +1317,12 @@ fn plan_panel_height(plan: &PlanState) -> u16 {
         lines += 1;
     }
     if let Some(runtime) = &plan.runtime {
+        if runtime.loop_stage.is_some()
+            || runtime.last_outcome.is_some()
+            || runtime.last_feedback.is_some()
+        {
+            lines += plan_loop_state_line_count(runtime);
+        }
         if runtime.followup.is_some() {
             lines += 2;
         }
@@ -1547,6 +1540,51 @@ fn draw_command_output_panel(
     frame.render_widget(widget, area);
 }
 
+fn chat_loop_panel_height(loop_state: &super::app::ChatLoopState) -> u16 {
+    (loop_state_line_count(
+        loop_state.stage.as_ref(),
+        loop_state.last_outcome.as_ref(),
+        loop_state.last_feedback.as_deref(),
+    ) + 2) as u16
+}
+
+fn should_render_chat_loop_panel(loop_state: &super::app::ChatLoopState) -> bool {
+    if !loop_state.has_state() {
+        return false;
+    }
+
+    !matches!(
+        (loop_state.stage.as_ref(), loop_state.last_outcome.as_ref()),
+        (
+            Some(PlanLoopStage::Responding),
+            Some(PlanLoopOutcome::Responded)
+        )
+    )
+}
+
+fn draw_chat_loop_panel(
+    frame: &mut Frame,
+    loop_state: &super::app::ChatLoopState,
+    theme: &Theme,
+    area: Rect,
+) {
+    let widget = Paragraph::new(loop_state_lines(
+        loop_state.stage.as_ref(),
+        loop_state.last_outcome.as_ref(),
+        loop_state.last_feedback.as_deref(),
+        theme,
+    ))
+    .block(
+        Block::default()
+            .title(" Loop State ")
+            .borders(Borders::TOP)
+            .border_style(theme.muted_style())
+            .padding(Padding::horizontal(1)),
+    )
+    .wrap(Wrap { trim: true });
+    frame.render_widget(widget, area);
+}
+
 fn detect_command_output_language(command: &str, content: &str) -> Option<&'static str> {
     let normalized_command = command.to_ascii_lowercase();
     if normalized_command.contains("git diff")
@@ -1688,6 +1726,7 @@ fn draw_plan_panel(
         ));
     }
     if let Some(runtime) = &plan.runtime {
+        lines.extend(plan_loop_state_lines(runtime, theme));
         lines.extend(plan_followup_lines(runtime, theme));
         lines.extend(plan_followup_history_lines(runtime, theme));
         lines.extend(plan_job_lines(
@@ -1956,6 +1995,94 @@ fn format_plan_runtime(runtime: &PlanRuntime) -> String {
         .or(runtime.active_tool.as_deref())
         .unwrap_or("task");
     format!("{}: {}", status, target)
+}
+
+fn plan_loop_state_lines(runtime: &PlanRuntime, theme: &Theme) -> Vec<Line<'static>> {
+    loop_state_lines(
+        runtime.loop_stage.as_ref(),
+        runtime.last_outcome.as_ref(),
+        runtime.last_feedback.as_deref(),
+        theme,
+    )
+}
+
+fn plan_loop_state_line_count(runtime: &PlanRuntime) -> usize {
+    loop_state_line_count(
+        runtime.loop_stage.as_ref(),
+        runtime.last_outcome.as_ref(),
+        runtime.last_feedback.as_deref(),
+    )
+}
+
+fn loop_state_lines(
+    stage: Option<&PlanLoopStage>,
+    outcome: Option<&PlanLoopOutcome>,
+    feedback: Option<&str>,
+    theme: &Theme,
+) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    if let Some(stage) = stage {
+        lines.push(Line::styled(
+            format!("loop: {}", format_loop_stage(stage)),
+            theme.muted_style().add_modifier(Modifier::ITALIC),
+        ));
+    }
+    if let Some(outcome) = outcome {
+        let color = match outcome {
+            PlanLoopOutcome::Succeeded
+            | PlanLoopOutcome::Checkpointed
+            | PlanLoopOutcome::Responded => theme.output,
+            PlanLoopOutcome::WaitingApproval | PlanLoopOutcome::RetryPending => {
+                Color::Rgb(245, 158, 11)
+            }
+            PlanLoopOutcome::Failed | PlanLoopOutcome::ReplanRequired => Color::Rgb(239, 68, 68),
+        };
+        lines.push(Line::styled(
+            format!("last outcome: {}", format_loop_outcome(outcome)),
+            Style::default().fg(color),
+        ));
+    }
+    if let Some(feedback) = feedback.filter(|value| !value.trim().is_empty()) {
+        lines.push(Line::styled(
+            format!("  {}", truncate_chat_summary(feedback, 72)),
+            theme.muted_style(),
+        ));
+    }
+    lines
+}
+
+fn loop_state_line_count(
+    stage: Option<&PlanLoopStage>,
+    outcome: Option<&PlanLoopOutcome>,
+    feedback: Option<&str>,
+) -> usize {
+    usize::from(stage.is_some())
+        + usize::from(outcome.is_some())
+        + usize::from(feedback.is_some_and(|value| !value.trim().is_empty()))
+}
+
+fn format_loop_stage(stage: &PlanLoopStage) -> &'static str {
+    match stage {
+        PlanLoopStage::Planning => "plan",
+        PlanLoopStage::Inspecting => "inspect",
+        PlanLoopStage::Executing => "execute",
+        PlanLoopStage::Feedback => "feedback",
+        PlanLoopStage::RetryPending => "retry",
+        PlanLoopStage::ReplanRequired => "replan",
+        PlanLoopStage::Responding => "respond",
+    }
+}
+
+fn format_loop_outcome(outcome: &PlanLoopOutcome) -> &'static str {
+    match outcome {
+        PlanLoopOutcome::WaitingApproval => "waiting approval",
+        PlanLoopOutcome::Succeeded => "succeeded",
+        PlanLoopOutcome::Failed => "failed",
+        PlanLoopOutcome::Checkpointed => "checkpointed",
+        PlanLoopOutcome::RetryPending => "retry suggested",
+        PlanLoopOutcome::ReplanRequired => "replan required",
+        PlanLoopOutcome::Responded => "responded",
+    }
 }
 
 fn plan_followup_lines(runtime: &PlanRuntime, theme: &Theme) -> Vec<Line<'static>> {
@@ -3434,6 +3561,7 @@ mod tests {
             plan_job_output_scroll: 0,
             navigation_focus: app::NavigationFocus::Messages,
             command_output: None,
+            loop_state: app::ChatLoopState::default(),
             agents_panel_expanded: false,
             agents_scroll_offset: 0,
             input: String::new(),
@@ -3656,7 +3784,7 @@ mod tests {
                 ],
                 followup: None,
                 followup_history: Vec::new(),
-                authoring: None,
+                ..Default::default()
             }),
             updated_at: None,
         };
@@ -3711,7 +3839,7 @@ mod tests {
             ],
             followup: None,
             followup_history: Vec::new(),
-            authoring: None,
+            ..Default::default()
         };
 
         let lines = plan_job_lines(&runtime, 0, true, &Theme::default());
@@ -3843,7 +3971,7 @@ mod tests {
                 }],
                 followup: None,
                 followup_history: Vec::new(),
-                authoring: None,
+                ..Default::default()
             }),
             updated_at: None,
         });
@@ -3885,5 +4013,70 @@ mod tests {
         assert!(lines[2]
             .to_string()
             .contains("checkpoint: Inspect output → Patch handler"));
+    }
+
+    #[test]
+    fn plan_loop_state_lines_render_stage_outcome_and_feedback() {
+        let runtime = PlanRuntime {
+            loop_stage: Some(PlanLoopStage::Inspecting),
+            last_outcome: Some(PlanLoopOutcome::RetryPending),
+            last_feedback: Some("inspect relevant files before editing".to_string()),
+            ..Default::default()
+        };
+
+        let lines = plan_loop_state_lines(&runtime, &Theme::default());
+
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].to_string().contains("loop: inspect"));
+        assert!(lines[1]
+            .to_string()
+            .contains("last outcome: retry suggested"));
+        assert!(lines[2]
+            .to_string()
+            .contains("inspect relevant files before editing"));
+    }
+
+    #[test]
+    fn loop_state_lines_render_non_plan_chat_state() {
+        let lines = loop_state_lines(
+            Some(&PlanLoopStage::Responding),
+            Some(&PlanLoopOutcome::Responded),
+            Some("answered directly without planning"),
+            &Theme::default(),
+        );
+
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].to_string().contains("loop: respond"));
+        assert!(lines[1].to_string().contains("last outcome: responded"));
+        assert!(lines[2]
+            .to_string()
+            .contains("answered directly without planning"));
+    }
+
+    #[test]
+    fn latest_action_summary_does_not_echo_plain_assistant_reply() {
+        let mut chat_state = empty_chat_state();
+        chat_state.messages.push(Message {
+            role: "user".to_string(),
+            content: "hi".to_string(),
+        });
+        chat_state.messages.push(Message {
+            role: "assistant".to_string(),
+            content: "Hello! How can I assist you today?".to_string(),
+        });
+
+        let app = app::TuiApp::default();
+        assert!(latest_action_summary(&app, &chat_state).is_none());
+    }
+
+    #[test]
+    fn respond_only_loop_panel_is_hidden() {
+        let loop_state = app::ChatLoopState {
+            stage: Some(PlanLoopStage::Responding),
+            last_outcome: Some(PlanLoopOutcome::Responded),
+            last_feedback: None,
+        };
+
+        assert!(!should_render_chat_loop_panel(&loop_state));
     }
 }

--- a/plans/README.md
+++ b/plans/README.md
@@ -9,13 +9,13 @@ This directory contains ready-to-use planner payloads for Harper's `update_plan`
 - `milestone-2-plan-job-coordination.json`
 - `milestone-3-cross-interface.json`
 - `milestone-4-planner-maturity.json`
-- `agents-md-improvement.json` - dedicated plan for improving `AGENTS.md` handling
-- `routing-improvement.json` - dedicated plan for strengthening deterministic and grounded routing
+- `agents-md-improvement.json` - completed record for the scoped `AGENTS.md` improvement workstream
+- `routing-improvement.json` - partially completed plan for the remaining routing work
 - `../PLANNER_NEXT_STEPS.md` - completed planner/runtime polish record for the last focused workstream
 
 ## Notes
 
 - All files use the same shape: `explanation` plus ordered `items`
-- Every item starts as `pending`
-- These plans are intended to be copied into Harper's `update_plan` tool flow
-- `PLANNER_NEXT_STEPS.md` is the exception: it now records a completed workstream rather than an active plan seed
+- Most plan files are intended to be copied into Harper's `update_plan` tool flow
+- Some files now record completed or partially completed workstreams rather than a fully pending seed
+- `PLANNER_NEXT_STEPS.md` and `agents-md-improvement.json` are completion-oriented records

--- a/plans/agents-md-improvement.json
+++ b/plans/agents-md-improvement.json
@@ -1,13 +1,13 @@
 {
-  "explanation": "Improve Harper's AGENTS.md handling from a single appended file into a scoped instruction system with directory-aware behavior.",
+  "explanation": "AGENTS.md handling is complete for the originally scoped workstream: scoped resolution, nested precedence, path-aware filtering, and UI visibility are in place.",
   "items": [
-    { "step": "Define AGENTS scope rules", "status": "pending" },
-    { "step": "Walk parent directories safely", "status": "pending" },
-    { "step": "Merge nested AGENTS files", "status": "pending" },
-    { "step": "Honor deeper file precedence", "status": "pending" },
-    { "step": "Filter rules by touched paths", "status": "pending" },
-    { "step": "Expose resolved rules to planner", "status": "pending" },
-    { "step": "Show AGENTS sources in UI", "status": "pending" },
-    { "step": "Add regression tests", "status": "pending" }
+    { "step": "Define AGENTS scope rules", "status": "completed" },
+    { "step": "Walk parent directories safely", "status": "completed" },
+    { "step": "Merge nested AGENTS files", "status": "completed" },
+    { "step": "Honor deeper file precedence", "status": "completed" },
+    { "step": "Filter rules by touched paths", "status": "completed" },
+    { "step": "Expose resolved rules to planner", "status": "completed" },
+    { "step": "Show AGENTS sources in UI", "status": "completed" },
+    { "step": "Add regression tests", "status": "completed" }
   ]
 }

--- a/plans/agents-md-improvement.md
+++ b/plans/agents-md-improvement.md
@@ -1,20 +1,20 @@
 # AGENTS.md Improvement Plan
 
-This plan treats `AGENTS.md` support as a product feature, not just prompt text.
+This plan treated `AGENTS.md` support as a product feature, not just prompt text.
 
-## Goal
+## Status
 
-Make Harper resolve, merge, and apply `AGENTS.md` files in a scoped way similar to stronger coding agents.
+This workstream is now effectively complete for the originally scoped goals.
 
-## Problems In The Current State
+## What Is Implemented
 
-- Only the repo-root `AGENTS.md` is effectively appended into prompt context
-- There is no directory-scope resolution
-- There is no nested override behavior
-- There is no path-based filtering for touched files
-- There is no explicit planner/runtime visibility into which `AGENTS.md` files are active
+- Directory-scope resolution from repo root to target path
+- Nested override behavior with deeper-path precedence
+- Path-aware filtering for touched files and targeted tool calls
+- Resolved `AGENTS.md` state surfaced into session/UI state
+- Visible AGENTS source/status in the TUI
 
-## Desired Behavior
+## Original Goal
 
 1. Find applicable `AGENTS.md` files from repo root down to the target path
 2. Merge them in order
@@ -22,16 +22,12 @@ Make Harper resolve, merge, and apply `AGENTS.md` files in a scoped way similar 
 4. Apply instructions only where their scope is valid
 5. Surface resolved instructions to the planner and UI
 
-## Implementation Outline
+## Remaining Gaps
 
-1. Define exact scope semantics
-2. Build a resolver for parent-directory lookup
-3. Add path-aware instruction filtering
-4. Add precedence merging for nested files
-5. Feed resolved instructions into prompt/planner state
-6. Surface active `AGENTS.md` sources in the UI
-7. Add tests for precedence, scope, and filtering
+- Persisting a startup preference for AGENTS context on/off in user config
+- Broader docs coverage for AGENTS UI behavior and debug flow
+- Additional regression coverage only if new AGENTS behavior is introduced
 
-## Planner Payload
+## Completed Plan Payload
 
-See `plans/agents-md-improvement.json`.
+See `plans/agents-md-improvement.json`, which now records the completed state of this workstream rather than an active pending seed.

--- a/plans/master-plan.json
+++ b/plans/master-plan.json
@@ -1,15 +1,15 @@
 {
-  "explanation": "Finish Harper's planner/runtime system from live execution visibility through planner-quality orchestration.",
+  "explanation": "Harper's planner/runtime roadmap is partially complete. Live execution visibility, runtime jobs, scoped AGENTS resolution, and core planner feedback loops are in place. The remaining work is the unfinished cross-interface runtime surface, editable plan actions, and deeper orchestration maturity.",
   "items": [
-    { "step": "Add live output panel", "status": "pending" },
-    { "step": "Introduce job model", "status": "pending" },
-    { "step": "Build job list UI", "status": "pending" },
-    { "step": "Link steps to jobs", "status": "pending" },
+    { "step": "Add live output panel", "status": "completed" },
+    { "step": "Introduce job model", "status": "completed" },
+    { "step": "Build job list UI", "status": "completed" },
+    { "step": "Link steps to jobs", "status": "completed" },
     { "step": "Auto-advance on job finish", "status": "pending" },
-    { "step": "Handle blocked and failed states", "status": "pending" },
+    { "step": "Handle blocked and failed states", "status": "completed" },
     { "step": "Expose runtime over HTTP", "status": "pending" },
     { "step": "Add UI plan editing", "status": "pending" },
-    { "step": "Resolve scoped AGENTS rules", "status": "pending" },
+    { "step": "Resolve scoped AGENTS rules", "status": "completed" },
     { "step": "Improve planner orchestration", "status": "pending" }
   ]
 }

--- a/plans/milestone-1-live-execution.json
+++ b/plans/milestone-1-live-execution.json
@@ -1,9 +1,9 @@
 {
-  "explanation": "Build the first real live execution UX so running work is visible while a turn is still active.",
+  "explanation": "Milestone 1 is complete. Running work is now visible while a turn is active through streamed command output, runtime job state, and TUI command-output surfaces.",
   "items": [
-    { "step": "Design command event model", "status": "pending" },
-    { "step": "Stream command output chunks", "status": "pending" },
-    { "step": "Add live output panel", "status": "pending" },
-    { "step": "Show job status summary", "status": "pending" }
+    { "step": "Design command event model", "status": "completed" },
+    { "step": "Stream command output chunks", "status": "completed" },
+    { "step": "Add live output panel", "status": "completed" },
+    { "step": "Show job status summary", "status": "completed" }
   ]
 }

--- a/plans/milestone-2-plan-job-coordination.json
+++ b/plans/milestone-2-plan-job-coordination.json
@@ -1,9 +1,9 @@
 {
-  "explanation": "Tie plan progress to actual runtime state so steps reflect real execution instead of only model intent.",
+  "explanation": "Milestone 2 is partially complete. Plan progress is now tied to runtime jobs and blocked/failed states are surfaced, but the remaining transition rules are still narrower than a fully planner-driven execution system.",
   "items": [
-    { "step": "Link steps to jobs", "status": "pending" },
+    { "step": "Link steps to jobs", "status": "completed" },
     { "step": "Advance steps on success", "status": "pending" },
-    { "step": "Handle blocked and failed runs", "status": "pending" },
+    { "step": "Handle blocked and failed runs", "status": "completed" },
     { "step": "Refine plan transition rules", "status": "pending" }
   ]
 }

--- a/plans/milestone-3-cross-interface.json
+++ b/plans/milestone-3-cross-interface.json
@@ -1,5 +1,5 @@
 {
-  "explanation": "Expose plan and job runtime state consistently across TUI and HTTP clients.",
+  "explanation": "Milestone 3 remains mostly open. Session state is more unified across TUI and HTTP surfaces, but dedicated runtime endpoints, streaming runtime delivery, and editable cross-interface plan actions are still unfinished.",
   "items": [
     { "step": "Add HTTP plan runtime endpoints", "status": "pending" },
     { "step": "Stream API-side runtime events", "status": "pending" },

--- a/plans/milestone-4-planner-maturity.json
+++ b/plans/milestone-4-planner-maturity.json
@@ -1,9 +1,9 @@
 {
-  "explanation": "Move from basic reactive execution toward a planner-quality agent with scoped repo instructions and stronger orchestration.",
+  "explanation": "Milestone 4 is mostly complete for the currently implemented scope. Scoped AGENTS rules, planner checkpoints, retry/recovery feedback, and cleaner execution summaries are in place. The remaining work is deeper orchestration quality rather than the original baseline capabilities.",
   "items": [
-    { "step": "Resolve scoped AGENTS rules", "status": "pending" },
-    { "step": "Add planner checkpoints", "status": "pending" },
-    { "step": "Improve retry and recovery", "status": "pending" },
-    { "step": "Summarize execution state cleanly", "status": "pending" }
+    { "step": "Resolve scoped AGENTS rules", "status": "completed" },
+    { "step": "Add planner checkpoints", "status": "completed" },
+    { "step": "Improve retry and recovery", "status": "completed" },
+    { "step": "Summarize execution state cleanly", "status": "completed" }
   ]
 }

--- a/plans/routing-improvement.json
+++ b/plans/routing-improvement.json
@@ -1,13 +1,13 @@
 {
-  "explanation": "Improve Harper routing from a mostly heuristic deterministic layer into a stronger strategy-aware system with better coverage, ambiguity handling, and observability.",
+  "explanation": "Routing is partially complete: grounded deterministic-first behavior, broader deterministic coverage, follow-up command resolution, and shell-visible routing diagnostics are in place. The remaining work is ambiguity handling, multi-intent decomposition, error/trace routing, and broader regression coverage.",
   "items": [
-    { "step": "Strengthen grounded deterministic routing", "status": "pending" },
-    { "step": "Expand deterministic inspection coverage", "status": "pending" },
+    { "step": "Strengthen grounded deterministic routing", "status": "completed" },
+    { "step": "Expand deterministic inspection coverage", "status": "completed" },
     { "step": "Rank overlapping intent matches", "status": "pending" },
     { "step": "Handle routing ambiguity explicitly", "status": "pending" },
     { "step": "Add bounded multi-intent decomposition", "status": "pending" },
     { "step": "Route compiler and trace prompts", "status": "pending" },
-    { "step": "Expose routing decisions for debugging", "status": "pending" },
+    { "step": "Expose routing decisions for debugging", "status": "completed" },
     { "step": "Add regression prompt coverage", "status": "pending" }
   ]
 }

--- a/plans/routing-improvement.md
+++ b/plans/routing-improvement.md
@@ -2,20 +2,28 @@
 
 This plan treats routing as a product capability, not a growing pile of one-off heuristics.
 
-## Goal
+## Status
 
-Make Harper's routing more reliable, more explainable, and more meaningfully differentiated across `auto`, `grounded`, and `deterministic`.
+This workstream is partially complete. The core strategy split, broader deterministic coverage, follow-up command resolution, shell-visible routing diagnostics, and graceful no-backend fallback are now in place.
 
 ## Problems In The Current State
 
-- Deterministic routing is still rule-based and phrase-sensitive
-- `grounded` only recently became meaningfully different from `auto`
-- Overlapping intents still rely on code-order precedence instead of explicit ranking
+- Deterministic routing is still rule-based and phrase-sensitive in edge cases
+- Overlapping intents still rely too much on precedence and heuristics instead of explicit ranking
 - Multi-intent prompts are not decomposed into bounded deterministic steps
-- Error, compiler, and stack-trace prompts are only handled indirectly through generic codebase search phrasing
-- Symbol extraction works for common cases but still lacks full ambiguity handling
+- Error, compiler, and stack-trace prompts are still not first-class routing inputs
+- Search quality is still ranking-based, not true semantic xref
+- Symbol extraction is stronger, but ambiguity handling is still incomplete
 
-## Desired Behavior
+## What Is Already Done
+
+1. `grounded` now prefers deterministic routing when the request is clearly routable
+2. Deterministic coverage for common repo inspection, follow-up command resolution, and codebase tracing prompts is broader
+3. Shell-visible routing observability exists through `harper-batch` and `debug_turn_summary(...)`
+4. Strategy behavior is meaningfully differentiated across `deterministic`, `grounded`, `auto`, and `model`
+5. No-backend model failures now degrade cleanly when deterministic fallback exists, and return clear assistant messaging when it does not
+
+## Desired Remaining Behavior
 
 1. Let `grounded` prefer deterministic routing when the request is clearly routable
 2. Expand deterministic coverage for common repo inspection and codebase tracing prompts
@@ -35,14 +43,12 @@ Make Harper's routing more reliable, more explainable, and more meaningfully dif
 6. Add compiler/error/trace-specific extraction
 7. Add routing observability and regression coverage
 
-## Recommended Order
+## Recommended Remaining Order
 
-1. Strengthen grounded deterministic routing
-2. Expand deterministic inspection/search coverage
-3. Add ranked intent competition
-4. Add compiler/error/trace-aware routing
-5. Add bounded multi-intent decomposition
-6. Add routing observability and regression coverage
+1. Add ranked intent competition
+2. Add compiler/error/trace-aware routing
+3. Add bounded multi-intent decomposition
+4. Expand routing observability and regression coverage
 
 ## Validation Focus
 
@@ -59,4 +65,4 @@ Make Harper's routing more reliable, more explainable, and more meaningfully dif
 
 ## Planner Payload
 
-See `plans/routing-improvement.json`.
+See `plans/routing-improvement.json`, which now marks completed phases and leaves only the remaining routing work pending.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,66 +1,38 @@
 #!/bin/bash
 
-# Copyright 2026 harpertoken
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+set -euo pipefail
 
-# Comprehensive test and validation script for Harper
-# This script runs all quality checks and tests
-
-set -euo pipefail  # Exit on any error, undefined vars, or pipe failures
-
-# Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# Quiet mode
-QUIET=${QUIET:-0}
+TOTAL_STEPS=14
+PASSED_STEPS=0
+WARNED_STEPS=0
 
-echo ""
-echo -e "${BLUE}╭──────────────────────────────────────────────╮${NC}"
-echo -e "${BLUE}│          Harper Validation Suite             │${NC}"
-echo -e "${BLUE}│        Calm checks. Strong guarantees.       │${NC}"
-echo -e "${BLUE}╰──────────────────────────────────────────────╯${NC}"
-echo ""
+print_banner() {
+    echo
+    echo -e "${BLUE}╭──────────────────────────────────────────────╮${NC}"
+    echo -e "${BLUE}│          Harper Validation Suite             │${NC}"
+    echo -e "${BLUE}│        Build. Lint. Test. Verify.            │${NC}"
+    echo -e "${BLUE}╰──────────────────────────────────────────────╯${NC}"
+    echo
+}
 
-# Function to print status
 print_status() {
     local status=$1
     local message=$2
     case $status in
-        "PASS")
-            echo -e "${GREEN}PASS${NC}: $message"
-            ;;
-        "FAIL")
-            echo -e "${RED}FAIL${NC}: $message"
-            ;;
-        "WARN")
-            echo -e "${YELLOW}WARN${NC}: $message"
-            ;;
-        "INFO")
-            echo -e "${BLUE}INFO${NC}: $message"
-            ;;
+        PASS) echo -e "${GREEN}PASS${NC}: $message" ;;
+        FAIL) echo -e "${RED}FAIL${NC}: $message" ;;
+        WARN) echo -e "${YELLOW}WARN${NC}: $message" ;;
+        INFO) echo -e "${BLUE}INFO${NC}: $message" ;;
     esac
 }
 
-run_check_with_output() {
-    local fail_message=$1
-    local tip_message=$2
-    shift 2
-
+run_command_with_log() {
     local log_file
     log_file=$(mktemp)
 
@@ -69,227 +41,285 @@ run_check_with_output() {
         return 0
     fi
 
-    print_status "FAIL" "$fail_message"
-    if [ -n "$tip_message" ]; then
-        echo "$tip_message"
-    fi
     echo "--- command output ---"
     cat "$log_file"
     rm -f "$log_file"
     return 1
 }
 
-# Check if we're in the right directory
-if [ ! -f "Cargo.toml" ]; then
-    print_status "FAIL" "Not in Harper project root (Cargo.toml not found)"
-    exit 1
-fi
+run_required_step() {
+    local step=$1
+    local title=$2
+    local fail_message=$3
+    local tip_message=$4
+    shift 4
 
-print_status "INFO" "Starting validation checks..."
-
-# 1. Rust Compilation Check
-echo ""
-print_status "INFO" "[1/14] Checking Rust compilation..."
-if run_check_with_output \
-    "Rust compilation failed" \
-    "Run 'cargo check --workspace' for details" \
-    cargo check --workspace --quiet; then
-    print_status "PASS" "Rust compilation successful ✓"
-else
-    exit 1
-fi
-
-# 2. Clippy Linting
-echo ""
-print_status "INFO" "2. Running Clippy linter..."
-if run_check_with_output \
-    "Clippy reported issues that need attention" \
-    "→ Tip: run 'cargo clippy --all-targets --all-features --workspace -- -A clippy::pedantic -D warnings' locally" \
-    cargo clippy --all-targets --all-features --workspace --quiet -- -A clippy::pedantic -D warnings; then
-    print_status "PASS" "Clippy linting passed"
-else
-    exit 1
-fi
-
-# 3. Code Formatting
-echo ""
-print_status "INFO" "3. Checking code formatting..."
-if run_check_with_output \
-    "Code formatting issues found" \
-    "Run 'cargo fmt --all' to fix formatting" \
-    cargo fmt --all -- --check; then
-    print_status "PASS" "Code formatting correct"
-else
-    exit 1
-fi
-
-# 4. Unit Tests
-echo ""
-print_status "INFO" "4. Running unit tests..."
-if run_check_with_output \
-    "Unit tests failed" \
-    "Run 'cargo test --workspace' for details" \
-    cargo test --workspace --quiet; then
-    print_status "PASS" "All unit tests passed"
-else
-    exit 1
-fi
-
-# 5. Security Audit
-echo ""
-print_status "INFO" "5. Running security audit..."
-if [ -x "$HOME/.cargo/bin/cargo-audit" ]; then
-    if "$HOME/.cargo/bin/cargo-audit" audit --quiet >/dev/null 2>&1; then
-        print_status "PASS" "Security audit passed"
+    echo
+    print_status "INFO" "[$step/$TOTAL_STEPS] $title"
+    if run_command_with_log "$@"; then
+        print_status "PASS" "$title"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
     else
-        print_status "FAIL" "Security vulnerabilities found"
-        echo "Run '$HOME/.cargo/bin/cargo-audit audit' for details"
-        exit 1
-    fi
-else
-    print_status "WARN" "cargo-audit not installed (run: cargo install cargo-audit)"
-fi
-
-# 6. File Size Check
-echo ""
-print_status "INFO" "6. Checking for large files..."
-LARGE_FILES=$(find . -type f -size +10M -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
-if [ -z "$LARGE_FILES" ]; then
-    print_status "PASS" "No large files found"
-else
-    print_status "FAIL" "Large files detected (>10MB)"
-    echo "$LARGE_FILES"
-    exit 1
-fi
-
-# 7. Sensitive Files Check
-echo ""
-print_status "INFO" "7. Checking for sensitive files..."
-SENSITIVE_FILES=$(find . \( -name "*.key" -o -name "*.pem" -o -name "*.env" \) -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
-if [ -z "$SENSITIVE_FILES" ]; then
-    print_status "PASS" "No sensitive files found in repository"
-else
-    print_status "WARN" "Potential sensitive files found"
-    echo "$SENSITIVE_FILES"
-fi
-
-# 8. YAML Validation
-echo ""
-print_status "INFO" "8. Validating YAML files..."
-if command -v yamllint >/dev/null 2>&1; then
-    YAML_FILES=$(find . -name "*.yml" -o -name "*.yaml" -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
-    if [ -n "$YAML_FILES" ]; then
-        # Use xargs to handle multiple files properly
-        if echo "$YAML_FILES" | xargs yamllint >/dev/null 2>&1; then
-            print_status "PASS" "YAML files are valid"
-        else
-            print_status "FAIL" "YAML validation failed"
-            echo "Run 'yamllint .github/workflows/*.yml docker/docker-compose.yml' for details"
-            exit 1
+        print_status "FAIL" "$fail_message"
+        if [ -n "$tip_message" ]; then
+            echo "$tip_message"
         fi
-    else
-        print_status "PASS" "No YAML files to validate"
+        exit 1
     fi
-else
-    print_status "WARN" "yamllint not installed (run: pip install yamllint)"
-fi
+}
 
-# 9. TODO Comments Check
-echo ""
-print_status "INFO" "9. Checking for TODO comments..."
-# Look for TODO/FIXME/XXX in Rust comments
-TODO_COUNT=$(
-    rg --glob '*.rs' --count-matches \
-        '(//|///|/\*|\*|//!).*(TODO|FIXME|XXX)' \
-        src/ 2>/dev/null || true
-)
-TODO_COUNT=$(
-    printf '%s\n' "$TODO_COUNT" \
-        | awk -F: '{sum += $NF} END {print sum + 0}'
-)
-if [ "$TODO_COUNT" -eq "0" ]; then
-    print_status "PASS" "No unresolved TODO comments found"
-else
-    print_status "WARN" "Found $TODO_COUNT unresolved TODO/FIXME/XXX comments"
-    echo "Consider resolving these or documenting why they're needed"
-fi
+run_optional_step() {
+    local step=$1
+    local title=$2
+    shift 2
 
-# 10. Documentation Check
-echo ""
-print_status "INFO" "10. Checking documentation..."
-if run_check_with_output \
-    "Documentation build failed" \
-    "Run 'cargo doc --no-deps --workspace' for details" \
-    cargo doc --no-deps --workspace --quiet; then
-    print_status "PASS" "Documentation builds successfully"
-else
-    exit 1
-fi
+    echo
+    print_status "INFO" "[$step/$TOTAL_STEPS] $title"
+    if "$@"; then
+        print_status "PASS" "$title"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
+    else
+        print_status "WARN" "$title"
+        WARNED_STEPS=$((WARNED_STEPS + 1))
+    fi
+}
 
-# 11. License Check
-echo ""
-print_status "INFO" "11. Checking license compliance..."
-if [ -x "$HOME/.cargo/bin/cargo-deny" ]; then
-    # Check only policy areas relevant to repository validation here.
-    # Advisories depend on an external database and can fail for environment reasons.
-    if run_check_with_output \
-        "License compliance issues found" \
-        "Run '$HOME/.cargo/bin/cargo-deny check licenses bans sources' for details" \
-        "$HOME/.cargo/bin/cargo-deny" check licenses bans sources; then
-        print_status "PASS" "License compliance check passed"
+check_project_root() {
+    if [ ! -f "Cargo.toml" ]; then
+        print_status "FAIL" "Not in Harper project root (Cargo.toml not found)"
+        exit 1
+    fi
+}
+
+check_large_files() {
+    local large_files
+    large_files=$(find . -type f -size +10M -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
+    if [ -n "$large_files" ]; then
+        print_status "FAIL" "Large files detected (>10MB)"
+        echo "$large_files"
+        return 1
+    fi
+    return 0
+}
+
+check_sensitive_files() {
+    local sensitive_files
+    sensitive_files=$(find . \( -name "*.key" -o -name "*.pem" -o -name "*.env" \) -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
+    if [ -n "$sensitive_files" ]; then
+        print_status "WARN" "Potential sensitive files found"
+        echo "$sensitive_files"
+        WARNED_STEPS=$((WARNED_STEPS + 1))
+    else
+        print_status "PASS" "No sensitive files found in repository"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
+    fi
+    return 0
+}
+
+check_yaml() {
+    if ! command -v yamllint >/dev/null 2>&1; then
+        print_status "WARN" "yamllint not installed (run: pip install yamllint)"
+        WARNED_STEPS=$((WARNED_STEPS + 1))
+        return 0
+    fi
+
+    local yaml_files
+    yaml_files=$(find . \( -name "*.yml" -o -name "*.yaml" \) -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
+    if [ -z "$yaml_files" ]; then
+        print_status "PASS" "No YAML files to validate"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
+        return 0
+    fi
+
+    if echo "$yaml_files" | xargs yamllint >/dev/null 2>&1; then
+        print_status "PASS" "YAML files are valid"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
+        return 0
+    fi
+
+    print_status "FAIL" "YAML validation failed"
+    echo "Run 'yamllint .github/workflows/*.yml docker/docker-compose.yml' for details"
+    return 1
+}
+
+check_todos() {
+    local todo_count
+    todo_count=$(
+        rg --glob '*.rs' --count-matches \
+            '(//|///|/\*|\*|//!).*(TODO|FIXME|XXX)' \
+            . 2>/dev/null || true
+    )
+    todo_count=$(
+        printf '%s\n' "$todo_count" \
+            | awk -F: '{sum += $NF} END {print sum + 0}'
+    )
+
+    if [ "$todo_count" -eq 0 ]; then
+        print_status "PASS" "No unresolved TODO comments found"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
+    else
+        print_status "WARN" "Found $todo_count unresolved TODO/FIXME/XXX comments"
+        echo "Consider resolving these or documenting why they're needed"
+        WARNED_STEPS=$((WARNED_STEPS + 1))
+    fi
+    return 0
+}
+
+check_cargo_audit() {
+    if ! command -v cargo-audit >/dev/null 2>&1 && [ ! -x "$HOME/.cargo/bin/cargo-audit" ]; then
+        print_status "WARN" "cargo-audit not installed (run: cargo install cargo-audit)"
+        WARNED_STEPS=$((WARNED_STEPS + 1))
+        return 0
+    fi
+
+    local audit_bin="cargo-audit"
+    if ! command -v cargo-audit >/dev/null 2>&1; then
+        audit_bin="$HOME/.cargo/bin/cargo-audit"
+    fi
+
+    if run_command_with_log "$audit_bin" audit --quiet; then
+        print_status "PASS" "Security audit passed"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
+        return 0
+    fi
+
+    print_status "FAIL" "Security audit found vulnerabilities"
+    echo "Run '$audit_bin audit' for details"
+    return 1
+}
+
+check_cargo_deny() {
+    if ! command -v cargo-deny >/dev/null 2>&1 && [ ! -x "$HOME/.cargo/bin/cargo-deny" ]; then
+        print_status "WARN" "cargo-deny not installed (run: cargo install cargo-deny)"
+        WARNED_STEPS=$((WARNED_STEPS + 1))
+        return 0
+    fi
+
+    local deny_bin="cargo-deny"
+    if ! command -v cargo-deny >/dev/null 2>&1; then
+        deny_bin="$HOME/.cargo/bin/cargo-deny"
+    fi
+
+    if run_command_with_log "$deny_bin" check; then
+        print_status "PASS" "cargo-deny policy checks passed"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
+        return 0
+    fi
+
+    print_status "FAIL" "cargo-deny reported dependency policy issues"
+    echo "Run '$deny_bin check' for details"
+    return 1
+}
+
+check_benchmarks() {
+    if cargo bench --workspace --quiet >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+check_integration_tests() {
+    if cargo test --tests --workspace --quiet >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+release_binary_size() {
+    if ! command -v stat >/dev/null 2>&1; then
+        echo "unknown"
+        return 0
+    fi
+
+    local bin
+    bin=$(cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.packages[0].targets[] | select(.kind[]=="bin") | .name' 2>/dev/null || echo "harper")
+    stat -f%z "target/release/$bin" 2>/dev/null || stat -c%s "target/release/$bin" 2>/dev/null || echo "unknown"
+}
+
+print_summary() {
+    echo
+    echo -e "${GREEN}✓ Harper validation completed${NC}"
+    echo
+    echo "Summary:"
+    echo " • Passed steps: $PASSED_STEPS/$TOTAL_STEPS"
+    echo " • Warning steps: $WARNED_STEPS"
+    echo " • Required checks: all passed"
+    echo
+}
+
+main() {
+    check_project_root
+    print_banner
+    print_status "INFO" "Starting validation checks..."
+
+    run_required_step 1 "Rust compilation check" \
+        "Rust compilation failed" \
+        "Run 'cargo check --workspace' for details" \
+        cargo check --workspace --quiet
+
+    run_required_step 2 "Clippy linter" \
+        "Clippy reported issues that need attention" \
+        "Run 'cargo clippy --all-targets --all-features --workspace -- -A clippy::pedantic -D warnings' for details" \
+        cargo clippy --all-targets --all-features --workspace --quiet -- -A clippy::pedantic -D warnings
+
+    run_required_step 3 "Formatting check" \
+        "Code formatting issues found" \
+        "Run 'cargo fmt --all' to fix formatting" \
+        cargo fmt --all -- --check
+
+    run_required_step 4 "Workspace tests" \
+        "Workspace tests failed" \
+        "Run 'cargo test --workspace' for details" \
+        cargo test --workspace --quiet
+
+    echo
+    print_status "INFO" "[5/$TOTAL_STEPS] Security audit"
+    check_cargo_audit
+
+    echo
+    print_status "INFO" "[6/$TOTAL_STEPS] Large file check"
+    if check_large_files; then
+        print_status "PASS" "No large files found"
+        PASSED_STEPS=$((PASSED_STEPS + 1))
     else
         exit 1
     fi
-else
-    print_status "WARN" "cargo-deny not installed (run: cargo install cargo-deny)"
-fi
 
-# 12. Performance Benchmark (if criterion is available)
-echo ""
-print_status "INFO" "12. Running performance benchmarks..."
-if cargo bench --workspace --quiet 2>/dev/null || true; then
-    print_status "PASS" "Performance benchmarks completed"
-else
-    print_status "WARN" "Performance benchmarks failed or not configured"
-fi
+    echo
+    print_status "INFO" "[7/$TOTAL_STEPS] Sensitive file check"
+    check_sensitive_files
 
-# 13. Integration Tests
-echo ""
-print_status "INFO" "13. Running integration tests..."
-if cargo test --tests --workspace --quiet 2>/dev/null; then
-    print_status "PASS" "Integration tests passed"
-else
-    print_status "WARN" "Integration tests failed or not configured"
-fi
-
-# 14. Build Optimization Check
-echo ""
-print_status "INFO" "14. Checking build optimization..."
-if run_check_with_output \
-    "Release build failed" \
-    "Run 'cargo build --release --workspace' for details" \
-    cargo build --release --workspace --quiet; then
-    if command -v stat >/dev/null 2>&1; then
-        BIN=$(cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.packages[0].targets[] | select(.kind[]=="bin") | .name' 2>/dev/null || echo "harper")
-        BINARY_SIZE=$(stat -f%z "target/release/$BIN" 2>/dev/null || stat -c%s "target/release/$BIN" 2>/dev/null || echo "unknown")
-    else
-        BINARY_SIZE="unknown"
+    echo
+    print_status "INFO" "[8/$TOTAL_STEPS] YAML validation"
+    if ! check_yaml; then
+        exit 1
     fi
-    print_status "PASS" "Release build successful (binary size: $BINARY_SIZE bytes)"
-else
-    exit 1
-fi
 
-# Summary
-echo ""
-echo -e "${GREEN}✓ Harper validation completed successfully${NC}"
-echo ""
-echo "What this means:"
-echo " • Code builds cleanly"
-echo " • Linting and formatting are consistent"
-echo " • Tests and docs are healthy"
-echo " • No obvious security or licensing risks"
-echo ""
-echo "You can merge, release, or ship with confidence."
-echo ""
-echo "Strong systems are built calmly."
+    echo
+    print_status "INFO" "[9/$TOTAL_STEPS] TODO/FIXME/XXX scan"
+    check_todos
+
+    run_required_step 10 "Documentation build" \
+        "Documentation build failed" \
+        "Run 'cargo doc --no-deps --workspace' for details" \
+        cargo doc --no-deps --workspace --quiet
+
+    echo
+    print_status "INFO" "[11/$TOTAL_STEPS] cargo-deny policy check"
+    if ! check_cargo_deny; then
+        exit 1
+    fi
+
+    run_optional_step 12 "Workspace benchmarks" check_benchmarks
+    run_optional_step 13 "Integration tests" check_integration_tests
+
+    run_required_step 14 "Release build" \
+        "Release build failed" \
+        "Run 'cargo build --release --workspace' for details" \
+        cargo build --release --workspace --quiet
+
+    print_status "PASS" "Release build successful (binary size: $(release_binary_size) bytes)"
+    print_summary
+}
+
+main "$@"

--- a/website/blog.html
+++ b/website/blog.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Blog</title>
-    <meta name="harper-update-version" content="2026-04-28-blog-v3" />
+    <meta name="harper-update-version" content="2026-05-01-blog-v5" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -15,6 +15,7 @@
             <nav class="nav">
                 <a href="index.html" data-update-target="home">Home</a>
                 <a href="installation.html" data-update-target="install">Install</a>
+                <a href="docs.html" data-update-target="docs">Docs</a>
                 <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
                 <a href="blog.html" data-update-target="blog" aria-current="page">Blog</a>
                 <a href="changelog.html" data-update-target="changelog">Changelog</a>
@@ -28,6 +29,13 @@
             <div class="content-container">
                 <h1 class="hero-title">Notes from the codebase.</h1>
                 <p class="hero-lede">Short product and engineering notes from Harper. This page stays high level. The <a href="changelog.html">changelog</a> keeps the version-by-version detail.</p>
+
+                <article>
+                    <h2>May 2026 · Shell-first verification is now the default debug path</h2>
+                    <p>One of the most practical changes in recent Harper work is not visual. It is the addition of a shell-facing verification path through <code>harper-batch</code>. That matters because the fastest way to debug routing, command normalization, follow-up resolution, and strategy behavior is not to open the TUI first. It is to run the same prompts headlessly and inspect the control path directly.</p>
+                    <p>The useful shift is clarity. Harper can now report the selected strategy, task mode, routed deterministic intent, normalized command, runtime activity, and final assistant reply in one shell-visible flow. That makes prompts such as <code>where is execution strategy used in this repo</code>, <code>run the git status</code>, and <code>run that</code> much easier to validate before spending time on UI-specific issues.</p>
+                    <p>This also sharpened the product split between strategies. <code>deterministic</code> is now easier to verify as a strict grounded tool path. <code>grounded</code> prefers deterministic grounding first for supported repo questions and then allows model synthesis when needed. <code>auto</code> stays tool-assisted, but it no longer has to fail noisily when a deterministic fallback exists. The result is not that Harper became simpler. The result is that it became more inspectable.</p>
+                </article>
 
                 <article>
                     <h2>April 2026 · Cargo and Bazel validation got tighter</h2>
@@ -56,8 +64,8 @@
 
                 <article>
                     <h2>April 2026 · Execution strategy became explicit</h2>
-                    <p>Harper now exposes execution strategy directly in the TUI and local config. The point is not to turn the product into a classical deterministic router; the point is to make the tradeoff explicit. <code>auto</code> and <code>grounded</code> keep the model in the loop for normal repo work, while <code>deterministic</code> provides a stricter direct-tool mode for smoke checks and operational prompts.</p>
-                    <p>This also cleaned up a real failure mode in local-model sessions. Instead of letting weaker models either invent shell commands or refuse valid repo actions, Harper now feeds grounded repo context into the model first and only falls back to deterministic execution when the model response is empty, low-value, or invalid.</p>
+                    <p>Harper now exposes execution strategy directly in the TUI and local config. The point is to make the control path explicit. <code>deterministic</code> prefers strict direct-tool handling for supported intents, <code>grounded</code> prefers deterministic grounding first for routable repo questions and then allows model synthesis when needed, <code>auto</code> stays tool-assisted, and <code>model</code> disables deterministic shortcuts.</p>
+                    <p>This also cleaned up a real failure mode in local-model sessions. Harper now has a shell-verifiable path for repo-grounded prompts and command follow-ups, so weak or unavailable model backends no longer have to break every operational check. When the model backend is unavailable and no deterministic fallback exists, Harper now returns a clear assistant reply instead of surfacing a raw transport error.</p>
                 </article>
 
                 <article>
@@ -68,8 +76,8 @@
 
                 <article>
                     <h2>April 2026 · The TUI started showing work in progress</h2>
-                    <p>One of the bigger gaps in earlier Harper builds was responsiveness during a turn. The assistant could be working, but the interface did not make that state obvious enough. The TUI now carries explicit activity status, a visible pending assistant row, live plan updates, and command-output panels for shell work.</p>
-                    <p>The goal is not cosmetic animation. The goal is to remove ambiguity: thinking, waiting for approval, running a command, and returning a final reply are different states, and the interface should show them as different states.</p>
+                    <p>One of the bigger gaps in earlier Harper builds was responsiveness during a turn. The assistant could be working, but the interface did not make that state obvious enough. The TUI now carries explicit activity status, live plan updates, command-output panels for shell work, and persistent loop-state feedback for planned tasks.</p>
+                    <p>The goal is not cosmetic animation. The goal is to remove ambiguity: planning, inspecting, waiting for approval, running a command, and returning a final reply are different states, and the interface should show them as different states. The same core flow is also available headlessly through <code>harper-batch</code> for shell-first verification before opening the TUI.</p>
                 </article>
 
                 <article>

--- a/website/changelog.html
+++ b/website/changelog.html
@@ -15,6 +15,7 @@
             <nav class="nav">
                 <a href="index.html" data-update-target="home">Home</a>
                 <a href="installation.html" data-update-target="install">Install</a>
+                <a href="docs.html" data-update-target="docs">Docs</a>
                 <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
                 <a href="blog.html" data-update-target="blog">Blog</a>
                 <a href="changelog.html" data-update-target="changelog" aria-current="page">Changelog</a>

--- a/website/docs.html
+++ b/website/docs.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Harper · Docs</title>
+    <meta name="harper-update-version" content="2026-05-01-docs-v1" />
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
+</head>
+<body>
+    <div class="page">
+        <header class="site-header">
+            <div class="brand"><img src="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" alt="" />HARPER<span>·AI</span></div>
+            <nav class="nav">
+                <a href="index.html" data-update-target="home">Home</a>
+                <a href="installation.html" data-update-target="install">Install</a>
+                <a href="docs.html" data-update-target="docs" aria-current="page">Docs</a>
+                <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
+                <a href="blog.html" data-update-target="blog">Blog</a>
+                <a href="changelog.html" data-update-target="changelog">Changelog</a>
+                <a href="server.html" data-update-target="server">API Server</a>
+                <a href="terms.html" data-update-target="terms">Terms</a>
+                <a href="privacy.html" data-update-target="privacy">Privacy</a>
+            </nav>
+        </header>
+
+        <main class="surface">
+            <div class="content-container">
+                <h1 class="hero-title">Harper docs<br/><span>for daily use and debugging.</span></h1>
+                <p class="hero-lede">Start with installation and configuration, use the shell-first verification flow for routing checks, then move to the TUI only for UI-specific validation.</p>
+
+                <div class="actions">
+                    <a class="button primary" href="installation.html">Install Guide</a>
+                    <a class="button secondary" href="https://github.com/harpertoken/harper/tree/main/docs/user-guide">Full Docs on GitHub</a>
+                </div>
+
+                <h2>Core guides</h2>
+                <ul>
+                    <li><a href="installation.html">Installation</a> — setup, TUI commands, execution policy, routing, and shell-first verification</li>
+                    <li><a href="server.html">API Server</a> — config, runtime behavior, and integration details</li>
+                    <li><a href="troubleshooting.html">Troubleshooting</a> — common runtime, auth, and shell issues</li>
+                </ul>
+
+                <h2>Verification workflow</h2>
+                <p>Use <code>harper-batch</code> before opening the TUI when you need to verify routing, normalization, or follow-up behavior:</p>
+                <div class="code-wrapper">
+                    <pre><code>target/debug/harper-batch --strategy deterministic --prompt "where is execution strategy used in this repo"
+target/debug/harper-batch --strategy deterministic --prompt "run the git status" --prompt "run that"
+target/debug/harper-batch --strategy grounded --prompt "where is execution strategy used in this repo"</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <p>Read these fields first: <code>ROUTING</code>, <code>DETERMINISTIC INTENT</code>, <code>NORMALIZED COMMAND</code>, <code>ACTIVITY</code>, and <code>ASSISTANT</code>.</p>
+
+                <h2>User guide sections</h2>
+                <ul>
+                    <li><a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/about.md">About Harper</a></li>
+                    <li><a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/chat.md">Chat Interface</a></li>
+                    <li><a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/configuration.md">Configuration</a></li>
+                    <li><a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/quick-start.md">Quick Start</a></li>
+                </ul>
+            </div>
+        </main>
+
+        <footer class="footnote">
+            <a class="button secondary" href="index.html">← Back</a>
+        </footer>
+    </div>
+    <script src="nav-updates.js"></script>
+    <script>
+        const header = document.querySelector('.site-header');
+        window.addEventListener('scroll', () => {
+            header.classList.toggle('scrolled', window.scrollY > 50);
+        });
+    </script>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Terminal AI</title>
-    <meta name="harper-update-version" content="2026-04-28-home" />
+    <meta name="harper-update-version" content="2026-05-01-home-v2" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -15,6 +15,7 @@
             <nav class="nav">
                 <a href="index.html" data-update-target="home" aria-current="page">Home</a>
                 <a href="installation.html" data-update-target="install">Install</a>
+                <a href="docs.html" data-update-target="docs">Docs</a>
                 <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
                 <a href="blog.html" data-update-target="blog">Blog</a>
                 <a href="changelog.html" data-update-target="changelog">Changelog</a>

--- a/website/installation.html
+++ b/website/installation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Installation</title>
-    <meta name="harper-update-version" content="2026-04-28-install-v6" />
+    <meta name="harper-update-version" content="2026-05-01-install-v7" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -15,6 +15,7 @@
             <nav class="nav">
                 <a href="index.html" data-update-target="home">Home</a>
                 <a href="installation.html" data-update-target="install" aria-current="page">Install</a>
+                <a href="docs.html" data-update-target="docs">Docs</a>
                 <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
                 <a href="blog.html" data-update-target="blog">Blog</a>
                 <a href="changelog.html" data-update-target="changelog">Changelog</a>
@@ -104,7 +105,7 @@ retry_max_attempts = 1
 header_widgets = ["model", "cwd", "strategy"]</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p>Approval profiles control whether commands always require approval, only allowlisted commands can run automatically, or all commands can run automatically. Under <code>allow_listed</code>, Harper still asks for approval when a command declares network access, or when it declares writes outside the configured sandbox writable roots, even if the command itself is allowlisted. Execution strategy controls whether Harper prefers model-first grounded behavior, deterministic execution, or no deterministic shortcuts. Sandbox profiles control whether command execution is unsandboxed, sandboxed to the workspace, or sandboxed with workspace access plus network enabled.</p>
+                <p>Approval profiles control whether commands always require approval, only allowlisted commands can run automatically, or all commands can run automatically. Under <code>allow_listed</code>, Harper still asks for approval when a command declares network access, or when it declares writes outside the configured sandbox writable roots, even if the command itself is allowlisted. Execution strategy controls whether Harper prefers strict direct grounded execution, deterministic-first grounding with model synthesis, tool-assisted behavior, or no deterministic shortcuts. Sandbox profiles control whether command execution is unsandboxed, sandboxed to the workspace, or sandboxed with workspace access plus network enabled.</p>
                 <p><code>header_widgets</code> controls which status items appear in the chat header. In <code>Settings -&gt; Execution Policy</code>, Harper now lets you edit that field in two ways at once: a checklist for toggling visible widgets and a synchronized comma-separated text field that shows exactly what will be written back to <code>config/local.toml</code>. Supported values are: <code>session</code>, <code>plan</code>, <code>agents</code>, <code>web</code>, <code>auth</code>, <code>focus</code>, <code>model</code>, <code>cwd</code>, <code>strategy</code>, <code>approval</code>, and <code>activity</code>. Keep only the fields you actually want visible.</p>
                 <p>The same screen also lets you edit <code>allowed_commands</code> and <code>blocked_commands</code> directly as comma-separated lists, so you do not have to hand-edit the local config for simple policy changes.</p>
                 <p><code>retry_max_attempts</code> controls bounded automatic retries for retry-safe commands. Network retries and write retries are still gated by command class and declared command intent.</p>
@@ -126,7 +127,7 @@ writable_dirs = ["./tmp", "./build"]</code></pre>
                 <p>Saving the profile updates <code>config/local.toml</code> and also applies to future commands in the current TUI session.</p>
 
                 <h2>Repo-aware routing</h2>
-                <p>Harper now uses a model-first grounded path for normal repo work. High-confidence intents still have deterministic grounding and fallback, but repo questions are no longer described as deterministic-only final answers.</p>
+                <p>Harper now uses an explicit control path for repo-aware work. <code>deterministic</code> prefers direct grounded tool execution for supported intents, <code>grounded</code> prefers deterministic grounding first for routable repo questions and then allows model synthesis when needed, <code>auto</code> remains tool-assisted, and <code>model</code> disables deterministic shortcuts.</p>
                 <ul>
                     <li><code>which branch am i on</code> → git branch lookup</li>
                     <li><code>which repo are we working on</code> → repo identity lookup</li>
@@ -135,7 +136,18 @@ writable_dirs = ["./tmp", "./build"]</code></pre>
                     <li><code>tell me the codebase</code> → structured workspace overview</li>
                     <li><code>create hello.rs with ...</code> → direct file creation/write flow</li>
                 </ul>
-                <p>For open-ended repo questions, Harper feeds the model grounded codebase and authoring context first, then validates tool use against runtime constraints. Deterministic summaries stay as fallback only when the model returns an empty, low-value, or invalid answer.</p>
+                <p>For open-ended repo questions, Harper still uses grounded codebase and authoring context before letting the model answer. Deterministic search and summaries remain available as the primary path in <code>deterministic</code>, and as fallback or explicit grounding in the other strategies. If the model backend is unavailable and there is no deterministic fallback, Harper now returns a clear assistant reply instead of a raw API error.</p>
+
+                <h2>Shell-first verification</h2>
+                <p>Before opening the TUI for routing or command-behavior checks, use the batch harness:</p>
+                <div class="code-wrapper">
+                    <pre><code>target/debug/harper-batch --strategy deterministic --prompt "where is execution strategy used in this repo"
+target/debug/harper-batch --strategy deterministic --prompt "run the git status" --prompt "run that"
+target/debug/harper-batch --strategy grounded --prompt "where is execution strategy used in this repo"
+target/debug/harper-batch --strategy auto --prompt "run the git status" --prompt "run that"</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <p>The shell output reports the selected strategy, task mode, routed deterministic intent, normalized command when one exists, runtime activity, and the final assistant reply. Use that to confirm routing and normalization first; then use the TUI only to confirm UI surfaces such as the loop panel, command-output panel, help modal, and slash completion list.</p>
 
                 <h2>File references and Tab completion</h2>
                 <p>Type <code>@</code> in the chat input to start a file or directory reference. Press <code>Tab</code> to autocomplete matching paths and keep pressing <code>Tab</code> to cycle through candidates.</p>

--- a/website/nav-updates.js
+++ b/website/nav-updates.js
@@ -1,5 +1,11 @@
 const STORAGE_PREFIX = "harper.site.seen.";
 
+function isAtPageBottom() {
+    const scrollBottom = window.scrollY + window.innerHeight;
+    const threshold = 16;
+    return scrollBottom >= document.documentElement.scrollHeight - threshold;
+}
+
 async function applyNavUpdateIndicators() {
     const currentPath = window.location.pathname.split("/").pop() || "index.html";
     const currentVersion = document
@@ -15,25 +21,53 @@ async function applyNavUpdateIndicators() {
 
     const updates = await response.json();
 
-    if (currentVersion) {
-        localStorage.setItem(`${STORAGE_PREFIX}${currentPath}`, currentVersion);
+    const renderIndicators = () => {
+        document.querySelectorAll(".nav a[data-update-target]").forEach((link) => {
+            const targetHref = link.getAttribute("href");
+            const latestVersion = targetHref ? updates[targetHref] : null;
+            if (!targetHref || !latestVersion) {
+                return;
+            }
+
+            const seenVersion = localStorage.getItem(`${STORAGE_PREFIX}${targetHref}`);
+            const hasUnread = seenVersion !== latestVersion;
+            link.classList.toggle("has-update", hasUnread);
+
+            if (!link.dataset.updateBound) {
+                link.addEventListener("click", () => {
+                    localStorage.setItem(`${STORAGE_PREFIX}${targetHref}`, latestVersion);
+                });
+                link.dataset.updateBound = "true";
+            }
+        });
+    };
+
+    renderIndicators();
+
+    if (!currentVersion) {
+        return;
     }
 
-    document.querySelectorAll(".nav a[data-update-target]").forEach((link) => {
-        const targetHref = link.getAttribute("href");
-        const latestVersion = targetHref ? updates[targetHref] : null;
-        if (!targetHref || !latestVersion) {
-            return;
+    const storageKey = `${STORAGE_PREFIX}${currentPath}`;
+    const markCurrentPageSeen = () => {
+        localStorage.setItem(storageKey, currentVersion);
+        renderIndicators();
+        window.removeEventListener("scroll", handleScroll);
+    };
+
+    const handleScroll = () => {
+        if (isAtPageBottom()) {
+            markCurrentPageSeen();
         }
+    };
 
-        const seenVersion = localStorage.getItem(`${STORAGE_PREFIX}${targetHref}`);
-        const hasUnread = seenVersion !== latestVersion;
-        link.classList.toggle("has-update", hasUnread);
-
-        link.addEventListener("click", () => {
-            localStorage.setItem(`${STORAGE_PREFIX}${targetHref}`, latestVersion);
-        });
-    });
+    if (localStorage.getItem(storageKey) !== currentVersion) {
+        if (isAtPageBottom()) {
+            markCurrentPageSeen();
+        } else {
+            window.addEventListener("scroll", handleScroll, { passive: true });
+        }
+    }
 }
 
 applyNavUpdateIndicators().catch(() => {});

--- a/website/nav-updates.json
+++ b/website/nav-updates.json
@@ -1,10 +1,11 @@
 {
-  "index.html": "2026-04-28-home",
-  "installation.html": "2026-04-28-install-v6",
+  "index.html": "2026-05-01-home-v2",
+  "docs.html": "2026-05-01-docs-v1",
+  "installation.html": "2026-05-01-install-v7",
   "troubleshooting.html": "2026-04-28-troubleshooting",
-  "blog.html": "2026-04-28-blog-v3",
+  "blog.html": "2026-05-01-blog-v5",
   "changelog.html": "2026-04-28-changelog",
-  "server.html": "2026-04-28-server-v6",
+  "server.html": "2026-05-01-server-v7",
   "terms.html": "2026-04-28-terms",
   "privacy.html": "2026-04-28-privacy"
 }

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -15,6 +15,7 @@
             <nav class="nav">
                 <a href="index.html" data-update-target="home">Home</a>
                 <a href="installation.html" data-update-target="install">Install</a>
+                <a href="docs.html" data-update-target="docs">Docs</a>
                 <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
                 <a href="blog.html" data-update-target="blog">Blog</a>
                 <a href="changelog.html" data-update-target="changelog">Changelog</a>

--- a/website/server.html
+++ b/website/server.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · API Server</title>
-    <meta name="harper-update-version" content="2026-04-28-server-v6" />
+    <meta name="harper-update-version" content="2026-05-01-server-v7" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -15,6 +15,7 @@
             <nav class="nav">
                 <a href="index.html" data-update-target="home">Home</a>
                 <a href="installation.html" data-update-target="install">Install</a>
+                <a href="docs.html" data-update-target="docs">Docs</a>
                 <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
                 <a href="blog.html" data-update-target="blog">Blog</a>
                 <a href="changelog.html" data-update-target="changelog">Changelog</a>
@@ -70,14 +71,15 @@ writable_dirs = ["./tmp", "./build"]</code></pre>
                 <p><code>allowed_dirs</code> are readable roots. <code>writable_dirs</code> are writable roots. This lets you keep most of the workspace readable while only allowing writes in specific subpaths.</p>
 
                 <h2>Deterministic repo routes</h2>
-                <p>Harper now uses a model-first grounded strategy for repo work:</p>
+                <p>Harper now uses an explicit control path for repo work:</p>
                 <ul>
-                    <li>Structured codebase and authoring helpers gather grounded context.</li>
-                    <li>The model reasons on top of that context for agentic repo questions.</li>
-                    <li>Deterministic routing and summaries remain available as fallback or explicit strategy choices.</li>
+                    <li><code>deterministic</code> prefers direct grounded tool execution for supported intents.</li>
+                    <li><code>grounded</code> prefers deterministic grounding first for routable repo questions, then allows model synthesis when needed.</li>
+                    <li><code>auto</code> remains tool-assisted and can still degrade to deterministic fallback for supported prompts.</li>
+                    <li><code>model</code> disables deterministic shortcuts.</li>
                 </ul>
-                <p>Examples of grounded routes include <code>git status</code>, <code>git diff</code>, repo identity, branch lookup, direct file reads, and simple create/write prompts. Codebase prompts such as <code>find where X is rendered</code> use a structured search helper first, then let the model summarize from that grounded result. Open-ended authoring prompts build authoring context, require plan/inspection before edits, and use deterministic fallback only when the model fails.</p>
-                <p>This keeps the execution path explicit and safe, while avoiding the older failure mode where a weaker local model would answer with generic prose instead of using the repo tools.</p>
+                <p>Examples of grounded routes include <code>git status</code>, <code>git diff</code>, repo identity, branch lookup, direct file reads, command follow-ups such as <code>run that</code>, and simple create/write prompts. Codebase prompts such as <code>where is X used</code>, <code>what calls X</code>, and <code>where is X defined</code> use a structured search helper with intent-aware ranking. Open-ended authoring prompts build authoring context, require plan/inspection before edits, and use deterministic fallback only when the model fails or is unavailable.</p>
+                <p>This keeps the execution path explicit and safe, while avoiding the older failure mode where a weaker local model would answer with generic prose instead of using the repo tools. If the model backend is unavailable and there is no deterministic fallback, Harper now returns a clear assistant reply instead of a raw API error.</p>
 
                 <h2>Run Harper with the server enabled</h2>
                 <p>Start Harper normally after enabling the server in config. If you only want the TUI, disable server startup with the flag below.</p>

--- a/website/terms.html
+++ b/website/terms.html
@@ -15,6 +15,7 @@
             <nav class="nav">
                 <a href="index.html" data-update-target="home">Home</a>
                 <a href="installation.html" data-update-target="install">Install</a>
+                <a href="docs.html" data-update-target="docs">Docs</a>
                 <a href="troubleshooting.html" data-update-target="troubleshooting">Troubleshooting</a>
                 <a href="blog.html" data-update-target="blog">Blog</a>
                 <a href="changelog.html" data-update-target="changelog">Changelog</a>

--- a/website/troubleshooting.html
+++ b/website/troubleshooting.html
@@ -15,6 +15,7 @@
             <nav class="nav">
                 <a href="index.html" data-update-target="home">Home</a>
                 <a href="installation.html" data-update-target="install">Install</a>
+                <a href="docs.html" data-update-target="docs">Docs</a>
                 <a href="troubleshooting.html" data-update-target="troubleshooting" aria-current="page">Troubleshooting</a>
                 <a href="blog.html" data-update-target="blog">Blog</a>
                 <a href="changelog.html" data-update-target="changelog">Changelog</a>


### PR DESCRIPTION
## Changes

- Tightened routing and deterministic follow-up handling in `harper-core`:
  - improved deterministic intent coverage for repo inspection and follow-up command resolution
  - normalized deterministic run-command handling and clarified ambiguous placeholder follow-ups
  - preserved search intent for `used`, `calls`, and `defined` queries
- Improved grounded search and planner/runtime state:
  - added intent-aware search ranking in `codebase_investigator`
  - added explicit planner/runtime loop state and follow-up history
  - added headless routing/debug summaries for shell verification
- Added a shell-first verification path with `harper-batch`:
  - repeated `--prompt` support in one session
  - routing, intent, command normalization, activity, and assistant output visibility
- Updated TUI state and widgets to align with the new loop/runtime behavior.
- Updated validation and dependency policy:
  - refreshed `scripts/validate.sh` with the current repo checks and fixed optional-step accounting
  - switched `jsonwebtoken` off the vulnerable `rsa` backend path
  - allowed `CDLA-Permissive-2.0` in `deny.toml` for current dependency policy
- Updated docs, plans, and website content to match current behavior:
  - documented `harper-batch` and shell-first verification
  - refreshed strategy/routing docs and stale planner files
  - added `website/docs.html`, updated nav links, nav update behavior, and a new blog entry

## Validation

- `bash -n scripts/validate.sh`
- `cargo test -p harper-core infer_followup_run_command_intent_uses_previous_assistant_command -- --nocapture`
- `cargo test -p harper-core search_matches_prefer_call_sites_over_definitions_for_update_plan -- --nocapture`
- `cargo test -p harper-core search_matches_prefer_exact_definition_for_execution_strategy -- --nocapture`
- `cargo test -p harper-core headless_turn_debug -- --nocapture`
- `cargo test -p harper-core route -- --nocapture`
- `cargo check -p harper-core`
- `cargo check -p harper-ui --bin harper-batch`
- `cargo check -p harper-ui`
- `cargo clippy --all-targets --all-features --workspace -- -A clippy::pedantic -D warnings`
- `cargo deny check`
- `target/debug/harper-batch --strategy deterministic --prompt "where is execution strategy used in this repo"`
- `target/debug/harper-batch --strategy deterministic --prompt "run the git status" --prompt "run that"`
- `target/debug/harper-batch --strategy grounded --prompt "where is execution strategy used in this repo"`
- `target/debug/harper-batch --strategy auto --prompt "where is execution strategy used in this repo"`
