### PR TITLE
[chore] fix bazel followups and website copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "harper-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aes",
  "arboard",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "harper-sandbox"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "caps",
  "log",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "harper-ui"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arboard",
  "async-trait",

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "4607d7e51685652eec6c0bb6e3424445468cf6984fd39629309d8da7ed1c9c06",
+  "checksum": "f82f1179a04fa4255d52f7d617f433f201e71dfd9de59eceebb5495dab039b8c",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -2327,6 +2327,205 @@
       ],
       "license_file": "LICENSE"
     },
+    "aws-lc-rs 1.16.2": {
+      "name": "aws-lc-rs",
+      "version": "1.16.2",
+      "package_url": "https://github.com/aws/aws-lc-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/aws-lc-rs/1.16.2/download",
+          "sha256": "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "aws_lc_rs",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "aws_lc_rs",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "alloc",
+            "aws-lc-sys",
+            "default",
+            "ring-io",
+            "ring-sig-verify"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "aws-lc-rs 1.16.2",
+              "target": "build_script_build"
+            },
+            {
+              "id": "aws-lc-sys 0.39.1",
+              "target": "aws_lc_sys"
+            },
+            {
+              "id": "untrusted 0.7.1",
+              "target": "untrusted"
+            },
+            {
+              "id": "zeroize 1.8.2",
+              "target": "zeroize"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "1.16.2"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "link_deps": {
+          "common": [
+            {
+              "id": "aws-lc-sys 0.39.1",
+              "target": "aws_lc_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "links": "aws_lc_rs_1_16_2_sys"
+      },
+      "license": "ISC AND (Apache-2.0 OR ISC)",
+      "license_ids": [
+        "Apache-2.0",
+        "ISC"
+      ],
+      "license_file": "LICENSE"
+    },
+    "aws-lc-sys 0.39.1": {
+      "name": "aws-lc-sys",
+      "version": "0.39.1",
+      "package_url": "https://github.com/aws/aws-lc-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/aws-lc-sys/0.39.1/download",
+          "sha256": "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "aws_lc_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_main",
+            "crate_root": "builder/main.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "aws_lc_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "aws-lc-sys 0.39.1",
+              "target": "build_script_main"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.39.1"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.2.61",
+              "target": "cc"
+            },
+            {
+              "id": "cmake 0.1.58",
+              "target": "cmake"
+            },
+            {
+              "id": "dunce 1.0.5",
+              "target": "dunce"
+            },
+            {
+              "id": "fs_extra 1.3.0",
+              "target": "fs_extra"
+            }
+          ],
+          "selects": {}
+        },
+        "links": "aws_lc_0_39_1"
+      },
+      "license": "ISC AND (Apache-2.0 OR ISC) AND Apache-2.0 AND MIT AND BSD-3-Clause AND (Apache-2.0 OR ISC OR MIT) AND (Apache-2.0 OR ISC OR MIT-0)",
+      "license_ids": [
+        "Apache-2.0",
+        "BSD-3-Clause",
+        "ISC",
+        "MIT",
+        "MIT-0"
+      ],
+      "license_file": "LICENSE"
+    },
     "axum 0.8.9": {
       "name": "axum",
       "version": "0.8.9",
@@ -2578,51 +2777,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "base16ct 0.2.0": {
-      "name": "base16ct",
-      "version": "0.2.0",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/base16ct",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/base16ct/0.2.0/download",
-          "sha256": "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "base16ct",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "base16ct",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc"
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.2.0"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "base64 0.22.1": {
       "name": "base64",
       "version": "0.22.1",
@@ -2664,51 +2818,6 @@
         "version": "0.22.1"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "base64ct 1.8.3": {
-      "name": "base64ct",
-      "version": "1.8.3",
-      "package_url": "https://github.com/RustCrypto/formats",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/base64ct/1.8.3/download",
-          "sha256": "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "base64ct",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "base64ct",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc"
-          ],
-          "selects": {}
-        },
-        "edition": "2024",
-        "version": "1.8.3"
-      },
-      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -3781,6 +3890,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "parallel"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -3788,11 +3903,40 @@
               "target": "find_msvc_tools"
             },
             {
+              "id": "jobserver 0.1.34",
+              "target": "jobserver"
+            },
+            {
               "id": "shlex 1.3.0",
               "target": "shlex"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-apple-darwin": [
+              {
+                "id": "libc 0.2.186",
+                "target": "libc"
+              }
+            ],
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "libc 0.2.186",
+                "target": "libc"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "libc 0.2.186",
+                "target": "libc"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "libc 0.2.186",
+                "target": "libc"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "1.2.61"
@@ -4489,6 +4633,54 @@
       ],
       "license_file": null
     },
+    "cmake 0.1.58": {
+      "name": "cmake",
+      "version": "0.1.58",
+      "package_url": "https://github.com/rust-lang/cmake-rs",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/cmake/0.1.58/download",
+          "sha256": "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "cmake",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "cmake",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.2.61",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.1.58"
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
     "color_quant 1.1.0": {
       "name": "color_quant",
       "version": "1.1.0",
@@ -4819,45 +5011,6 @@
         "version": "0.15.22"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "const-oid 0.9.6": {
-      "name": "const-oid",
-      "version": "0.9.6",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/const-oid",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/const-oid/0.9.6/download",
-          "sha256": "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "const_oid",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "const_oid",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2021",
-        "version": "0.9.6"
-      },
-      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -6091,74 +6244,6 @@
       ],
       "license_file": "LICENSE"
     },
-    "crypto-bigint 0.5.5": {
-      "name": "crypto-bigint",
-      "version": "0.5.5",
-      "package_url": "https://github.com/RustCrypto/crypto-bigint",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/crypto-bigint/0.5.5/download",
-          "sha256": "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "crypto_bigint",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "crypto_bigint",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "generic-array",
-            "rand_core",
-            "zeroize"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "generic-array 0.14.7",
-              "target": "generic_array"
-            },
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.5.5"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "crypto-common 0.1.7": {
       "name": "crypto-common",
       "version": "0.1.7",
@@ -6189,10 +6274,18 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -6298,190 +6391,6 @@
         "version": "0.9.2"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "curve25519-dalek 4.1.3": {
-      "name": "curve25519-dalek",
-      "version": "4.1.3",
-      "package_url": "https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/curve25519-dalek/4.1.3/download",
-          "sha256": "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "curve25519_dalek",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "curve25519_dalek",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "digest",
-            "precomputed-tables",
-            "zeroize"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "cfg-if 1.0.4",
-              "target": "cfg_if"
-            },
-            {
-              "id": "curve25519-dalek 4.1.3",
-              "target": "build_script_build"
-            },
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {
-            "cfg(curve25519_dalek_backend = \"fiat\")": [
-              {
-                "id": "fiat-crypto 0.2.9",
-                "target": "fiat_crypto"
-              }
-            ],
-            "cfg(target_arch = \"x86_64\")": [
-              {
-                "id": "cpufeatures 0.2.17",
-                "target": "cpufeatures"
-              }
-            ]
-          }
-        },
-        "edition": "2021",
-        "proc_macro_deps": {
-          "common": [],
-          "selects": {
-            "cfg(all(not(curve25519_dalek_backend = \"fiat\"), not(curve25519_dalek_backend = \"serial\"), target_arch = \"x86_64\"))": [
-              {
-                "id": "curve25519-dalek-derive 0.1.1",
-                "target": "curve25519_dalek_derive"
-              }
-            ]
-          }
-        },
-        "version": "4.1.3"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "rustc_version 0.4.1",
-              "target": "rustc_version"
-            }
-          ],
-          "selects": {}
-        }
-      },
-      "license": "BSD-3-Clause",
-      "license_ids": [
-        "BSD-3-Clause"
-      ],
-      "license_file": "LICENSE"
-    },
-    "curve25519-dalek-derive 0.1.1": {
-      "name": "curve25519-dalek-derive",
-      "version": "0.1.1",
-      "package_url": "https://github.com/dalek-cryptography/curve25519-dalek",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/curve25519-dalek-derive/0.1.1/download",
-          "sha256": "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-        }
-      },
-      "targets": [
-        {
-          "ProcMacro": {
-            "crate_name": "curve25519_dalek_derive",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "curve25519_dalek_derive",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "proc-macro2 1.0.106",
-              "target": "proc_macro2"
-            },
-            {
-              "id": "quote 1.0.45",
-              "target": "quote"
-            },
-            {
-              "id": "syn 2.0.117",
-              "target": "syn"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.1.1"
-      },
-      "license": "MIT/Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -6780,72 +6689,6 @@
         "MIT"
       ],
       "license_file": "LICENSE"
-    },
-    "der 0.7.10": {
-      "name": "der",
-      "version": "0.7.10",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/der",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/der/0.7.10/download",
-          "sha256": "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "der",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "der",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "oid",
-            "pem",
-            "std",
-            "zeroize"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "const-oid 0.9.6",
-              "target": "const_oid"
-            },
-            {
-              "id": "pem-rfc7468 0.7.0",
-              "target": "pem_rfc7468"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.10"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
     },
     "deranged 0.5.8": {
       "name": "deranged",
@@ -7148,17 +6991,30 @@
         ],
         "crate_features": {
           "common": [
-            "alloc",
             "block-buffer",
-            "const-oid",
             "core-api",
-            "default",
-            "mac",
-            "oid",
-            "std",
-            "subtle"
+            "default"
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "alloc",
+              "mac",
+              "std",
+              "subtle"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "alloc",
+              "mac",
+              "std",
+              "subtle"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "alloc",
+              "mac",
+              "std",
+              "subtle"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -7167,19 +7023,30 @@
               "target": "block_buffer"
             },
             {
-              "id": "const-oid 0.9.6",
-              "target": "const_oid"
-            },
-            {
               "id": "crypto-common 0.1.7",
               "target": "crypto_common"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
             }
           ],
-          "selects": {}
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "subtle 2.6.1",
+                "target": "subtle"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "subtle 2.6.1",
+                "target": "subtle"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "subtle 2.6.1",
+                "target": "subtle"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.10.7"
@@ -7557,20 +7424,20 @@
       ],
       "license_file": "LICENSE"
     },
-    "ecdsa 0.16.9": {
-      "name": "ecdsa",
-      "version": "0.16.9",
-      "package_url": "https://github.com/RustCrypto/signatures/tree/master/ecdsa",
+    "dunce 1.0.5": {
+      "name": "dunce",
+      "version": "1.0.5",
+      "package_url": "https://gitlab.com/kornelski/dunce",
       "repository": {
         "Http": {
-          "url": "https://static.crates.io/crates/ecdsa/0.16.9/download",
-          "sha256": "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+          "url": "https://static.crates.io/crates/dunce/1.0.5/download",
+          "sha256": "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
         }
       },
       "targets": [
         {
           "Library": {
-            "crate_name": "ecdsa",
+            "crate_name": "dunce",
             "crate_root": "src/lib.rs",
             "srcs": {
               "allow_empty": true,
@@ -7581,198 +7448,19 @@
           }
         }
       ],
-      "library_target_name": "ecdsa",
+      "library_target_name": "dunce",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "arithmetic",
-            "der",
-            "digest",
-            "hazmat",
-            "pem",
-            "pkcs8",
-            "rfc6979",
-            "signing",
-            "spki",
-            "std",
-            "verifying"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "der 0.7.10",
-              "target": "der"
-            },
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "elliptic-curve 0.13.8",
-              "target": "elliptic_curve"
-            },
-            {
-              "id": "rfc6979 0.4.0",
-              "target": "rfc6979"
-            },
-            {
-              "id": "signature 2.2.0",
-              "target": "signature"
-            },
-            {
-              "id": "spki 0.7.3",
-              "target": "spki"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2021",
-        "version": "0.16.9"
+        "version": "1.0.5"
       },
-      "license": "Apache-2.0 OR MIT",
+      "license": "CC0-1.0 OR MIT-0 OR Apache-2.0",
       "license_ids": [
         "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "ed25519 2.2.3": {
-      "name": "ed25519",
-      "version": "2.2.3",
-      "package_url": "https://github.com/RustCrypto/signatures/tree/master/ed25519",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ed25519/2.2.3/download",
-          "sha256": "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ed25519",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ed25519",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "pkcs8",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "pkcs8 0.10.2",
-              "target": "pkcs8"
-            },
-            {
-              "id": "signature 2.2.0",
-              "target": "signature"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.2.3"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "ed25519-dalek 2.2.0": {
-      "name": "ed25519-dalek",
-      "version": "2.2.0",
-      "package_url": "https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ed25519-dalek/2.2.0/download",
-          "sha256": "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ed25519_dalek",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ed25519_dalek",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "fast",
-            "pkcs8",
-            "std",
-            "zeroize"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "curve25519-dalek 4.1.3",
-              "target": "curve25519_dalek"
-            },
-            {
-              "id": "ed25519 2.2.3",
-              "target": "ed25519"
-            },
-            {
-              "id": "sha2 0.10.9",
-              "target": "sha2"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "2.2.0"
-      },
-      "license": "BSD-3-Clause",
-      "license_ids": [
-        "BSD-3-Clause"
+        "CC0-1.0",
+        "MIT-0"
       ],
       "license_file": "LICENSE"
     },
@@ -7816,118 +7504,6 @@
         "version": "1.15.0"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "elliptic-curve 0.13.8": {
-      "name": "elliptic-curve",
-      "version": "0.13.8",
-      "package_url": "https://github.com/RustCrypto/traits/tree/master/elliptic-curve",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/elliptic-curve/0.13.8/download",
-          "sha256": "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "elliptic_curve",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "elliptic_curve",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "arithmetic",
-            "digest",
-            "ecdh",
-            "ff",
-            "group",
-            "hazmat",
-            "pem",
-            "pkcs8",
-            "sec1",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "base16ct 0.2.0",
-              "target": "base16ct"
-            },
-            {
-              "id": "crypto-bigint 0.5.5",
-              "target": "crypto_bigint"
-            },
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "ff 0.13.1",
-              "target": "ff"
-            },
-            {
-              "id": "generic-array 0.14.7",
-              "target": "generic_array"
-            },
-            {
-              "id": "group 0.13.0",
-              "target": "group"
-            },
-            {
-              "id": "hkdf 0.12.4",
-              "target": "hkdf"
-            },
-            {
-              "id": "pem-rfc7468 0.7.0",
-              "target": "pem_rfc7468"
-            },
-            {
-              "id": "pkcs8 0.10.2",
-              "target": "pkcs8"
-            },
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            },
-            {
-              "id": "sec1 0.7.3",
-              "target": "sec1"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.8"
-      },
-      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -9228,104 +8804,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "ff 0.13.1": {
-      "name": "ff",
-      "version": "0.13.1",
-      "package_url": "https://github.com/zkcrypto/ff",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/ff/0.13.1/download",
-          "sha256": "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "ff",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "ff",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.1"
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "fiat-crypto 0.2.9": {
-      "name": "fiat-crypto",
-      "version": "0.2.9",
-      "package_url": "https://github.com/mit-plv/fiat-crypto",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/fiat-crypto/0.2.9/download",
-          "sha256": "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "fiat_crypto",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "fiat_crypto",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "edition": "2018",
-        "version": "0.2.9"
-      },
-      "license": "MIT OR Apache-2.0 OR BSD-1-Clause",
-      "license_ids": [
-        "Apache-2.0",
-        "BSD-1-Clause",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "filedescriptor 0.8.3": {
       "name": "filedescriptor",
       "version": "0.8.3",
@@ -9882,6 +9360,44 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "fs_extra 1.3.0": {
+      "name": "fs_extra",
+      "version": "1.3.0",
+      "package_url": "https://github.com/webdesus/fs_extra",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/fs_extra/1.3.0/download",
+          "sha256": "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "fs_extra",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "fs_extra",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "1.3.0"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE"
     },
     "futures 0.3.32": {
       "name": "futures",
@@ -10616,8 +10132,7 @@
         ],
         "crate_features": {
           "common": [
-            "more_lengths",
-            "zeroize"
+            "more_lengths"
           ],
           "selects": {}
         },
@@ -10630,10 +10145,6 @@
             {
               "id": "typenum 1.20.0",
               "target": "typenum"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
             }
           ],
           "selects": {}
@@ -10752,10 +10263,18 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -10830,6 +10349,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -11133,68 +10658,6 @@
         "version": "0.14.2"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "group 0.13.0": {
-      "name": "group",
-      "version": "0.13.0",
-      "package_url": "https://github.com/zkcrypto/group",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/group/0.13.0/download",
-          "sha256": "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "group",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "group",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ff 0.13.1",
-              "target": "ff"
-            },
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.0"
-      },
-      "license": "MIT/Apache-2.0",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -12596,12 +12059,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "reset"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -15696,16 +15153,10 @@
         ],
         "crate_features": {
           "common": [
+            "aws-lc-rs",
+            "aws_lc_rs",
             "default",
-            "ed25519-dalek",
-            "hmac",
-            "p256",
-            "p384",
             "pem",
-            "rand",
-            "rsa",
-            "rust_crypto",
-            "sha2",
             "simple_asn1",
             "use_pem"
           ],
@@ -15714,36 +15165,16 @@
         "deps": {
           "common": [
             {
+              "id": "aws-lc-rs 1.16.2",
+              "target": "aws_lc_rs"
+            },
+            {
               "id": "base64 0.22.1",
               "target": "base64"
             },
             {
-              "id": "ed25519-dalek 2.2.0",
-              "target": "ed25519_dalek"
-            },
-            {
-              "id": "hmac 0.12.1",
-              "target": "hmac"
-            },
-            {
-              "id": "p256 0.13.2",
-              "target": "p256"
-            },
-            {
-              "id": "p384 0.13.1",
-              "target": "p384"
-            },
-            {
               "id": "pem 3.0.6",
               "target": "pem"
-            },
-            {
-              "id": "rand 0.8.6",
-              "target": "rand"
-            },
-            {
-              "id": "rsa 0.9.10",
-              "target": "rsa"
             },
             {
               "id": "serde 1.0.228",
@@ -15752,10 +15183,6 @@
             {
               "id": "serde_json 1.0.149",
               "target": "serde_json"
-            },
-            {
-              "id": "sha2 0.10.9",
-              "target": "sha2"
             },
             {
               "id": "signature 2.2.0",
@@ -16037,22 +15464,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "spin",
-            "spin_no_std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "spin 0.9.8",
-              "target": "spin"
-            }
-          ],
-          "selects": {}
-        },
         "edition": "2015",
         "version": "1.5.0"
       },
@@ -16315,83 +15726,6 @@
         "NCSA"
       ],
       "license_file": "LICENSE-APACHE"
-    },
-    "libm 0.2.16": {
-      "name": "libm",
-      "version": "0.2.16",
-      "package_url": "https://github.com/rust-lang/compiler-builtins",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/libm/0.2.16/download",
-          "sha256": "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "libm",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "libm",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "arch",
-            "default"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "libm 0.2.16",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.2.16"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE.txt"
     },
     "libredox 0.1.16": {
       "name": "libredox",
@@ -18713,119 +18047,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "num-bigint-dig 0.8.6": {
-      "name": "num-bigint-dig",
-      "version": "0.8.6",
-      "package_url": "https://github.com/dignifiedquire/num-bigint",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/num-bigint-dig/0.8.6/download",
-          "sha256": "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "num_bigint_dig",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "num_bigint_dig",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "i128",
-            "prime",
-            "rand",
-            "u64_digit",
-            "zeroize"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "lazy_static 1.5.0",
-              "target": "lazy_static"
-            },
-            {
-              "id": "libm 0.2.16",
-              "target": "libm"
-            },
-            {
-              "id": "num-bigint-dig 0.8.6",
-              "target": "build_script_build"
-            },
-            {
-              "id": "num-integer 0.1.46",
-              "target": "num_integer"
-            },
-            {
-              "id": "num-iter 0.1.45",
-              "target": "num_iter"
-            },
-            {
-              "id": "num-traits 0.2.19",
-              "target": "num_traits"
-            },
-            {
-              "id": "rand 0.8.6",
-              "target": "rand"
-            },
-            {
-              "id": "smallvec 1.15.1",
-              "target": "smallvec"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.8.6"
-      },
-      "build_script_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "compile_data_glob_excludes": [
-          "**/*.rs"
-        ],
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "MIT/Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "num-complex 0.4.6": {
       "name": "num-complex",
       "version": "0.4.6",
@@ -19060,21 +18281,11 @@
           "**"
         ],
         "crate_features": {
-          "common": [],
-          "selects": {
-            "aarch64-unknown-linux-gnu": [
-              "i128",
-              "std"
-            ],
-            "x86_64-unknown-linux-gnu": [
-              "i128",
-              "std"
-            ],
-            "x86_64-unknown-nixos-gnu": [
-              "i128",
-              "std"
-            ]
-          }
+          "common": [
+            "i128",
+            "std"
+          ],
+          "selects": {}
         },
         "deps": {
           "common": [
@@ -19218,17 +18429,12 @@
           "common": [
             "default",
             "i128",
-            "libm",
             "std"
           ],
           "selects": {}
         },
         "deps": {
           "common": [
-            {
-              "id": "libm 0.2.16",
-              "target": "libm"
-            },
             {
               "id": "num-traits 0.2.19",
               "target": "build_script_build"
@@ -20580,161 +19786,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "p256 0.13.2": {
-      "name": "p256",
-      "version": "0.13.2",
-      "package_url": "https://github.com/RustCrypto/elliptic-curves/tree/master/p256",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/p256/0.13.2/download",
-          "sha256": "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "p256",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "p256",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "arithmetic",
-            "default",
-            "digest",
-            "ecdsa",
-            "ecdsa-core",
-            "pem",
-            "pkcs8",
-            "sha2",
-            "sha256",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ecdsa 0.16.9",
-              "target": "ecdsa",
-              "alias": "ecdsa_core"
-            },
-            {
-              "id": "elliptic-curve 0.13.8",
-              "target": "elliptic_curve"
-            },
-            {
-              "id": "primeorder 0.13.6",
-              "target": "primeorder"
-            },
-            {
-              "id": "sha2 0.10.9",
-              "target": "sha2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.2"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "p384 0.13.1": {
-      "name": "p384",
-      "version": "0.13.1",
-      "package_url": "https://github.com/RustCrypto/elliptic-curves/tree/master/p384",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/p384/0.13.1/download",
-          "sha256": "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "p384",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "p384",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "arithmetic",
-            "default",
-            "digest",
-            "ecdh",
-            "ecdsa",
-            "ecdsa-core",
-            "pem",
-            "pkcs8",
-            "sha2",
-            "sha384",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "ecdsa 0.16.9",
-              "target": "ecdsa",
-              "alias": "ecdsa_core"
-            },
-            {
-              "id": "elliptic-curve 0.13.8",
-              "target": "elliptic_curve"
-            },
-            {
-              "id": "primeorder 0.13.6",
-              "target": "primeorder"
-            },
-            {
-              "id": "sha2 0.10.9",
-              "target": "sha2"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.1"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "parking 2.2.1": {
       "name": "parking",
       "version": "2.2.1",
@@ -21132,60 +20183,6 @@
         "MIT"
       ],
       "license_file": "LICENSE.md"
-    },
-    "pem-rfc7468 0.7.0": {
-      "name": "pem-rfc7468",
-      "version": "0.7.0",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/pem-rfc7468",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pem-rfc7468/0.7.0/download",
-          "sha256": "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pem_rfc7468",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "pem_rfc7468",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "base64ct 1.8.3",
-              "target": "base64ct"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.0"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
     },
     "percent-encoding 2.3.2": {
       "name": "percent-encoding",
@@ -21833,132 +20830,6 @@
         "version": "0.2.5"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "pkcs1 0.7.5": {
-      "name": "pkcs1",
-      "version": "0.7.5",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/pkcs1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pkcs1/0.7.5/download",
-          "sha256": "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pkcs1",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "pkcs1",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "pem",
-            "pkcs8",
-            "std",
-            "zeroize"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "der 0.7.10",
-              "target": "der"
-            },
-            {
-              "id": "pkcs8 0.10.2",
-              "target": "pkcs8"
-            },
-            {
-              "id": "spki 0.7.3",
-              "target": "spki"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.5"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "pkcs8 0.10.2": {
-      "name": "pkcs8",
-      "version": "0.10.2",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/pkcs8",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/pkcs8/0.10.2/download",
-          "sha256": "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "pkcs8",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "pkcs8",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "pem",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "der 0.7.10",
-              "target": "der"
-            },
-            {
-              "id": "spki 0.7.3",
-              "target": "spki"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.10.2"
-      },
-      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -22955,54 +21826,6 @@
         "links": "prettyplease02"
       },
       "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "primeorder 0.13.6": {
-      "name": "primeorder",
-      "version": "0.13.6",
-      "package_url": "https://github.com/RustCrypto/elliptic-curves/tree/master/primeorder",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/primeorder/0.13.6/download",
-          "sha256": "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "primeorder",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "primeorder",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "elliptic-curve 0.13.8",
-              "target": "elliptic_curve"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.13.6"
-      },
-      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -24034,68 +22857,74 @@
         ],
         "crate_features": {
           "common": [
-            "alloc",
-            "getrandom",
-            "libc",
-            "rand_chacha",
-            "std",
-            "std_rng"
+            "small_rng"
           ],
           "selects": {
-            "aarch64-apple-darwin": [
-              "small_rng"
-            ],
             "aarch64-unknown-linux-gnu": [
+              "alloc",
               "default",
-              "small_rng"
-            ],
-            "x86_64-pc-windows-msvc": [
-              "small_rng"
+              "getrandom",
+              "libc",
+              "rand_chacha",
+              "std",
+              "std_rng"
             ],
             "x86_64-unknown-linux-gnu": [
+              "alloc",
               "default",
-              "small_rng"
+              "getrandom",
+              "libc",
+              "rand_chacha",
+              "std",
+              "std_rng"
             ],
             "x86_64-unknown-nixos-gnu": [
+              "alloc",
               "default",
-              "small_rng"
+              "getrandom",
+              "libc",
+              "rand_chacha",
+              "std",
+              "std_rng"
             ]
           }
         },
         "deps": {
           "common": [
             {
-              "id": "rand_chacha 0.3.1",
-              "target": "rand_chacha"
-            },
-            {
               "id": "rand_core 0.6.4",
               "target": "rand_core"
             }
           ],
           "selects": {
-            "aarch64-apple-darwin": [
-              {
-                "id": "libc 0.2.186",
-                "target": "libc"
-              }
-            ],
             "aarch64-unknown-linux-gnu": [
               {
                 "id": "libc 0.2.186",
                 "target": "libc"
+              },
+              {
+                "id": "rand_chacha 0.3.1",
+                "target": "rand_chacha"
               }
             ],
             "x86_64-unknown-linux-gnu": [
               {
                 "id": "libc 0.2.186",
                 "target": "libc"
+              },
+              {
+                "id": "rand_chacha 0.3.1",
+                "target": "rand_chacha"
               }
             ],
             "x86_64-unknown-nixos-gnu": [
               {
                 "id": "libc 0.2.186",
                 "target": "libc"
+              },
+              {
+                "id": "rand_chacha 0.3.1",
+                "target": "rand_chacha"
               }
             ]
           }
@@ -24365,21 +23194,47 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "alloc",
-            "getrandom",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "alloc",
+              "getrandom",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "alloc",
+              "getrandom",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "alloc",
+              "getrandom",
+              "std"
+            ]
+          }
         },
         "deps": {
-          "common": [
-            {
-              "id": "getrandom 0.2.17",
-              "target": "getrandom"
-            }
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              {
+                "id": "getrandom 0.2.17",
+                "target": "getrandom"
+              }
+            ],
+            "x86_64-unknown-linux-gnu": [
+              {
+                "id": "getrandom 0.2.17",
+                "target": "getrandom"
+              }
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              {
+                "id": "getrandom 0.2.17",
+                "target": "getrandom"
+              }
+            ]
+          }
         },
         "edition": "2018",
         "version": "0.6.4"
@@ -26290,58 +25145,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "rfc6979 0.4.0": {
-      "name": "rfc6979",
-      "version": "0.4.0",
-      "package_url": "https://github.com/RustCrypto/signatures/tree/master/rfc6979",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rfc6979/0.4.0/download",
-          "sha256": "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "rfc6979",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "rfc6979",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "hmac 0.12.1",
-              "target": "hmac"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.4.0"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "rgb 0.8.53": {
       "name": "rgb",
       "version": "0.8.53",
@@ -26572,108 +25375,6 @@
           "selects": {}
         },
         "version": "0.12.1"
-      },
-      "license": "MIT OR Apache-2.0",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
-    "rsa 0.9.10": {
-      "name": "rsa",
-      "version": "0.9.10",
-      "package_url": "https://github.com/RustCrypto/RSA",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/rsa/0.9.10/download",
-          "sha256": "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "rsa",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "rsa",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "pem",
-            "std",
-            "u64_digit"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "const-oid 0.9.6",
-              "target": "const_oid"
-            },
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "num-bigint-dig 0.8.6",
-              "target": "num_bigint_dig",
-              "alias": "num_bigint"
-            },
-            {
-              "id": "num-integer 0.1.46",
-              "target": "num_integer"
-            },
-            {
-              "id": "num-traits 0.2.19",
-              "target": "num_traits"
-            },
-            {
-              "id": "pkcs1 0.7.5",
-              "target": "pkcs1"
-            },
-            {
-              "id": "pkcs8 0.10.2",
-              "target": "pkcs8"
-            },
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            },
-            {
-              "id": "signature 2.2.0",
-              "target": "signature"
-            },
-            {
-              "id": "spki 0.7.3",
-              "target": "spki"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.9.10"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -27895,88 +26596,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "sec1 0.7.3": {
-      "name": "sec1",
-      "version": "0.7.3",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/sec1",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/sec1/0.7.3/download",
-          "sha256": "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "sec1",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "sec1",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "default",
-            "der",
-            "pem",
-            "pkcs8",
-            "point",
-            "std",
-            "subtle",
-            "zeroize"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "base16ct 0.2.0",
-              "target": "base16ct"
-            },
-            {
-              "id": "der 0.7.10",
-              "target": "der"
-            },
-            {
-              "id": "generic-array 0.14.7",
-              "target": "generic_array"
-            },
-            {
-              "id": "pkcs8 0.10.2",
-              "target": "pkcs8"
-            },
-            {
-              "id": "subtle 2.6.1",
-              "target": "subtle"
-            },
-            {
-              "id": "zeroize 1.8.2",
-              "target": "zeroize"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.3"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "secret-service 3.1.0": {
       "name": "secret-service",
       "version": "3.1.0",
@@ -29066,12 +27685,21 @@
           "**"
         ],
         "crate_features": {
-          "common": [
-            "default",
-            "oid",
-            "std"
-          ],
-          "selects": {}
+          "common": [],
+          "selects": {
+            "aarch64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-linux-gnu": [
+              "default",
+              "std"
+            ],
+            "x86_64-unknown-nixos-gnu": [
+              "default",
+              "std"
+            ]
+          }
         },
         "deps": {
           "common": [
@@ -29384,22 +28012,7 @@
         "crate_features": {
           "common": [
             "alloc",
-            "digest",
-            "rand_core",
             "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "digest 0.10.7",
-              "target": "digest"
-            },
-            {
-              "id": "rand_core 0.6.4",
-              "target": "rand_core"
-            }
           ],
           "selects": {}
         },
@@ -29843,106 +28456,6 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "spin 0.9.8": {
-      "name": "spin",
-      "version": "0.9.8",
-      "package_url": "https://github.com/mvdnes/spin-rs.git",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/spin/0.9.8/download",
-          "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "spin",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "spin",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "once"
-          ],
-          "selects": {}
-        },
-        "edition": "2015",
-        "version": "0.9.8"
-      },
-      "license": "MIT",
-      "license_ids": [
-        "MIT"
-      ],
-      "license_file": "LICENSE"
-    },
-    "spki 0.7.3": {
-      "name": "spki",
-      "version": "0.7.3",
-      "package_url": "https://github.com/RustCrypto/formats/tree/master/spki",
-      "repository": {
-        "Http": {
-          "url": "https://static.crates.io/crates/spki/0.7.3/download",
-          "sha256": "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "spki",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "allow_empty": true,
-              "include": [
-                "**/*.rs"
-              ]
-            }
-          }
-        }
-      ],
-      "library_target_name": "spki",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "alloc",
-            "pem",
-            "std"
-          ],
-          "selects": {}
-        },
-        "deps": {
-          "common": [
-            {
-              "id": "der 0.7.10",
-              "target": "der"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2021",
-        "version": "0.7.3"
-      },
-      "license": "Apache-2.0 OR MIT",
-      "license_ids": [
-        "Apache-2.0",
-        "MIT"
-      ],
-      "license_file": "LICENSE-APACHE"
-    },
     "stable_deref_trait 1.2.1": {
       "name": "stable_deref_trait",
       "version": "1.2.1",
@@ -30202,12 +28715,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "i128"
-          ],
-          "selects": {}
-        },
         "edition": "2018",
         "version": "2.6.1"
       },
@@ -34104,6 +32611,44 @@
         "MIT"
       ],
       "license_file": "LICENSE-APACHE"
+    },
+    "untrusted 0.7.1": {
+      "name": "untrusted",
+      "version": "0.7.1",
+      "package_url": "https://github.com/briansmith/untrusted",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/untrusted/0.7.1/download",
+          "sha256": "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "untrusted",
+            "crate_root": "src/untrusted.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "untrusted",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "version": "0.7.1"
+      },
+      "license": "ISC",
+      "license_ids": [
+        "ISC"
+      ],
+      "license_file": "LICENSE.txt"
     },
     "untrusted 0.9.0": {
       "name": "untrusted",
@@ -41533,11 +40078,6 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
     ],
-    "cfg(all(not(curve25519_dalek_backend = \"fiat\"), not(curve25519_dalek_backend = \"serial\"), target_arch = \"x86_64\"))": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
-    ],
     "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", any(target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"), all(target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"powerpc64\", target_arch = \"riscv64\", target_arch = \"mips\", target_arch = \"mips64\")))))": [
       "aarch64-unknown-linux-gnu",
       "x86_64-unknown-linux-gnu",
@@ -41662,7 +40202,6 @@
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-nixos-gnu"
     ],
-    "cfg(curve25519_dalek_backend = \"fiat\")": [],
     "cfg(fuzzing)": [],
     "cfg(not(all(target_arch = \"wasm32\", any(target_os = \"unknown\", target_os = \"none\"))))": [
       "aarch64-apple-darwin",
@@ -41706,11 +40245,6 @@
     "cfg(target_arch = \"wasm32\")": [
       "wasm32-unknown-unknown",
       "wasm32-wasip1"
-    ],
-    "cfg(target_arch = \"x86_64\")": [
-      "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu",
-      "x86_64-unknown-nixos-gnu"
     ],
     "cfg(target_os = \"android\")": [],
     "cfg(target_os = \"haiku\")": [],

--- a/lib/harper-core/src/tools/codebase_investigator.rs
+++ b/lib/harper-core/src/tools/codebase_investigator.rs
@@ -2440,8 +2440,7 @@ mod tests {
 
     use super::{
         authoring_search_query, build_semantic_graph, build_workspace_definition_index,
-        classify_member_role, collect_search_matches, collect_search_matches_with_intent,
-        extract_rust_semantic_file, format_search_match, format_workspace_graph,
+        classify_member_role, extract_rust_semantic_file, format_workspace_graph,
         infer_edit_plan_candidates, infer_query_focus, is_searchable_file, path_relative_to_root,
         resolve_symbol_candidates, rust_module_path, search_line_score, search_symbol_variants,
         workspace_member_for_path, QueryFocus, RustSemanticFile, SearchIntentKind, SearchMatch,
@@ -2883,30 +2882,46 @@ struct Planner;
 
     #[test]
     fn search_matches_prefer_symbol_usage_over_license_comment_noise() {
-        let matches = collect_search_matches("execution strategy").unwrap();
-        let top = matches.first().expect("at least one search match");
-        let rendered = format_search_match(top);
+        let terms = vec!["execution".to_string(), "strategy".to_string()];
+        let symbol_variants = search_symbol_variants(&terms);
+        let symbol_score = search_line_score(
+            "settings::execution_strategy_name(app.execution_strategy)",
+            &terms,
+            &symbol_variants,
+            SearchIntentKind::General,
+        )
+        .expect("symbol usage score");
+        let license_score = search_line_score(
+            "// execution strategy overview and notes",
+            &terms,
+            &symbol_variants,
+            SearchIntentKind::General,
+        )
+        .expect("comment line score");
 
-        assert!(
-            !rendered.contains("Licensed under")
-                && !rendered.contains("http://www.apache.org/licenses")
-        );
-        assert!(rendered.contains("ExecutionStrategy") || rendered.contains("execution_strategy"));
+        assert!(symbol_score > license_score);
     }
 
     #[test]
     fn search_matches_prefer_real_usage_sites_over_imports_for_execution_strategy() {
-        let matches =
-            collect_search_matches_with_intent("execution strategy", SearchIntentKind::Used)
-                .unwrap();
-        let top = matches.first().expect("at least one search match");
-        let top_snippet = top.snippets.first().expect("at least one top snippet");
+        let terms = vec!["execution".to_string(), "strategy".to_string()];
+        let symbol_variants = search_symbol_variants(&terms);
+        let usage_score = search_line_score(
+            "settings::execution_strategy_name(app.execution_strategy)",
+            &terms,
+            &symbol_variants,
+            SearchIntentKind::Used,
+        )
+        .expect("usage score");
+        let import_score = search_line_score(
+            "use harper_core::ExecutionStrategy;",
+            &terms,
+            &symbol_variants,
+            SearchIntentKind::Used,
+        )
+        .expect("import score");
 
-        assert!(
-            top_snippet.contains("execution_strategy") || top_snippet.contains("ExecutionStrategy")
-        );
-        assert!(!top_snippet.trim_start().starts_with("38: use "));
-        assert!(!top.path.contains("codebase_investigator.rs"));
+        assert!(usage_score > import_score);
     }
 
     #[test]

--- a/lib/harper-ui/BUILD
+++ b/lib/harper-ui/BUILD
@@ -47,5 +47,8 @@ rust_binary(
         ":harper_ui",
         "//lib/harper-core:harper_core",
     ] + all_crate_deps(normal = True),
+    proc_macro_deps = [
+        "@crates//:async-trait",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/website/docs.html
+++ b/website/docs.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Harper · Docs</title>
-    <meta name="harper-update-version" content="2026-05-01-docs-v1" />
+    <title>Docs</title>
+    <meta name="harper-update-version" content="2026-05-01-docs-v2" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -27,7 +27,7 @@
 
         <main class="surface">
             <div class="content-container">
-                <h1 class="hero-title">Harper docs<br/><span>for daily use and debugging.</span></h1>
+                <h1 class="hero-title">Docs<br/><span>for daily use and debugging.</span></h1>
                 <p class="hero-lede">Start with installation and configuration, use the shell-first verification flow for routing checks, then move to the TUI only for UI-specific validation.</p>
 
                 <div class="actions">
@@ -35,30 +35,21 @@
                     <a class="button secondary" href="https://github.com/harpertoken/harper/tree/main/docs/user-guide">Full Docs on GitHub</a>
                 </div>
 
-                <h2>Core guides</h2>
-                <ul>
-                    <li><a href="installation.html">Installation</a> — setup, TUI commands, execution policy, routing, and shell-first verification</li>
-                    <li><a href="server.html">API Server</a> — config, runtime behavior, and integration details</li>
-                    <li><a href="troubleshooting.html">Troubleshooting</a> — common runtime, auth, and shell issues</li>
-                </ul>
+                <h2>Start here</h2>
+                <p>The <a href="installation.html">installation guide</a> is the best entry point for most people. It covers setup, the current slash commands, execution policy, routing behavior, and the shell-first verification flow. If you are running Harper with the local HTTP interface enabled, the <a href="server.html">API Server</a> page explains the runtime model, configuration, and integration details. When something goes wrong in local development, the <a href="troubleshooting.html">troubleshooting guide</a> is the right place to check for auth, shell, and runtime issues.</p>
 
                 <h2>Verification workflow</h2>
-                <p>Use <code>harper-batch</code> before opening the TUI when you need to verify routing, normalization, or follow-up behavior:</p>
+                <p>Use <code>harper-batch</code> before opening the TUI when you need to verify routing, normalization, or follow-up behavior. This keeps the verification path close to the core chat flow and removes UI state from the first debugging step.</p>
                 <div class="code-wrapper">
-                    <pre><code>target/debug/harper-batch --strategy deterministic --prompt "where is execution strategy used in this repo"
-target/debug/harper-batch --strategy deterministic --prompt "run the git status" --prompt "run that"
-target/debug/harper-batch --strategy grounded --prompt "where is execution strategy used in this repo"</code></pre>
+                    <pre><code>cargo run -p harper-ui --bin harper-batch -- --strategy deterministic --prompt "where is execution strategy used in this repo"
+cargo run -p harper-ui --bin harper-batch -- --strategy deterministic --prompt "run the git status" --prompt "run that"
+cargo run -p harper-ui --bin harper-batch -- --strategy grounded --prompt "where is execution strategy used in this repo"</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p>Read these fields first: <code>ROUTING</code>, <code>DETERMINISTIC INTENT</code>, <code>NORMALIZED COMMAND</code>, <code>ACTIVITY</code>, and <code>ASSISTANT</code>.</p>
+                <p>Read <code>ROUTING</code>, <code>DETERMINISTIC INTENT</code>, <code>NORMALIZED COMMAND</code>, <code>ACTIVITY</code>, and <code>ASSISTANT</code> first. Those fields tell you whether Harper chose the right path before you spend time checking the TUI.</p>
 
-                <h2>User guide sections</h2>
-                <ul>
-                    <li><a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/about.md">About Harper</a></li>
-                    <li><a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/chat.md">Chat Interface</a></li>
-                    <li><a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/configuration.md">Configuration</a></li>
-                    <li><a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/quick-start.md">Quick Start</a></li>
-                </ul>
+                <h2>Deeper reading</h2>
+                <p>If you want the longer reference material, the full user guide still lives in the repository. The main pages are <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/about.md">About Harper</a>, <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/chat.md">Chat Interface</a>, <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/configuration.md">Configuration</a>, and <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/quick-start.md">Quick Start</a>. Use this page as the short path through the product, and use the repository docs when you need the full detail.</p>
             </div>
         </main>
 

--- a/website/installation.html
+++ b/website/installation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Installation</title>
-    <meta name="harper-update-version" content="2026-05-01-install-v7" />
+    <meta name="harper-update-version" content="2026-05-01-install-v8" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -141,10 +141,10 @@ writable_dirs = ["./tmp", "./build"]</code></pre>
                 <h2>Shell-first verification</h2>
                 <p>Before opening the TUI for routing or command-behavior checks, use the batch harness:</p>
                 <div class="code-wrapper">
-                    <pre><code>target/debug/harper-batch --strategy deterministic --prompt "where is execution strategy used in this repo"
-target/debug/harper-batch --strategy deterministic --prompt "run the git status" --prompt "run that"
-target/debug/harper-batch --strategy grounded --prompt "where is execution strategy used in this repo"
-target/debug/harper-batch --strategy auto --prompt "run the git status" --prompt "run that"</code></pre>
+                    <pre><code>cargo run -p harper-ui --bin harper-batch -- --strategy deterministic --prompt "where is execution strategy used in this repo"
+cargo run -p harper-ui --bin harper-batch -- --strategy deterministic --prompt "run the git status" --prompt "run that"
+cargo run -p harper-ui --bin harper-batch -- --strategy grounded --prompt "where is execution strategy used in this repo"
+cargo run -p harper-ui --bin harper-batch -- --strategy auto --prompt "run the git status" --prompt "run that"</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <p>The shell output reports the selected strategy, task mode, routed deterministic intent, normalized command when one exists, runtime activity, and the final assistant reply. Use that to confirm routing and normalization first; then use the TUI only to confirm UI surfaces such as the loop panel, command-output panel, help modal, and slash completion list.</p>

--- a/website/nav-updates.json
+++ b/website/nav-updates.json
@@ -1,11 +1,11 @@
 {
   "index.html": "2026-05-01-home-v2",
-  "docs.html": "2026-05-01-docs-v1",
-  "installation.html": "2026-05-01-install-v7",
-  "troubleshooting.html": "2026-04-28-troubleshooting",
+  "docs.html": "2026-05-01-docs-v2",
+  "installation.html": "2026-05-01-install-v8",
+  "troubleshooting.html": "2026-05-01-troubleshooting-v2",
   "blog.html": "2026-05-01-blog-v5",
   "changelog.html": "2026-04-28-changelog",
-  "server.html": "2026-05-01-server-v7",
+  "server.html": "2026-05-01-server-v8",
   "terms.html": "2026-04-28-terms",
   "privacy.html": "2026-04-28-privacy"
 }

--- a/website/server.html
+++ b/website/server.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · API Server</title>
-    <meta name="harper-update-version" content="2026-05-01-server-v7" />
+    <meta name="harper-update-version" content="2026-05-01-server-v8" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -51,7 +51,7 @@ retry_max_attempts = 1
 header_widgets = ["model", "cwd", "strategy"]</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p><code>allow_listed</code> preserves the existing default behavior for safe commands, but Harper still asks for approval when the command declares network access or writes outside the configured writable roots. <code>strict</code> requires approval for every command. <code>allow_all</code> skips approval checks. <code>auto</code> and <code>grounded</code> keep the model in the loop for normal repo work, while <code>deterministic</code> prefers direct grounded tool execution for supported intents and <code>model</code> disables deterministic shortcuts. <code>workspace</code> enables sandboxing with workspace access and network disabled. <code>networked_workspace</code> enables the same workspace sandbox but allows network access.</p>
+                <p><code>allow_listed</code> preserves the existing default behavior for safe commands, but Harper still asks for approval when the command declares network access or writes outside the configured writable roots. <code>strict</code> requires approval for every command. <code>allow_all</code> skips approval checks. <code>deterministic</code> prefers direct grounded tool execution for supported intents, <code>grounded</code> prefers deterministic grounding first for routable repo questions and then allows model synthesis when needed, <code>auto</code> remains tool-assisted and can still fall back to deterministic handling for supported prompts, and <code>model</code> disables deterministic shortcuts. <code>workspace</code> enables sandboxing with workspace access and network disabled. <code>networked_workspace</code> enables the same workspace sandbox but allows network access.</p>
                 <p><code>header_widgets</code> controls the persistent chat header. In <code>Settings -&gt; Execution Policy</code>, Harper now exposes that field as both a checklist and a synchronized comma-separated text field, while saving still writes the selected widgets back to <code>config/local.toml</code>. Supported values are <code>session</code>, <code>plan</code>, <code>agents</code>, <code>web</code>, <code>auth</code>, <code>focus</code>, <code>model</code>, <code>cwd</code>, <code>strategy</code>, <code>approval</code>, and <code>activity</code>.</p>
                 <p><code>retry_max_attempts</code> controls bounded automatic retries for retry-safe commands. You can also tune which command classes qualify:</p>
                 <div class="code-wrapper">

--- a/website/troubleshooting.html
+++ b/website/troubleshooting.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Troubleshooting</title>
-    <meta name="harper-update-version" content="2026-04-28-troubleshooting" />
+    <meta name="harper-update-version" content="2026-05-01-troubleshooting-v2" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -61,7 +61,7 @@
                 <p>If that fails, start Harper with the server enabled in config, then run the TUI normally.</p>
 
                 <h2>Wrong provider or missing responses</h2>
-                <p>If requests hang or fail immediately, check provider settings in <code>config/local.toml</code> and make sure the selected model endpoint is reachable from your machine. For offline mode, confirm Ollama is running before starting Harper.</p>
+                <p>If requests hang or fail immediately, check provider settings in <code>config/local.toml</code> and make sure the selected model endpoint is reachable from your machine. For local offline setups, confirm Ollama is running before starting Harper. Current Harper builds also return a clear assistant reply when the model backend is unavailable and no deterministic fallback exists, so a clean failure usually points to provider reachability or configuration rather than a silent UI problem.</p>
 
                 <h2>No visible reply indicator</h2>
                 <p>If the assistant looks idle after you send a message, update to a recent build. Current TUI builds show a visible in-thread <code>Thinking...</code> row while the worker is waiting on a reply, plus header activity state for longer tool and approval flows.</p>
@@ -69,12 +69,27 @@
                 <h2>Sandbox or command approval confusion</h2>
                 <p>If a command does not run, check whether it was blocked by policy, waiting for approval, or denied by sandbox rules. Harper is designed to stop rather than silently escalate.</p>
 
-                <h2>Build issues while developing</h2>
-                <p>For local development problems, run the standard Rust loop first:</p>
+                <h2>Routing or follow-up behavior looks wrong</h2>
+                <p>Do not start in the TUI. Verify the same prompt through the shell harness first so you can see the selected strategy, task mode, deterministic intent, normalized command, activity, and final assistant reply without UI state in the way.</p>
                 <div class="code-wrapper">
-                    <pre><code>cargo fmt
-cargo clippy --all-targets --all-features
-cargo test</code></pre>
+                    <pre><code>cargo run -p harper-ui --bin harper-batch -- --strategy deterministic --prompt "where is execution strategy used in this repo"
+cargo run -p harper-ui --bin harper-batch -- --strategy deterministic --prompt "run the git status" --prompt "run that"
+cargo run -p harper-ui --bin harper-batch -- --strategy grounded --prompt "where is execution strategy used in this repo"</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <p>Read <code>ROUTING</code>, <code>DETERMINISTIC INTENT</code>, <code>NORMALIZED COMMAND</code>, <code>ACTIVITY</code>, and <code>ASSISTANT</code> first. If the shell path is wrong, fix core routing. If the shell path is right and the TUI still looks wrong, the problem is in UI state or rendering.</p>
+
+                <h2>Build issues while developing</h2>
+                <p>For local development problems, run the repository validation script first. It matches the current repo workflow more closely than an ad hoc sequence of Rust commands.</p>
+                <div class="code-wrapper">
+                    <pre><code>bash scripts/validate.sh</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <p>If you need to run commands by hand after that, use the same narrow checks Harper expects in development, including the full workspace clippy invocation with warnings denied.</p>
+                <div class="code-wrapper">
+                    <pre><code>cargo check --workspace
+cargo clippy --all-targets --all-features --workspace -- -A clippy::pedantic -D warnings
+cargo test --workspace</code></pre>
                     <button class="copy-btn"></button>
                 </div>
             </div>


### PR DESCRIPTION
## Changes

- Fixed Bazel-specific follow-ups for the shell verification path:
  - added `async-trait` proc-macro wiring to `//lib/harper-ui:harper_batch`
  - stabilized `codebase_investigator` ranking tests so they do not depend on repo-wide search layout under Bazel sandboxes
  - updated Bazel lockfiles after the dependency backend change
- Refined website copy and consistency:
  - made the docs page title and hero title consistent as `Docs`
  - rewrote `website/docs.html` to be more prose-driven and less list-driven
  - switched website `harper-batch` examples to `cargo run -p harper-ui --bin harper-batch -- ...`
  - refreshed `installation`, `server`, and `troubleshooting` pages to match the current shell-first verification workflow and strategy wording
  - aligned `nav-updates.json` versions with the edited pages

## Validation

- `bazel build //lib/harper-ui:harper_batch`
- `bazel test //lib/harper-core:harper_core_test`
- `bazel test //...`
- `cargo check`
- `cargo clippy --all-targets --all-features --workspace -- -A clippy::pedantic -D warnings`
