### PR TITLE
[test] fix windows install source path case

### DIFF
--- a/lib/harper-core/src/runtime/update.rs
+++ b/lib/harper-core/src/runtime/update.rs
@@ -547,8 +547,14 @@ mod tests {
             )),
             InstallSource::Npm
         );
+
+        #[cfg(windows)]
+        let direct_path = Path::new(r"C:\Program Files\Harper\harper.exe");
+        #[cfg(not(windows))]
+        let direct_path = Path::new("/usr/local/bin/harper");
+
         assert_eq!(
-            InstallSource::infer_from_executable(Path::new("/usr/local/bin/harper")),
+            InstallSource::infer_from_executable(direct_path),
             InstallSource::Direct
         );
     }


### PR DESCRIPTION
## Changes
- make the direct-install path assertion in `runtime::update::tests::infers_install_source_from_common_paths` platform-aware
- use a Windows absolute path on Windows and keep the Unix path on non-Windows targets

## Validation
- `cargo test -p harper-core runtime::update::tests::infers_install_source_from_common_paths -- --nocapture`
- `cargo test -p harper-core --lib`
