### PR TITLE
[fix] rename release-assets workflow secret

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -94,5 +94,5 @@ jobs:
           }
         ]
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      release_token: ${{ secrets.GITHUB_TOKEN }}
       signing_key_pem_b64: ${{ secrets.HARPER_UPDATE_SIGNING_KEY_PEM_B64 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,5 +141,5 @@ jobs:
           }
         ]
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      release_token: ${{ secrets.GITHUB_TOKEN }}
       signing_key_pem_b64: ${{ secrets.HARPER_UPDATE_SIGNING_KEY_PEM_B64 }}


### PR DESCRIPTION
## Changes
- rename the reusable release-assets workflow secret from `github_token` to `release_token` in Harper callers
- update both `release.yml` and `package-test.yml` to match the fixed `libnudget/release-assets` contract

## Validation
- parsed `.github/workflows/release.yml` and `.github/workflows/package-test.yml`
- push hooks passed: `check yaml`, `fmt`, `clippy`, `cargo check`
- manually dispatched `release.yml` on this branch and confirmed jobs were created successfully
