### PR TITLE
[fix] correct release workflow output delimiter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           echo "manifest_name=release-manifest.json" >> "$GITHUB_OUTPUT"
           echo "public_key_b64=BDOY84nu7unipalQUWLr4dyBTisXYX/+9oyPdBQiZBo=" >> "$GITHUB_OUTPUT"
           {
-            echo "targets_json<<'EOF'"
+            echo "targets_json<<EOF"
             cat <<'EOF'
           [
             {


### PR DESCRIPTION
## Changes
- fix the `prepare-release-assets-inputs` job to write `targets_json` to `$GITHUB_OUTPUT` using a valid multiline delimiter header
- keep the release asset target payload unchanged; only the output syntax is corrected

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- local hooks passed: `check yaml`, `fmt`, `clippy`, `cargo check`
