### PR TITLE
[fix] correct release versions json parse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,9 @@ jobs:
         env:
           VERSIONS_JSON: ${{ steps.release.outputs.versions }}
         run: |
-          value=$(printf '%s' "${VERSIONS_JSON:-{}}" | jq -r '."harper-core" // empty')
+          versions_json=${VERSIONS_JSON:-}
+          [ -n "$versions_json" ] || versions_json='{}'
+          value=$(printf '%s' "$versions_json" | jq -r '."harper-core" // empty')
           echo "harper_core_version=$value" >> "$GITHUB_OUTPUT"
 
   create-tags:
@@ -183,7 +185,9 @@ jobs:
         env:
           VERSIONS_JSON: ${{ steps.release.outputs.versions }}
         run: |
-          value=$(printf '%s' "${VERSIONS_JSON:-{}}" | jq -r '."harper-core" // empty')
+          versions_json=${VERSIONS_JSON:-}
+          [ -n "$versions_json" ] || versions_json='{}'
+          value=$(printf '%s' "$versions_json" | jq -r '."harper-core" // empty')
           echo "harper_core_version=$value" >> "$GITHUB_OUTPUT"
 
   release-assets-from-direct:


### PR DESCRIPTION
## Changes
- fix the `release.yml` version extraction steps to avoid unsafe `${VERSIONS_JSON:-{}}` expansion
- assign an explicit `'{}'` fallback before piping to `jq`
- keep the release flow unchanged apart from the safe JSON parsing

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- push hooks passed: `check yaml`, `fmt`, `clippy`, `cargo check`
