### PR TITLE
[fix] rotate update public key

### DIFF
--- a/lib/harper-core/src/runtime/update-public-key.b64
+++ b/lib/harper-core/src/runtime/update-public-key.b64
@@ -1,1 +1,1 @@
-BDOY84nu7unipalQUWLr4dyBTisXYX/+9oyPdBQiZBo=
+9kEE0GQW9lm0SmyulN/TxVnC6dNs730Wc7ttS7apBsw=


### PR DESCRIPTION
## Changes
- rotate the embedded updater public key in `lib/harper-core/src/runtime/update-public-key.b64`
- align the repo-trusted update verification key with the new signing key now stored in Actions secrets

## Validation
- verified the diff is a one-line public key replacement
- local hooks passed: `fmt`, `clippy`, `cargo check`
