### PR TITLE
[ci] automate homebrew tap updates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -30,6 +30,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | Rust Auto-Fix Bot | `rust-auto-fix.yml` | Applies automated `cargo fmt`/`clippy --fix` patches via `libnudget/rust-fix@v1` when `/rust-fix` comment is confirmed with `/confirm`. | Issue comment on PRs |
 | Cancel Runs Bot | `cancel-runs.yml` | Cancels in-progress runs when `/cancel-runs` is commented on PRs via `libnudget/cancel@v1`. Also triggers on `cancel-runs` label. | Issue comment on PRs, `cancel-runs` label |
 | Update Rust lockfiles | `update-lockfiles.yml` | Runs `cargo update` + `CARGO_BAZEL_REPIN=true bazel build :harper_bin` (repins `cargo-bazel-lock.json`), opens PR. | Weekly cron (Sunday midnight UTC), manual dispatch |
+| Update Homebrew Tap | `update-homebrew-tap.yml` | Manually updates `harpertoken/homebrew-tap/Formula/harper-ai.rb` for a published `harper-*` release by downloading the release tarball, recomputing sha256, patching the formula, and opening a PR in the tap repo. Requires `HOMEBREW_TAP_TOKEN`. | Manual dispatch |
 | Deploy Website | `website.yml` | Builds and deploys the website bundle to GitHub Pages. | Push to `main` touching `website/**`, manual dispatch |
 
 > **Tip:** Run `rg -n '^name:' .github/workflows` to see the canonical name shown in the Actions UI.
@@ -72,4 +73,4 @@ Current rules:
 Feel free to expand this file with additional details (matrix descriptions, secrets used, etc.) as workflows evolve.
 
 ## Last Updated
-2026-05-01
+2026-05-02

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,134 @@
+name: Update Homebrew Tap
+
+"on":
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Installable Harper release tag"
+        required: true
+        type: string
+
+jobs:
+  update-homebrew-tap:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TAP_REPO: harpertoken/homebrew-tap
+      FORMULA_PATH: Formula/harper-ai.rb
+    steps:
+      - name: Checkout Harper
+        uses: actions/checkout@v4
+
+      - name: Validate release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ github.event.inputs.release_tag }}" in
+            harper-*) ;;
+            *)
+              echo "release_tag must start with harper-"
+              exit 1
+              ;;
+          esac
+
+      - name: Download release tarball and compute sha256
+        id: tarball
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ github.event.inputs.release_tag }}"
+          tarball_url="https://github.com/harpertoken/harper/archive/refs/tags/${release_tag}.tar.gz"
+          curl -L "$tarball_url" -o harper-release.tar.gz
+          sha256=$(sha256sum harper-release.tar.gz | awk '{print $1}')
+          version="${release_tag#harper-}"
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Clone homebrew tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh repo clone "$TAP_REPO" homebrew-tap
+
+      - name: Patch formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/update-homebrew-tap.py \
+            --release-tag "${{ github.event.inputs.release_tag }}" \
+            --sha256 "${{ steps.tarball.outputs.sha256 }}" \
+            --formula-path "homebrew-tap/$FORMULA_PATH"
+
+      - name: Check for formula changes
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git -C homebrew-tap diff --quiet -- "$FORMULA_PATH"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit formula update
+        if: steps.diff.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.tarball.outputs.version }}"
+          branch="automation/homebrew-tap-${version}"
+          git -C homebrew-tap checkout -B "$branch"
+          git -C homebrew-tap add "$FORMULA_PATH"
+          git -C homebrew-tap commit -m "build(tap): bump harper-ai ${version}"
+          echo "branch=$branch" >> "$GITHUB_ENV"
+
+      - name: Push tap branch
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C homebrew-tap push --force-with-lease origin "$branch"
+
+      - name: Open tap PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.tarball.outputs.version }}"
+          cat > pr-body.md <<EOF
+          ## Changes
+          - update \`harper-ai\` to \`${version}\`
+          - point the formula at \`${{ github.event.inputs.release_tag }}\`
+          - refresh the source tarball sha256
+
+          ## Validation
+          - downloaded the \`${{ github.event.inputs.release_tag }}\` source tarball
+          - recomputed sha256 in workflow
+          - patched \`Formula/harper-ai.rb\`
+          EOF
+          pr_url=$(gh pr list --repo "$TAP_REPO" --head "$branch" --json url --jq '.[0].url')
+          if [ -n "$pr_url" ]; then
+            gh pr edit "$pr_url" \
+              --repo "$TAP_REPO" \
+              --title "build(tap): bump harper-ai to ${version}" \
+              --body-file pr-body.md
+          else
+            gh pr create \
+              --repo "$TAP_REPO" \
+              --head "$branch" \
+              --base main \
+              --title "build(tap): bump harper-ai to ${version}" \
+              --body-file pr-body.md
+          fi
+
+      - name: Report no-op
+        if: steps.diff.outputs.changed != 'true'
+        shell: bash
+        run: echo "Formula already matches ${{ github.event.inputs.release_tag }}"

--- a/scripts/update-homebrew-tap.py
+++ b/scripts/update-homebrew-tap.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+def replace_once(content: str, pattern: str, replacement: str) -> str:
+    updated, count = re.subn(pattern, replacement, content, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise ValueError(f"pattern not found exactly once: {pattern}")
+    return updated
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update harper-ai Homebrew formula to a released Harper version."
+    )
+    parser.add_argument("--release-tag", required=True, help="Release tag like harper-0.17.1")
+    parser.add_argument("--sha256", required=True, help="SHA256 of the release source tarball")
+    parser.add_argument("--formula-path", required=True, help="Path to Formula/harper-ai.rb")
+    args = parser.parse_args()
+
+    release_tag = args.release_tag
+    prefix = "harper-"
+    if not release_tag.startswith(prefix):
+        raise SystemExit(f"release tag must start with '{prefix}': {release_tag}")
+
+    version = release_tag[len(prefix) :]
+    tarball_url = (
+        f"https://github.com/harpertoken/harper/archive/refs/tags/{release_tag}.tar.gz"
+    )
+
+    formula_path = pathlib.Path(args.formula_path)
+    content = formula_path.read_text(encoding="utf-8")
+
+    if f'version "{version}"' in content and tarball_url in content and args.sha256 in content:
+        print("formula already matches requested release")
+        return 0
+
+    content = replace_once(content, r'^  version ".*"$', f'  version "{version}"')
+    content = replace_once(
+        content,
+        r'^      url "https://github\.com/harpertoken/harper/archive/refs/tags/.*\.tar\.gz"$',
+        f'      url "{tarball_url}"',
+    )
+    content = replace_once(
+        content,
+        r'^      sha256 "[0-9a-f]{64}"$',
+        f'      sha256 "{args.sha256}"',
+    )
+    content = replace_once(
+        content,
+        r'^      url "https://github\.com/harpertoken/harper/archive/refs/tags/.*\.tar\.gz"$',
+        f'      url "{tarball_url}"',
+    )
+    content = replace_once(
+        content,
+        r'^      sha256 "[0-9a-f]{64}"$',
+        f'      sha256 "{args.sha256}"',
+    )
+
+    formula_path.write_text(content, encoding="utf-8")
+    print(f"updated {formula_path} to {release_tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as err:
+        print(err, file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Changes
- add a manual `Update Homebrew Tap` workflow that downloads a published `harper-*` source tarball, recomputes sha256, patches `harpertoken/homebrew-tap/Formula/harper-ai.rb`, and opens or updates a PR in the tap repo
- add `scripts/update-homebrew-tap.py` to update the formula's version, URL, and sha256 deterministically
- document the workflow and required `HOMEBREW_TAP_TOKEN` secret in `.github/workflows/README.md`

## Validation
- `python3 -m py_compile scripts/update-homebrew-tap.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/update-homebrew-tap.yml")'`
- script smoke test against a temporary formula copy using `harper-0.17.1`
