### PR TITLE
[build] sync workspace version metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release_token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          packages: '[{"path": "lib/harper-core", "name": "harper-core"}, {"path": "lib/harper-ui", "name": "harper-ui"}, {"path": "lib/harper-firmware", "name": "harper-firmware"}, {"path": "lib/harper-mcp-server", "name": "harper-mcp-server"}, {"path": "lib/harper-sandbox", "name": "harper-sandbox"}]'
+          packages: '[{"path": ".", "name": "harper-workspace"}, {"path": "lib/harper-core", "name": "harper-core"}, {"path": "lib/harper-ui", "name": "harper-ui"}, {"path": "lib/harper-firmware", "name": "harper-firmware"}, {"path": "lib/harper-mcp-server", "name": "harper-mcp-server"}, {"path": "lib/harper-sandbox", "name": "harper-sandbox"}]'
           version_bump: ${{ github.event.inputs.version_bump || 'patch' }}
           release_mode: ${{ github.event.inputs.release_mode || 'pr' }}
       - id: head
@@ -175,7 +175,7 @@ jobs:
         uses: libnudget/release@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          packages: '[{"path": "lib/harper-core", "name": "harper-core"}, {"path": "lib/harper-ui", "name": "harper-ui"}, {"path": "lib/harper-firmware", "name": "harper-firmware"}, {"path": "lib/harper-mcp-server", "name": "harper-mcp-server"}, {"path": "lib/harper-sandbox", "name": "harper-sandbox"}]'
+          packages: '[{"path": ".", "name": "harper-workspace"}, {"path": "lib/harper-core", "name": "harper-core"}, {"path": "lib/harper-ui", "name": "harper-ui"}, {"path": "lib/harper-firmware", "name": "harper-firmware"}, {"path": "lib/harper-mcp-server", "name": "harper-mcp-server"}, {"path": "lib/harper-sandbox", "name": "harper-sandbox"}]'
           release_mode: merge
       - id: head
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "harper-workspace"
-version = "0.7.0"
+version = "0.17.1"
 dependencies = [
  "assert_cmd",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 
 [package]
 name = "harper-workspace"
-version = "0.7.0"
+version = "0.17.1"
 edition = "2021"
 rust-version = "1.85.0"
 authors = ["Harper Contributors"]

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "2a30279df907640e5ad0c193929dc09575695db866178a99283e7d978e704464",
+  "checksum": "777ca9d04eb7fab8d73e351f3e094c0347f442fa992b98b033f0770b0cc9a10d",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -10941,9 +10941,9 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
-    "harper-core 0.16.0": {
+    "harper-core 0.17.1": {
       "name": "harper-core",
-      "version": "0.16.0",
+      "version": "0.17.1",
       "package_url": "https://github.com/harpertoken/harper",
       "repository": null,
       "targets": [
@@ -11183,7 +11183,7 @@
           ],
           "selects": {}
         },
-        "version": "0.16.0"
+        "version": "0.17.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11405,9 +11405,9 @@
       ],
       "license_file": null
     },
-    "harper-ui 0.15.0": {
+    "harper-ui 0.16.0": {
       "name": "harper-ui",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "package_url": "https://github.com/harpertoken/harper",
       "repository": null,
       "targets": [
@@ -11508,7 +11508,7 @@
           ],
           "selects": {}
         },
-        "version": "0.15.0"
+        "version": "0.16.0"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -11517,9 +11517,9 @@
       ],
       "license_file": null
     },
-    "harper-workspace 0.7.0": {
+    "harper-workspace 0.17.1": {
       "name": "harper-workspace",
-      "version": "0.7.0",
+      "version": "0.17.1",
       "package_url": "https://github.com/harpertoken/harper",
       "repository": null,
       "targets": [
@@ -11603,7 +11603,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.0"
+        "version": "0.17.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -40616,12 +40616,12 @@
   },
   "binary_crates": [],
   "workspace_members": {
-    "harper-core 0.16.0": "lib/harper-core",
+    "harper-core 0.17.1": "lib/harper-core",
     "harper-firmware 0.1.3": "lib/harper-firmware",
     "harper-mcp-server 0.1.2": "lib/harper-mcp-server",
     "harper-sandbox 0.3.0": "lib/harper-sandbox",
-    "harper-ui 0.15.0": "lib/harper-ui",
-    "harper-workspace 0.7.0": ""
+    "harper-ui 0.16.0": "lib/harper-ui",
+    "harper-workspace 0.17.1": ""
   },
   "conditions": {
     "aarch64-apple-darwin": [


### PR DESCRIPTION
## Changes
- update the root `harper-workspace` package version from `0.7.0` to `0.17.1`
- include `harper-workspace` in `.github/workflows/release.yml` package lists so future release automation keeps the root workspace package in sync
- refresh `Cargo.lock` and `cargo-bazel-lock.json` so the workspace package version matches the root manifest

## Validation
- `cargo check -q`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- push hooks passed: `check yaml`, `fmt`, `clippy`, `cargo check`
