### PR TITLE
[docs] refresh docs landing and install guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,32 +1,32 @@
 # Harper
 
-Welcome to Harper, an AI agent for intelligent interactions with AI models. Harper provides a powerful command-line interface for chatting with AI, with features like clipboard integration, session management, and more.
+Harper is a terminal-first AI agent for code and shell work. It keeps command execution visible, supports approval-gated workflows, tracks multi-step work explicitly, and maintains an audit trail instead of hiding what it did.
 
 ## Features
 
-- **Chat Interface**: Interactive conversations with AI models
-- **Clipboard Integration**: Process images and text from your clipboard
-- **Session Management**: Save and load conversation sessions
-- **Command History**: Access previous commands with arrow keys
-- **Audit Trail**: Review all executed commands for security
+- **Visible command execution**: Harper shows the concrete commands it plans to run
+- **Approval gates**: Sensitive or higher-risk operations can require confirmation
+- **Session and plan tracking**: Conversations, titles, audit logs, and plans persist with the session
+- **Provider support**: Works with OpenAI, Gemini, SambaNova, Cerebras, and Ollama
+- **TUI and batch flows**: Use the interactive terminal UI or verify behavior headlessly with `harper-batch`
 
 ## Getting Started
 
 New to Harper? Start here:
 
-1. [Installation Guide](user-guide/installation.md) - Install Harper on your system
-2. [Quick Start](user-guide/quick-start.md) - Get up and running in 5 minutes
-3. [Configuration](user-guide/configuration.md) - Set up API keys and preferences
+1. [Installation Guide](user-guide/installation.md) - Install Harper from source, Homebrew, or direct release artifacts
+2. [Quick Start](user-guide/quick-start.md) - Get the TUI running and learn the basic interaction model
+3. [Configuration](user-guide/configuration.md) - Configure providers, execution policy, and UI behavior
 
 ## User Guide
 
 Learn about Harper's features in detail:
 
-- [About the Binary](user-guide/about.md) - How Harper runs, binary overview
-- [Chat Interface](user-guide/chat.md) - Commands, features, and tips for chatting
-- [Clipboard Features](user-guide/clipboard.md) - Working with images and text
+- [About the Binary](user-guide/about.md) - Runtime model, install source behavior, and binary overview
+- [Chat Interface](user-guide/chat.md) - Commands, routing, follow-ups, and update checks
+- [Clipboard Features](user-guide/clipboard.md) - Working with images and text from the terminal
 - [Configuration](user-guide/configuration.md) - Complete configuration options
-- [Troubleshooting](user-guide/troubleshooting.md) - Common issues and solutions
+- [Troubleshooting](user-guide/troubleshooting.md) - Common issues and validation paths
 
 ## Development
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-This guide covers how to install Harper on your system. Harper is a Rust application that can be built from source.
+This guide covers the supported ways to install Harper and how updates behave for each install source.
 
 ## Prerequisites
 
@@ -34,7 +34,22 @@ Before installing Harper, ensure you have the following:
 
 ## Installation Methods
 
-### Method 1: Build from Source (Recommended)
+### Method 1: Homebrew
+
+Use Homebrew if you want a package-managed install on macOS.
+
+```bash
+brew tap harpertoken/tap
+brew install harpertoken/tap/harper-ai
+```
+
+To update later:
+
+```bash
+brew upgrade harpertoken/tap/harper-ai
+```
+
+### Method 2: Build from Source
 
 1. Clone the repository:
    ```bash
@@ -61,7 +76,20 @@ Before installing Harper, ensure you have the following:
    ./target/release/harper
    ```
 
-### Method 2: Using Make
+### Method 3: Direct Release Artifact
+
+Download the release artifact for your platform from GitHub Releases, extract it, and place the `harper` binary somewhere on your `PATH`.
+
+Direct installs support Harper's built-in updater:
+
+```bash
+harper self-update --check
+harper self-update
+```
+
+Direct self-update verifies the published manifest, checksum, and detached signature before replacing the local binary.
+
+### Method 4: Using Make
 
 If the project includes a Makefile:
 
@@ -74,9 +102,9 @@ make run
 
 ## Post-Installation
 
-### Configure API Key
+### Configure Provider Access
 
-After installation, you'll need to configure your AI API key:
+After installation, configure your provider settings:
 
 1. Create a config file:
    ```bash
@@ -85,14 +113,19 @@ After installation, you'll need to configure your AI API key:
    nano config/local.toml
    ```
 
-2. Add your API key:
+2. Add provider configuration:
    ```toml
-   [api]
-   key = "your-api-key-here"
-   provider = "OpenAI"
+   [provider]
+   name = "openai"
+   model = "gpt-5"
    ```
 
-3. Save and exit. You're ready to use Harper!
+3. Export the matching provider credential, for example:
+   ```bash
+   export OPENAI_API_KEY="your-api-key-here"
+   ```
+
+4. Save and exit. You're ready to use Harper.
 
 ## Verifying Installation
 
@@ -109,12 +142,15 @@ You should see a welcome message. If you get an error, check:
 
 ## Updating Harper
 
-To update to the latest version:
+Update paths depend on how Harper was installed:
 
-```bash
-git pull origin main
-cargo build --release
-```
+- **Homebrew**: `brew upgrade harpertoken/tap/harper-ai`
+- **Direct release install**: `harper self-update --check` or `harper self-update`
+- **Source build**:
+  ```bash
+  git pull origin main
+  cargo build --release
+  ```
 
 ## Uninstallation
 


### PR DESCRIPTION
## Changes
- refresh the docs landing page copy in `docs/index.md` so it matches the current terminal-first product positioning
- update `docs/user-guide/installation.md` to document Homebrew installs, direct release artifacts, built-in self-update, and current provider configuration examples

## Validation
- reviewed the exact source diff for both docs pages
- local hooks passed on commit and push
- noted that `site/` regeneration still depends on the mkdocs workflow because `mkdocs` is not installed in this shell
