### PR TITLE
[feat] integrate azure data explorer adx_query tool with device-code and service-principal auth

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -14,6 +14,15 @@ CEREBRAS_API_KEY=your_cerebras_api_key_here
 # Database Configuration
 # DATABASE_PATH=data/harper.db
 
+# Azure Data Explorer query tool
+# HARPER_ADX_CLUSTER_URL=https://your-cluster.kusto.windows.net
+# HARPER_ADX_DATABASE=your_database
+# HARPER_ADX_TENANT_ID=00000000-0000-0000-0000-000000000000
+# Optional: set a public/native app client ID for device-code login.
+# HARPER_ADX_CLIENT_ID=00000000-0000-0000-0000-000000000000
+# Optional: set client credentials for server or CI use instead of device-code login.
+# HARPER_ADX_CLIENT_SECRET=your-client-secret
+
 # MCP Configuration (optional)
 # MCP_ENABLED=true
 # MCP_SERVER_URL=http://localhost:3000

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -108,6 +108,11 @@ Additional constraints.
 | `GEMINI_API_KEY`     | provider | Gemini auth      |
 | `HARPER_CONFIG_PATH` | global   | Config override  |
 | `HARPER_DATA_DIR`    | global   | Storage override |
+| `HARPER_ADX_CLUSTER_URL` | tool | Azure Data Explorer cluster URL |
+| `HARPER_ADX_DATABASE` | tool | Azure Data Explorer database |
+| `HARPER_ADX_TENANT_ID` | tool | Microsoft Entra tenant ID |
+| `HARPER_ADX_CLIENT_ID` | tool | Optional Microsoft Entra application client ID |
+| `HARPER_ADX_CLIENT_SECRET` | tool | Optional Microsoft Entra application secret for service-principal auth |
 
 ---
 

--- a/docs/user-guide/chat.md
+++ b/docs/user-guide/chat.md
@@ -56,6 +56,8 @@ Typing `/` in the TUI opens the slash-command list. Use `↑` / `↓` or `Tab` t
 
 `/update` shows the current cached update status from the header widget. Use `/update check` to re-run the manifest-backed update check on demand. The same refresh is also available from `Settings -> Execution Policy -> Updates`. Harper now checks the default GitHub release manifest automatically, and `HARPER_UPDATE_MANIFEST_URL` can override that source when needed. Published direct-install artifacts are verified with both a SHA-256 checksum and a detached signature before Harper replaces the local binary.
 
+For Azure Data Explorer, ask Harper for a KQL query after setting `HARPER_ADX_CLUSTER_URL`, `HARPER_ADX_DATABASE`, and `HARPER_ADX_TENANT_ID`. Harper routes read-only Kusto requests through `adx_query`, asks for approval, uses device-code login for local accounts, and rejects management commands that start with `.`.
+
 ## Chat Features
 
 ### Multi-line Input

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -115,6 +115,27 @@ provider = "ProviderName"
 base_url = "https://api.example.com/v1"  # Optional: for custom endpoints
 ```
 
+## Azure Data Explorer
+
+Harper can run read-only KQL queries against Azure Data Explorer through the `adx_query` tool. For local use, set the cluster, database, and tenant. Harper will use Microsoft device-code login the first time it needs an ADX token:
+
+```bash
+export HARPER_ADX_CLUSTER_URL="https://your-cluster.kusto.windows.net"
+export HARPER_ADX_DATABASE="your_database"
+export HARPER_ADX_TENANT_ID="00000000-0000-0000-0000-000000000000"
+```
+
+Harper caches the resulting access token under the user cache directory until it expires. Set `HARPER_ADX_CLIENT_ID` to use a specific public/native app registration for device-code login.
+
+For server or CI use, set client credentials instead:
+
+```bash
+export HARPER_ADX_CLIENT_ID="00000000-0000-0000-0000-000000000000"
+export HARPER_ADX_CLIENT_SECRET="your-client-secret"
+```
+
+Grant the user or service principal database viewer access in ADX before querying. Harper rejects Kusto management commands that start with `.` and asks for approval before sending a query.
+
 ## Model Configuration
 
 ### Selecting Models

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = { version = "0.12.20", features = ["json", "native-tls"] }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "process", "signal"] }
+tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "process", "signal", "time"] }
 tower = "0.5"
 futures-util = "0.3"
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/lib/harper-core/src/agent/chat.rs
+++ b/lib/harper-core/src/agent/chat.rs
@@ -1271,6 +1271,12 @@ impl<'a> ChatService<'a> {
             }
             if executed_tool_calls.contains(&dedupe_key) {
                 if let Some(content) = last_tool_content {
+                    if matches!(
+                        Self::tool_name_from_tool_call(&normalized_tool_call).as_deref(),
+                        Some("adx_query" | "azure_data_explorer")
+                    ) {
+                        return Ok(content);
+                    }
                     return Ok(format!("Tool result:\n{}", content));
                 }
                 break;
@@ -1317,7 +1323,11 @@ impl<'a> ChatService<'a> {
 
             if let Some((tool_result, tool_content)) = tool_option {
                 self.notify_command_activity(session_id);
+                let mut terminal_tool_result = false;
                 if let Some(tool_name) = Self::tool_name_from_tool_call(&normalized_tool_call) {
+                    if matches!(tool_name.as_str(), "adx_query" | "azure_data_explorer") {
+                        terminal_tool_result = true;
+                    }
                     if tool_name == "update_plan" {
                         saw_plan_update = true;
                         if let Some(authoring_request_context) = authoring_context.as_ref() {
@@ -1392,6 +1402,9 @@ impl<'a> ChatService<'a> {
                 history.push(tool_message.clone());
                 history_for_llm.push(tool_message);
                 response = tool_result;
+                if terminal_tool_result {
+                    break;
+                }
                 continue;
             }
 

--- a/lib/harper-core/src/agent/prompt.rs
+++ b/lib/harper-core/src/agent/prompt.rs
@@ -86,6 +86,7 @@ User Intent Recognition:
 - understand how something works -> use codebase_investigator
 - what changed -> use git_diff or list_changed_files
 - tell me about a specific file -> use read_file
+- query Azure Data Explorer or Kusto -> use adx_query
 
 Use this JSON shape for built-in tools:
 {\"tool\":\"tool_name\",\"args\":{...}}
@@ -111,6 +112,7 @@ Core Tools:
 - run_command(args: {\"command\": \"git status\"})
 - run_command(args: {\"command\": \"cp ./src.txt ./build/out.txt\", \"declared_read_paths\": [\"./src.txt\"], \"declared_write_paths\": [\"./build/out.txt\"]})
 - run_command(args: {\"command\": \"curl -fsSL http://127.0.0.1:8081/health\", \"requires_network\": true, \"retry_policy\": \"safe\"})
+- adx_query(args: {\"query\": \"StormEvents | take 10\", \"database\": \"Samples\", \"cluster_url\": \"https://help.kusto.windows.net\"})
 - todo(args: {\"action\": \"add|list|remove|clear\", \"description\": \"...\", \"index\": 1})
 - update_plan(args: {\"explanation\": \"optional context\", \"items\": [{\"step\": \"Inspect files\", \"status\": \"in_progress\"}]})
 - list_changed_files(args: {\"ext\": \"rs\", \"tracked_only\": true, \"since\": \"HEAD~1\"})

--- a/lib/harper-core/src/core/constants.rs
+++ b/lib/harper-core/src/core/constants.rs
@@ -180,6 +180,10 @@ pub mod tools {
     #[allow(dead_code)]
     pub const DB_QUERY: &str = "[DB_QUERY";
 
+    /// Azure Data Explorer query prefix
+    #[allow(dead_code)]
+    pub const ADX_QUERY: &str = "[ADX_QUERY";
+
     /// Image info prefix
     #[allow(dead_code)]
     pub const IMAGE_INFO: &str = "[IMAGE_INFO";

--- a/lib/harper-core/src/core/llm_client.rs
+++ b/lib/harper-core/src/core/llm_client.rs
@@ -132,6 +132,28 @@ fn built_in_tool_functions() -> Vec<Value> {
             }
         }),
         json!({
+            "name": "adx_query",
+            "description": "Run a read-only KQL query against Azure Data Explorer. Credentials come from HARPER_ADX_* environment variables unless explicitly provided.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "cluster_url": {
+                        "type": "string",
+                        "description": "Azure Data Explorer cluster URL, for example https://help.kusto.windows.net"
+                    },
+                    "database": {
+                        "type": "string",
+                        "description": "ADX database name"
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Read-only KQL query. Management commands that start with a dot are not allowed."
+                    }
+                },
+                "required": ["query"]
+            }
+        }),
+        json!({
             "name": "todo",
             "description": "Manage todo list. Supported actions: add, list, remove, clear",
             "parameters": {

--- a/lib/harper-core/src/tools/adx.rs
+++ b/lib/harper-core/src/tools/adx.rs
@@ -1,0 +1,670 @@
+// Copyright 2026 harpertoken
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Azure Data Explorer query tool.
+
+use crate::core::error::{HarperError, HarperResult};
+use crate::core::io_traits::UserApproval;
+use crate::tools::parsing;
+use chrono::Utc;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+const AZURE_CLI_CLIENT_ID: &str = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
+const DEFAULT_ROW_LIMIT: usize = 100;
+const TOKEN_EXPIRY_SKEW_SECONDS: i64 = 60;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdxQueryRequest {
+    pub cluster_url: String,
+    pub database: String,
+    pub query: String,
+    pub tenant_id: String,
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: Option<Value>,
+    expires_on: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    message: String,
+    interval: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthErrorResponse {
+    error: String,
+    error_description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct CachedToken {
+    access_token: String,
+    expires_at: i64,
+}
+
+pub async fn query_from_json(
+    client: &Client,
+    args: &Value,
+    approver: Option<Arc<dyn UserApproval>>,
+) -> HarperResult<String> {
+    let request = AdxQueryRequest::from_json(args)?;
+    let Some(request) = request else {
+        return Ok(
+            "The ADX query tool needs a `query` field. Provide a read-only KQL query, for example: print hello=\"world\""
+                .to_string(),
+        );
+    };
+    request.validate()?;
+
+    let is_approved = if let Some(approver) = approver {
+        approver
+            .approve(
+                &format!(
+                    "Run Azure Data Explorer query on {}/{}?",
+                    request.cluster_url, request.database
+                ),
+                &request.query,
+            )
+            .await?
+    } else {
+        let cluster_url = request.cluster_url.clone();
+        let database = request.database.clone();
+        let query = request.query.clone();
+        tokio::task::spawn_blocking(move || {
+            println!(
+                "Run Azure Data Explorer query on {}/{}? (y/n): {}",
+                cluster_url, database, query
+            );
+            io::stdout()
+                .flush()
+                .map_err(|err| HarperError::Io(err.to_string()))?;
+            let mut approval = String::new();
+            io::stdin()
+                .read_line(&mut approval)
+                .map_err(|err| HarperError::Io(err.to_string()))?;
+            Ok::<bool, HarperError>(approval.trim().eq_ignore_ascii_case("y"))
+        })
+        .await
+        .map_err(|err| HarperError::Command(format!("Task failed: {}", err)))??
+    };
+
+    if !is_approved {
+        return Ok("Azure Data Explorer query cancelled by user".to_string());
+    }
+
+    query(client, &request).await
+}
+
+pub fn args_from_bracket_call(response: &str) -> HarperResult<Value> {
+    let args = parsing::extract_tool_args(response, "[ADX_QUERY", 3)?;
+    Ok(json!({
+        "cluster_url": args[0],
+        "database": args[1],
+        "query": args[2],
+    }))
+}
+
+async fn query(client: &Client, request: &AdxQueryRequest) -> HarperResult<String> {
+    let token = fetch_access_token(client, request).await?;
+    let query_url = format!(
+        "{}/v1/rest/query",
+        request.cluster_url.trim_end_matches('/')
+    );
+    let response = client
+        .post(&query_url)
+        .bearer_auth(token)
+        .json(&json!({
+            "db": request.database,
+            "csl": request.query,
+        }))
+        .send()
+        .await
+        .map_err(|err| HarperError::Command(format!("ADX query request failed: {}", err)))?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .map_err(|err| HarperError::Command(format!("Failed to read ADX response: {}", err)))?;
+
+    if !status.is_success() {
+        return Err(HarperError::Command(format!(
+            "ADX query failed with status {}: {}",
+            status,
+            body.trim()
+        )));
+    }
+
+    format_query_response(&body)
+}
+
+async fn fetch_access_token(client: &Client, request: &AdxQueryRequest) -> HarperResult<String> {
+    if let Some(client_secret) = request.client_secret.as_deref() {
+        return fetch_client_credentials_token(client, request, client_secret).await;
+    }
+
+    if uses_device_token_cache(request) {
+        if let Some(token) = read_cached_token(request)? {
+            return Ok(token);
+        }
+    }
+
+    fetch_device_code_token(client, request).await
+}
+
+fn uses_device_token_cache(request: &AdxQueryRequest) -> bool {
+    request.client_secret.is_none()
+}
+
+async fn fetch_client_credentials_token(
+    client: &Client,
+    request: &AdxQueryRequest,
+    client_secret: &str,
+) -> HarperResult<String> {
+    let token_url = format!(
+        "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+        request.tenant_id
+    );
+    let scope = format!("{}/.default", request.cluster_url.trim_end_matches('/'));
+    let client_id = request.client_id.as_deref().ok_or_else(|| {
+        HarperError::Config(
+            "Missing Azure Data Explorer setting: client_id or HARPER_ADX_CLIENT_ID".to_string(),
+        )
+    })?;
+    let response = client
+        .post(token_url)
+        .form(&[
+            ("client_id", client_id),
+            ("client_secret", client_secret),
+            ("grant_type", "client_credentials"),
+            ("scope", scope.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|err| HarperError::Command(format!("ADX token request failed: {}", err)))?;
+
+    let status = response.status();
+    let body = response.text().await.map_err(|err| {
+        HarperError::Command(format!("Failed to read ADX token response: {}", err))
+    })?;
+
+    if !status.is_success() {
+        return Err(HarperError::Command(format!(
+            "ADX token request failed with status {}: {}",
+            status,
+            body.trim()
+        )));
+    }
+
+    serde_json::from_str::<TokenResponse>(&body)
+        .map(|token| token.access_token)
+        .map_err(|err| HarperError::Command(format!("Failed to parse ADX token response: {}", err)))
+}
+
+async fn fetch_device_code_token(
+    client: &Client,
+    request: &AdxQueryRequest,
+) -> HarperResult<String> {
+    let client_id = request
+        .client_id
+        .as_deref()
+        .unwrap_or(AZURE_CLI_CLIENT_ID)
+        .to_string();
+    let resource = request.cluster_url.trim_end_matches('/').to_string();
+    let device_code_url = format!(
+        "https://login.microsoftonline.com/{}/oauth2/devicecode",
+        request.tenant_id
+    );
+    let device_response = client
+        .post(device_code_url)
+        .form(&[
+            ("client_id", client_id.as_str()),
+            ("resource", resource.as_str()),
+        ])
+        .send()
+        .await
+        .map_err(|err| HarperError::Command(format!("ADX device login request failed: {}", err)))?;
+
+    let status = device_response.status();
+    let body = device_response.text().await.map_err(|err| {
+        HarperError::Command(format!("Failed to read ADX device login response: {}", err))
+    })?;
+
+    if !status.is_success() {
+        return Err(HarperError::Command(format!(
+            "ADX device login failed with status {}: {}",
+            status,
+            body.trim()
+        )));
+    }
+
+    let device_code = serde_json::from_str::<DeviceCodeResponse>(&body).map_err(|err| {
+        HarperError::Command(format!(
+            "Failed to parse ADX device login response: {}",
+            err
+        ))
+    })?;
+
+    eprintln!("{}", device_code.message);
+    poll_device_code_token(client, request, &client_id, &device_code).await
+}
+
+async fn poll_device_code_token(
+    client: &Client,
+    request: &AdxQueryRequest,
+    client_id: &str,
+    device_code: &DeviceCodeResponse,
+) -> HarperResult<String> {
+    let token_url = format!(
+        "https://login.microsoftonline.com/{}/oauth2/token",
+        request.tenant_id
+    );
+    let mut interval = Duration::from_secs(
+        device_code
+            .interval
+            .as_ref()
+            .and_then(value_as_u64)
+            .unwrap_or(5)
+            .max(1),
+    );
+
+    loop {
+        tokio::time::sleep(interval).await;
+        let response = client
+            .post(&token_url)
+            .form(&[
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+                ("client_id", client_id),
+                ("code", device_code.device_code.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|err| HarperError::Command(format!("ADX token poll failed: {}", err)))?;
+
+        let status = response.status();
+        let body = response.text().await.map_err(|err| {
+            HarperError::Command(format!("Failed to read ADX token poll: {}", err))
+        })?;
+
+        if status.is_success() {
+            let token = serde_json::from_str::<TokenResponse>(&body).map_err(|err| {
+                HarperError::Command(format!("Failed to parse ADX token response: {}", err))
+            })?;
+            let expires_at = token_expiry(&token);
+            write_cached_token(
+                request,
+                &CachedToken {
+                    access_token: token.access_token.clone(),
+                    expires_at,
+                },
+            )?;
+            return Ok(token.access_token);
+        }
+
+        let oauth_error = serde_json::from_str::<OAuthErrorResponse>(&body).ok();
+        match oauth_error.as_ref().map(|err| err.error.as_str()) {
+            Some("authorization_pending") => continue,
+            Some("slow_down") => {
+                interval += Duration::from_secs(5);
+                continue;
+            }
+            Some("authorization_declined") => {
+                return Err(HarperError::Command(
+                    "ADX device login was cancelled".to_string(),
+                ));
+            }
+            Some("expired_token") => {
+                return Err(HarperError::Command("ADX device login expired".to_string()));
+            }
+            _ => {
+                let detail = oauth_error
+                    .and_then(|err| err.error_description)
+                    .unwrap_or_else(|| body.trim().to_string());
+                return Err(HarperError::Command(format!(
+                    "ADX token poll failed with status {}: {}",
+                    status, detail
+                )));
+            }
+        }
+    }
+}
+
+fn env_or_arg(args: &Value, key: &str, env_key: &str) -> HarperResult<String> {
+    args.get(key)
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            env::var(env_key)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .ok_or_else(|| {
+            HarperError::Config(format!(
+                "Missing Azure Data Explorer setting: {} or {}",
+                key, env_key
+            ))
+        })
+}
+
+fn optional_env_or_arg(args: &Value, key: &str, env_key: &str) -> Option<String> {
+    args.get(key)
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            env::var(env_key)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+}
+
+impl AdxQueryRequest {
+    fn from_json(args: &Value) -> HarperResult<Option<Self>> {
+        let Some(query) = args
+            .get("query")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+        else {
+            return Ok(None);
+        };
+
+        Ok(Self {
+            cluster_url: normalize_cluster_url(&env_or_arg(
+                args,
+                "cluster_url",
+                "HARPER_ADX_CLUSTER_URL",
+            )?),
+            database: env_or_arg(args, "database", "HARPER_ADX_DATABASE")?,
+            query,
+            tenant_id: env_or_arg(args, "tenant_id", "HARPER_ADX_TENANT_ID")?,
+            client_id: optional_env_or_arg(args, "client_id", "HARPER_ADX_CLIENT_ID"),
+            client_secret: optional_env_or_arg(args, "client_secret", "HARPER_ADX_CLIENT_SECRET"),
+        }
+        .into())
+    }
+
+    fn validate(&self) -> HarperResult<()> {
+        if self.query.trim_start().starts_with('.') {
+            return Err(HarperError::Command(
+                "ADX management commands are not allowed. Use a read-only KQL query.".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn token_expiry(token: &TokenResponse) -> i64 {
+    if let Some(expires_on) = token.expires_on.as_ref().and_then(value_as_i64) {
+        return expires_on;
+    }
+
+    let expires_in = token
+        .expires_in
+        .as_ref()
+        .and_then(value_as_i64)
+        .unwrap_or(3600);
+    Utc::now().timestamp() + expires_in
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_str().and_then(|value| value.parse::<i64>().ok()))
+}
+
+fn value_as_u64(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|value| value.parse::<u64>().ok()))
+}
+
+fn read_cached_token(request: &AdxQueryRequest) -> HarperResult<Option<String>> {
+    let Some(path) = token_cache_path(request) else {
+        return Ok(None);
+    };
+    let Ok(raw) = fs::read_to_string(path) else {
+        return Ok(None);
+    };
+    let token = serde_json::from_str::<CachedToken>(&raw)
+        .map_err(|err| HarperError::Config(format!("Failed to parse ADX token cache: {}", err)))?;
+    if token.expires_at <= Utc::now().timestamp() + TOKEN_EXPIRY_SKEW_SECONDS {
+        return Ok(None);
+    }
+    Ok(Some(token.access_token))
+}
+
+fn write_cached_token(request: &AdxQueryRequest, token: &CachedToken) -> HarperResult<()> {
+    let Some(path) = token_cache_path(request) else {
+        return Ok(());
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            HarperError::Io(format!(
+                "Failed to create ADX token cache directory: {}",
+                err
+            ))
+        })?;
+    }
+    let raw = serde_json::to_string(token)
+        .map_err(|err| HarperError::Config(format!("Failed to encode ADX token cache: {}", err)))?;
+    fs::write(path, raw)
+        .map_err(|err| HarperError::Io(format!("Failed to write ADX token cache: {}", err)))
+}
+
+fn token_cache_path(request: &AdxQueryRequest) -> Option<PathBuf> {
+    let mut path = dirs::cache_dir()?;
+    path.push("harper");
+    path.push("adx");
+    path.push(format!(
+        "{}-{}-{}.json",
+        sanitize_cache_key(&request.tenant_id),
+        sanitize_cache_key(&request.cluster_url),
+        sanitize_cache_key(&request.database)
+    ));
+    Some(path)
+}
+
+fn sanitize_cache_key(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect()
+}
+
+fn normalize_cluster_url(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{}", trimmed)
+    }
+}
+
+fn format_query_response(body: &str) -> HarperResult<String> {
+    let value: Value = serde_json::from_str(body)
+        .map_err(|err| HarperError::Command(format!("Failed to parse ADX response: {}", err)))?;
+    let tables = value
+        .get("Tables")
+        .and_then(|tables| tables.as_array())
+        .ok_or_else(|| HarperError::Command("ADX response did not include Tables".to_string()))?;
+
+    let Some(table) = tables.first() else {
+        return Ok("ADX query returned no tables.".to_string());
+    };
+
+    let columns = table
+        .get("Columns")
+        .and_then(|columns| columns.as_array())
+        .map(|columns| {
+            columns
+                .iter()
+                .filter_map(|column| column.get("ColumnName").and_then(|name| name.as_str()))
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let rows = table
+        .get("Rows")
+        .and_then(|rows| rows.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut output = format!("ADX query returned {} rows.\n", rows.len());
+    if !columns.is_empty() {
+        output.push_str(&format!("Columns: {}\n", columns.join(", ")));
+    }
+
+    for (index, row) in rows.iter().take(DEFAULT_ROW_LIMIT).enumerate() {
+        output.push_str(&format!("Row {}: {}\n", index, format_row(row, &columns)));
+    }
+    if rows.len() > DEFAULT_ROW_LIMIT {
+        output.push_str("... truncated\n");
+    }
+
+    Ok(output)
+}
+
+fn format_row(row: &Value, columns: &[String]) -> String {
+    let Some(values) = row.as_array() else {
+        return row.to_string();
+    };
+
+    if columns.is_empty() {
+        return values
+            .iter()
+            .map(format_value)
+            .collect::<Vec<_>>()
+            .join(", ");
+    }
+
+    columns
+        .iter()
+        .zip(values.iter())
+        .map(|(column, value)| format!("{}={}", column, format_value(value)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn format_value(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::String(value) => value.clone(),
+        _ => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_query_response, normalize_cluster_url, query_from_json, AdxQueryRequest};
+    use reqwest::Client;
+    use serde_json::json;
+
+    #[test]
+    fn rejects_management_commands() {
+        let request = AdxQueryRequest {
+            cluster_url: "https://example.kusto.windows.net".to_string(),
+            database: "Samples".to_string(),
+            query: ".show tables".to_string(),
+            tenant_id: "tenant".to_string(),
+            client_id: Some("client".to_string()),
+            client_secret: Some("secret".to_string()),
+        };
+
+        let err = request.validate().expect_err("management command rejected");
+        assert!(err
+            .to_string()
+            .contains("management commands are not allowed"));
+    }
+
+    #[test]
+    fn formats_query_response_table() {
+        let body = r#"{
+            "Tables": [{
+                "TableName": "PrimaryResult",
+                "Columns": [
+                    {"ColumnName": "State", "DataType": "String"},
+                    {"ColumnName": "Count", "DataType": "Int64"}
+                ],
+                "Rows": [["WA", 3], ["CA", 5]]
+            }]
+        }"#;
+
+        let formatted = format_query_response(body).expect("formatted");
+        assert!(formatted.contains("ADX query returned 2 rows."));
+        assert!(formatted.contains("Columns: State, Count"));
+        assert!(formatted.contains("Row 0: State=WA, Count=3"));
+    }
+
+    #[test]
+    fn normalizes_cluster_url() {
+        assert_eq!(
+            normalize_cluster_url("cluster.kusto.windows.net/"),
+            "https://cluster.kusto.windows.net"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_query_returns_tool_guidance() {
+        let output = query_from_json(&Client::new(), &json!({}), None)
+            .await
+            .expect("tool guidance");
+
+        assert!(output.contains("needs a `query` field"));
+    }
+
+    #[test]
+    fn sanitizes_token_cache_key() {
+        assert_eq!(
+            super::sanitize_cache_key("https://cluster.kusto.windows.net/db"),
+            "https---cluster-kusto-windows-net-db"
+        );
+    }
+
+    #[test]
+    fn service_principal_request_is_not_cache_eligible() {
+        let request = AdxQueryRequest {
+            cluster_url: "https://example.kusto.windows.net".to_string(),
+            database: "Samples".to_string(),
+            query: "print hello=\"world\"".to_string(),
+            tenant_id: "tenant".to_string(),
+            client_id: Some("client".to_string()),
+            client_secret: Some("secret".to_string()),
+        };
+
+        assert!(!super::uses_device_token_cache(&request));
+    }
+}

--- a/lib/harper-core/src/tools/mod.rs
+++ b/lib/harper-core/src/tools/mod.rs
@@ -17,6 +17,7 @@
 //! This module provides a unified interface to various tools
 //! for file operations, shell commands, web search, and todos.
 
+pub mod adx;
 pub mod api;
 pub mod code_analysis;
 pub mod codebase_investigator;
@@ -367,6 +368,14 @@ impl<'a> ToolService<'a> {
                 .call_llm_after_tool(client, history, response, &tool_result)
                 .await?;
             Ok(Some((final_response, tool_result)))
+        } else if response.to_uppercase().starts_with(tools::ADX_QUERY) {
+            self.sync_plan_before_tool("adx_query")?;
+            let args = adx::args_from_bracket_call(response)?;
+            let tool_result = adx::query_from_json(client, &args, self.approver.clone()).await?;
+            let final_response = self
+                .call_llm_after_tool(client, history, response, &tool_result)
+                .await?;
+            Ok(Some((final_response, tool_result)))
         } else if response.to_uppercase().starts_with(tools::IMAGE_INFO) {
             self.sync_plan_before_tool("image_info")?;
             self.execute_sync_tool(client, history, response, |_, response| {
@@ -537,6 +546,11 @@ impl<'a> ToolService<'a> {
                 } else {
                     Ok(None)
                 }
+            }
+            "adx_query" | "azure_data_explorer" => {
+                let query_result =
+                    adx::query_from_json(client, args, self.approver.clone()).await?;
+                Ok(Some((query_result.clone(), query_result)))
             }
             "update_plan" => {
                 let Some(session_id) = self.session_id else {
@@ -910,6 +924,7 @@ SYSTEM INSTRUCTION: The tool has completed successfully. The output above is the
             || upper.starts_with(tools::CODE_ANALYZE)
             || upper.starts_with(tools::CODEBASE_INVESTIGATE)
             || upper.starts_with(tools::DB_QUERY)
+            || upper.starts_with(tools::ADX_QUERY)
             || upper.starts_with(tools::IMAGE_INFO)
             || upper.starts_with(tools::IMAGE_RESIZE)
             || upper.starts_with(tools::SCREENPIPE)
@@ -1511,6 +1526,30 @@ mod tests {
             "Web search is off. Enable web mode and try again."
         );
         assert_eq!(result.1, "Web search is disabled for this session.");
+    }
+
+    #[tokio::test]
+    async fn adx_json_tool_missing_query_returns_terminal_guidance() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        let config = test_config();
+        let exec_policy = ExecPolicyConfig::default();
+        let client = Client::new();
+        let mut service = ToolService::new(&conn, &config, &exec_policy, None, None);
+        let result = service
+            .handle_regular_json_tool(
+                &client,
+                &[],
+                "adx_query",
+                &json!({}),
+                r#"{"tool":"adx_query","args":{}}"#,
+                false,
+            )
+            .await
+            .expect("adx guidance")
+            .expect("terminal response");
+
+        assert_eq!(result.0, result.1);
+        assert!(result.0.contains("needs a `query` field"));
     }
 
     #[test]

--- a/website/docs.html
+++ b/website/docs.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Docs</title>
-    <meta name="harper-update-version" content="2026-05-01-docs-v2" />
+    <meta name="harper-update-version" content="2026-05-05-docs-adx" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -36,7 +36,7 @@
                 </div>
 
                 <h2>Start here</h2>
-                <p>The <a href="installation.html">installation guide</a> is the best entry point for most people. It covers setup, the current slash commands, execution policy, routing behavior, and the shell-first verification flow. If you are running Harper with the local HTTP interface enabled, the <a href="server.html">API Server</a> page explains the runtime model, configuration, and integration details. When something goes wrong in local development, the <a href="troubleshooting.html">troubleshooting guide</a> is the right place to check for auth, shell, and runtime issues.</p>
+                <p>The <a href="installation.html">installation guide</a> is the best entry point for most people. It covers setup, the current slash commands, execution policy, routing behavior, Azure Data Explorer queries, and the shell-first verification flow. If you are running Harper with the local HTTP interface enabled, the <a href="server.html">API Server</a> page explains the runtime model, configuration, and integration details. When something goes wrong in local development, the <a href="troubleshooting.html">troubleshooting guide</a> is the right place to check for auth, shell, and runtime issues.</p>
 
                 <h2>Verification workflow</h2>
                 <p>Use <code>harper-batch</code> before opening the TUI when you need to verify routing, normalization, or follow-up behavior. This keeps the verification path close to the core chat flow and removes UI state from the first debugging step.</p>
@@ -49,7 +49,7 @@ cargo run -p harper-ui --bin harper-batch -- --strategy grounded --prompt "where
                 <p>Read <code>ROUTING</code>, <code>DETERMINISTIC INTENT</code>, <code>NORMALIZED COMMAND</code>, <code>ACTIVITY</code>, and <code>ASSISTANT</code> first. Those fields tell you whether Harper chose the right path before you spend time checking the TUI.</p>
 
                 <h2>Deeper reading</h2>
-                <p>If you want the longer reference material, the full user guide still lives in the repository. The main pages are <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/about.md">About Harper</a>, <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/chat.md">Chat Interface</a>, <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/configuration.md">Configuration</a>, and <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/quick-start.md">Quick Start</a>. Use this page as the short path through the product, and use the repository docs when you need the full detail.</p>
+                <p>If you want the longer reference material, the full user guide still lives in the repository. The main pages are <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/about.md">About Harper</a>, <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/chat.md">Chat Interface</a>, <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/configuration.md">Configuration</a>, <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/configuration.md#azure-data-explorer">Azure Data Explorer</a>, and <a href="https://github.com/harpertoken/harper/blob/main/docs/user-guide/quick-start.md">Quick Start</a>. Use this page as the short path through the product, and use the repository docs when you need the full detail.</p>
             </div>
         </main>
 

--- a/website/installation.html
+++ b/website/installation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Installation</title>
-    <meta name="harper-update-version" content="2026-05-01-install-v8" />
+    <meta name="harper-update-version" content="2026-05-05-install-adx" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -90,6 +90,7 @@ SUPABASE_ALLOWED_PROVIDERS=github</code></pre>
                 <p><code>/strategy</code> shows the current execution strategy. Use <code>/strategy auto</code>, <code>/strategy grounded</code>, <code>/strategy deterministic</code>, or <code>/strategy model</code> to switch the live chat session without leaving the conversation.</p>
                 <p><code>/update</code> reports the current cached update state from the chat header. Use <code>/update check</code> to re-run the release-manifest check and refresh that header status. The same action is also available in <code>Settings -&gt; Execution Policy -&gt; Updates</code>. Harper uses the default GitHub release manifest automatically, and <code>HARPER_UPDATE_MANIFEST_URL</code> can override that source when needed.</p>
                 <p><code>/agents</code> reports AGENTS context status for the current TUI session. Use <code>/agents on</code> or <code>/agents off</code> to enable or disable AGENTS context resolution in the UI, and <code>/agents status</code> to inspect the current setting.</p>
+                <p>Azure Data Explorer queries use the <code>adx_query</code> tool. Set <code>HARPER_ADX_CLUSTER_URL</code>, <code>HARPER_ADX_DATABASE</code>, and <code>HARPER_ADX_TENANT_ID</code>, then ask Harper for a read-only KQL query. Local use signs in with Microsoft device-code login. Server or CI use can also set <code>HARPER_ADX_CLIENT_ID</code> and <code>HARPER_ADX_CLIENT_SECRET</code>. Harper asks for approval before sending the query and rejects management commands that start with <code>.</code>.</p>
                 <p>When sign-in succeeds, Harper stores the local TUI auth session in the OS credential store (macOS Keychain, Linux keyring, or Windows Credential Manager) instead of writing the active tokens to a JSON file under your home directory.</p>
                 <p>Harper also exposes the same auth state through <code>Settings -&gt; Profile</code>. When signed out, that screen offers login actions for the configured providers. When signed in, it shows the current account, plus <code>Logout</code> and <code>Refresh Session</code>.</p>
                 <p>When you are signed in, Harper scopes session data to that account. <code>History</code>, <code>Export</code>, and <code>Statistics</code> all reflect the signed-in user only. When you are not signed in, those screens continue to use local-only data.</p>

--- a/website/nav-updates.json
+++ b/website/nav-updates.json
@@ -1,7 +1,7 @@
 {
   "index.html": "2026-05-01-home-v2",
-  "docs.html": "2026-05-01-docs-v2",
-  "installation.html": "2026-05-01-install-v8",
+  "docs.html": "2026-05-05-docs-adx",
+  "installation.html": "2026-05-05-install-adx",
   "troubleshooting.html": "2026-05-01-troubleshooting-v2",
   "blog.html": "2026-05-01-blog-v6",
   "changelog.html": "2026-04-28-changelog",


### PR DESCRIPTION
## Changes

- Added the Azure Data Explorer `adx_query` tool for read-only KQL queries:
  - Uses `HARPER_ADX_CLUSTER_URL`, `HARPER_ADX_DATABASE`, and `HARPER_ADX_TENANT_ID`.
  - Uses Microsoft device-code login for local interactive auth.
  - Supports optional `HARPER_ADX_CLIENT_ID` and `HARPER_ADX_CLIENT_SECRET` for service-principal auth.
- Added ADX token handling:
  - Caches device-code tokens under the user cache directory until expiry.
  - Bypasses cached device tokens when service-principal credentials are configured.
- Updated tool behavior for reliability with local models:
  - Missing `query` returns user-facing guidance instead of crashing batch.
  - ADX query results are terminal for the turn to avoid duplicate external queries and repeated approvals.
- Updated docs, env examples, and website copy for ADX configuration and validation.

## Validation

- `cargo test -p harper-core adx -- --nocapture`
- `cargo check -p harper-core --all-targets`
- `git diff --check`
- Live `harper-batch` query against Azure Data Explorer:
  - `print hello="world"`
  - verified one approval prompt, one `adx_query` execution, and result `hello=world`
- Browser ADX web UI query:
  - `print hello="world"`
  - verified the same result shape in `MyDatabase`
- Azure CLI token plus ADX REST query:
  - `print source="az-cli", marker="from-az-rest", ts=now()`