### PR TITLE
[ci] set homebrew tap workflow git author

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -81,6 +81,8 @@ jobs:
           version="${{ steps.tarball.outputs.version }}"
           branch="automation/homebrew-tap-${version}"
           git -C homebrew-tap checkout -B "$branch"
+          git -C homebrew-tap config user.name "github-actions[bot]"
+          git -C homebrew-tap config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git -C homebrew-tap add "$FORMULA_PATH"
           git -C homebrew-tap commit -m "build(tap): bump harper-ai ${version}"
           echo "branch=$branch" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Changes

- Configured the cloned Homebrew tap repository with the GitHub Actions bot identity before committing formula updates.
- Fixes the tap update workflow failure where `git commit` exits with `Author identity unknown`.

## Validation

- `python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/update-homebrew-tap.yml").read_text()); print("yaml ok")'`\n- push hook checks: trim whitespace, end-of-file, YAML, merge conflicts, fmt, clippy, cargo check\n- manual workflow failure review from `https://github.com/harpertoken/harper/actions/runs/25403435743`