### PR TITLE
[deps] refresh runtime and mcp dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5116,9 +5116,9 @@ dependencies = [
 
 [[package]]
 name = "turul-mcp-json-rpc-server"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7a0b978098c6394e4e467a36bf493563614f9a068dd14e126c15c969ba3be4"
+checksum = "2dfb216e88b096da2a69872b14e38e12ab7e0347b591912875a98a12c1e2760a"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,9 +5092,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turul-mcp-client"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c7c081876ab260d8b9439cf402f1a49868a299764cc04e13b6db62c2a8dbb3"
+checksum = "86b4d5b91a0946dc2dd4b3c3fa032f86451172ad4b5282605918fd3c26221725"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5116,9 +5116,9 @@ dependencies = [
 
 [[package]]
 name = "turul-mcp-json-rpc-server"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7a0b978098c6394e4e467a36bf493563614f9a068dd14e126c15c969ba3be4"
+checksum = "2dfb216e88b096da2a69872b14e38e12ab7e0347b591912875a98a12c1e2760a"
 dependencies = [
  "async-trait",
  "futures",
@@ -5129,18 +5129,18 @@ dependencies = [
 
 [[package]]
 name = "turul-mcp-protocol"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b80d8c60f73d2a98db91abc1d166d1f375a426f1d5ecd9e888b7b171105a9c7"
+checksum = "30b36579e6dbf42094bedae6b63e1367eb649a28d42b482fd82f3b7611e2fc89"
 dependencies = [
  "turul-mcp-protocol-2025-11-25",
 ]
 
 [[package]]
 name = "turul-mcp-protocol-2025-11-25"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20dbbe6b8d1c62ad8cf294ba2b526fb49203b327016590b9036bbf08691ef97c"
+checksum = "73a21bd1f85d218efabc91867868473aedd50755917363c25d21df808f8b3c29"
 dependencies = [
  "async-trait",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4895,9 +4895,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rusqlite = { version = "0.37.0", features = ["bundled"] }
 rand = "0.10.1"
 ratatui = "0.30"
 syntect = { version = "5.3", features = ["parsing", "html"] }
-tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 wait-timeout = "0.2"
 num_cpus = "1.16"
 serde_json = "1.0.140"

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -31,7 +31,7 @@ colored = "3.0.0"
 config = "0.15.19"
 dotenvy = "0.15"
 dirs = "6.0"
-turul-mcp-client = "0.3.37"
+turul-mcp-client = "0.3.38"
 reqwest = { version = "0.12.20", features = ["json", "native-tls"] }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/lib/harper-core/Cargo.toml
+++ b/lib/harper-core/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = { version = "0.12.20", features = ["json", "native-tls"] }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "process", "signal", "time"] }
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "process", "signal", "time"] }
 tower = "0.5"
 futures-util = "0.3"
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/lib/harper-mcp-server/Cargo.toml
+++ b/lib/harper-mcp-server/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/harpertoken/harper"
 homepage = "https://github.com/harpertoken/harper"
 
 [dependencies]
-turul-mcp-json-rpc-server = "0.3.37"
+turul-mcp-json-rpc-server = "0.3.38"
 tokio = { version = "^1.48", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/lib/harper-mcp-server/Cargo.toml
+++ b/lib/harper-mcp-server/Cargo.toml
@@ -24,7 +24,7 @@ homepage = "https://github.com/harpertoken/harper"
 
 [dependencies]
 turul-mcp-json-rpc-server = "0.3.37"
-tokio = { version = "^1.48", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "^1.52", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 axum = "0.8"

--- a/lib/harper-sandbox/Cargo.toml
+++ b/lib/harper-sandbox/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
-tokio = { version = "1.48", features = ["process", "rt", "time", "io-util", "sync"] }
+tokio = { version = "1.52", features = ["process", "rt", "time", "io-util", "sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "0.5"

--- a/lib/harper-ui/Cargo.toml
+++ b/lib/harper-ui/Cargo.toml
@@ -42,7 +42,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }
-turul-mcp-client = "0.3.37"
+turul-mcp-client = "0.3.38"
 uuid = { version = "1.17.0", features = ["v4"] }
 async-trait = "0.1"
 

--- a/lib/harper-ui/Cargo.toml
+++ b/lib/harper-ui/Cargo.toml
@@ -41,7 +41,7 @@ rusqlite = { version = "0.37.0", features = ["bundled"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }
 turul-mcp-client = "0.3.37"
 uuid = { version = "1.17.0", features = ["v4"] }
 async-trait = "0.1"


### PR DESCRIPTION
## Changes

- Combined dependency updates from Dependabot PRs `#379`, `#380`, `#381`, and `#382` into one branch.
- Updated runtime networking dependencies:
  - `h2` from `0.4.13` to `0.4.14`
  - `tokio` from `1.52.1` to `1.52.2`
- Updated MCP dependencies together so the Turul stack stays aligned:
  - `turul-mcp-client` from `0.3.37` to `0.3.38`
  - `turul-mcp-json-rpc-server` from `0.3.37` to `0.3.38`
- Resolved manifest overlap by keeping Tokio on the workspace `1.52` line while applying the Turul `0.3.38` updates.

## Closes

Closes #379.
Closes #380.
Closes #381.
Closes #382.

## Validation

- `cargo check --workspace`
- push hook checks: trim whitespace, end-of-file, YAML, merge conflicts, fmt, clippy, cargo check