### PR TITLE
[ci] authenticate homebrew tap push

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -94,7 +94,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git -C homebrew-tap push --force-with-lease origin "$branch"
+          git -C homebrew-tap push \
+            --force-with-lease \
+            "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" \
+            "$branch"
 
       - name: Open tap PR
         if: steps.diff.outputs.changed == 'true'


### PR DESCRIPTION
## Changes

- Updated `update-homebrew-tap.yml` so the tap branch push uses the `HOMEBREW_TAP_TOKEN` through an authenticated HTTPS remote.
- Fixes the `Push tap branch` failure from `https://github.com/harpertoken/harper/actions/runs/25404149050/job/74510976898`, where plain `git push origin` had no Git credentials.

## Validation

- `python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/update-homebrew-tap.yml").read_text()); print("yaml ok")'`\n- push hook checks: trim whitespace, end-of-file, YAML, merge conflicts, fmt, clippy, cargo check