### PR TITLE
[feat] introduce native harper commands

### DIFF
--- a/PLANNER_NEXT_STEPS.md
+++ b/PLANNER_NEXT_STEPS.md
@@ -1,48 +1,121 @@
-# Harper Planner Next Steps
+# Harper Native Shell
 
-This file captured the remaining planner/runtime polish after planning, jobs, follow-up handling, scoped `AGENTS.md`, cross-process delivery, deterministic repo routing, structured codebase helpers, and the persisted authoring-manager workflow were in place.
+This file tracks the native shell interaction model.
 
-## Current State
+The goal is to give Harper a first-class command surface for Harper concepts. Native shell commands make common Harper actions explicit, scriptable, and consistent across the TUI and batch mode.
 
-The previously tracked planner/runtime items are now implemented:
+This is not a replacement for `bash`, `zsh`, PowerShell, or Harper's existing controlled command runner. Harper should continue to delegate operating-system commands through the existing safe execution path.
 
-1. **Live command output polish**
-   - Command output falls back to planner/runtime job output when the live stream is absent.
-   - The command-output panel shows clearer truncation and richer status labels.
+## Product Direction
 
-2. **Semantic authoring depth**
-   - The grounded semantic graph now carries stronger type-alias and trait-implementation links.
-   - Multi-file authoring candidates are decomposed into primary and supporting edit files.
+When users run Harper, the input surface should behave like a Harper command shell:
 
-3. **Planner follow-up history polish**
-   - `PlanRuntime` now persists bounded follow-up history.
-   - The plan panel shows recent follow-up entries without replacing the active follow-up model.
+```text
+harper> ask "inspect the update flow"
+harper> plan show
+harper> plan done 2
+harper> session list
+harper> session open 3
+harper> history show 3
+harper> auth status
+harper> update check
+harper> config show
+harper> run cargo test -p harper-core
+```
 
-## Count
+The shell should support Harper-native commands directly and reserve arbitrary process execution for an explicit `run` command.
 
-There are **0 remaining items** in this specific planner/runtime polish pass.
+## Scope
 
-## What This File Is Now
+The native shell covers Harper's own concepts first:
 
-This file is now a completion marker for the planner/runtime polish workstream, not an active backlog.
+- chat and model interaction
+- planner state
+- sessions and history
+- configuration
+- authentication
+- updates
+- controlled command execution
+- diagnostics/status
 
-## If New Planner Work Starts
+The same command parser is reused from the TUI and batch mode.
 
-Open a new focused plan instead of appending more unrelated items here. The next likely planner-adjacent work would be one of:
+## Commands
 
-1. richer planner browsing UX
-2. deeper authoring sequencing
-3. planner/runtime observability
+The first typed command set is:
 
-## Final Completed `update_plan` Shape
+```text
+ask "question or instruction"
+plan show
+plan list
+plan add "Inspect current planner state"
+plan done 1
+plan start 2
+plan block 3 "Waiting on CI"
+plan clear
+session list
+session ls
+session open 3
+session show 3
+history show
+history list
+history show 3
+auth status
+auth login
+auth login github
+auth logout
+update check
+update apply
+config show
+config set key value
+status
+run cargo test -p harper-core
+help
+```
+
+These commands map to existing Harper services wherever possible. Avoid adding parallel state or duplicate business logic.
+
+## Implementation
+
+The first shell slice is implemented:
+
+- shared typed parser and dispatcher
+- TUI command routing
+- batch command routing
+- explicit `run ...` delegation through the existing safe command runner
+- planner commands for show, add, start, done, block, and clear
+- service commands for session list, session show, session open, history show, auth status, auth logout in the TUI, config show, config set for execution policy fields, status, help, update check, and explicit update apply guidance
+- safe aliases for `plan list`, `plan ls`, `session ls`, and `history list`
+- focused parser and planner storage tests
+- documented release boundary: Harper-native commands are not a Unix-compatible shell
+
+## Non-Goals
+
+- Do not implement a Unix-compatible shell.
+- Do not support pipes, redirects, aliases, glob expansion, job control, or process substitution.
+- Do not make arbitrary process execution implicit.
+- Do not bypass Harper's existing command safety and approval model.
+- Do not replace `update_plan`; the model should still use it for multi-step work.
+- Do not create duplicate storage models for sessions, plans, config, or auth.
+
+## Completed `update_plan` Shape
 
 ```json
 {
-  "explanation": "Planner/runtime polish is complete for the originally scoped workstream.",
+  "explanation": "Implemented the first Harper-native shell slice.",
   "items": [
-    { "step": "Polish live command output", "status": "completed" },
-    { "step": "Deepen semantic authoring context", "status": "completed" },
-    { "step": "Improve follow-up history UX", "status": "completed" }
+    { "step": "Define native shell grammar", "status": "completed" },
+    { "step": "Add typed command parser", "status": "completed" },
+    { "step": "Add command dispatcher", "status": "completed" },
+    { "step": "Integrate shell with TUI input", "status": "completed" },
+    { "step": "Integrate shell with batch mode", "status": "completed" },
+    { "step": "Add planner shell actions", "status": "completed" },
+    { "step": "Add core service actions", "status": "completed" },
+    { "step": "Add native shell tests", "status": "completed" }
   ]
 }
 ```
+
+## Release Note Boundary
+
+Add release notes only when this slice ships in a release. The release note should describe the feature as Harper-native command handling, not a complete Unix shell.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The goal isn’t to replace the shell with chat. It’s to make command-driven w
   <img src="https://raw.githubusercontent.com/harpertoken/harper/main/website/harper.png?v=3" width="600" alt="Harper interface" style="border-radius: 14px;" />
 </div>
 
-Harper works with OpenAI, SambaNova, Gemini, and Cerebras, or fully offline using Ollama. It keeps session history, supports planner-style task tracking, and exposes an optional HTTP review API for editor integrations.
+Harper works with OpenAI, SambaNova, Gemini, and Cerebras, or fully offline using Ollama. It keeps session history, tracks plans, supports native TUI/batch commands, and provides an optional HTTP review API.
 
 To get started, clone the repo, copy the env file, and run the TUI:
 
@@ -19,7 +19,7 @@ cp .env.example .env
 cargo harper
 ```
 
-You can use Harper to inspect files, patch code, run commands, and manage multi-step work without losing track of what’s happening. Commands stay explicit, risky actions can require approval, and every session keeps both an audit log and active plan state. If you want to plug it into an editor workflow, the HTTP review API is there for that.
+You can use Harper to inspect files, patch code, run commands, and manage multi-step work. Native commands cover plans, sessions, config, and updates. OS commands stay explicit through `run ...`, with approvals and audit logs where configured.
 
 Configuration is straightforward. Copy `config/local.example.toml` to `config/local.toml` for local non-secret settings like provider choice, model, UI widgets, and server port, and keep real secrets in `.env`. Sandboxed execution is supported on Linux (bubblewrap) and macOS (sandbox-exec), so commands can run in isolation when configured.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,13 @@
 # Harper
 
-Harper is a terminal-first AI agent for code and shell work. It keeps command execution visible, supports approval-gated workflows, tracks multi-step work explicitly, and maintains an audit trail instead of hiding what it did.
+Harper is a terminal-first AI agent for code and shell work. It keeps command execution visible, supports approval-gated workflows, tracks multi-step work explicitly, and provides a native command shell for Harper concepts instead of hiding what it did.
 
 ## Features
 
 - **Visible command execution**: Harper shows the concrete commands it plans to run
 - **Approval gates**: Sensitive or higher-risk operations can require confirmation
 - **Session and plan tracking**: Conversations, titles, audit logs, and plans persist with the session
+- **Native shell commands**: Use commands such as `plan show`, `session list`, `config show`, `update check`, and explicit `run ...`
 - **Provider support**: Works with OpenAI, Gemini, SambaNova, Cerebras, and Ollama
 - **TUI and batch flows**: Use the interactive terminal UI or verify behavior headlessly with `harper-batch`
 
@@ -23,7 +24,7 @@ New to Harper? Start here:
 Learn about Harper's features in detail:
 
 - [About the Binary](user-guide/about.md) - Runtime model, install source behavior, and binary overview
-- [Chat Interface](user-guide/chat.md) - Commands, routing, follow-ups, and update checks
+- [Chat Interface](user-guide/chat.md) - Native commands, slash commands, routing, follow-ups, and update checks
 - [Clipboard Features](user-guide/clipboard.md) - Working with images and text from the terminal
 - [Configuration](user-guide/configuration.md) - Complete configuration options
 - [Troubleshooting](user-guide/troubleshooting.md) - Common issues and validation paths

--- a/docs/user-guide/chat.md
+++ b/docs/user-guide/chat.md
@@ -12,7 +12,51 @@ After installation, run Harper from your terminal:
 
 You will see a welcome message followed by the chat prompt where you can type your messages.
 
-## Chat Commands
+## Native Shell Commands
+
+Harper has a native command shell for Harper concepts. These commands can be entered directly in the TUI input or passed to `harper-batch` with `--prompt`.
+
+```text
+ask "question or instruction"
+plan show
+plan list
+plan add "Inspect current planner state"
+plan done 1
+plan start 2
+plan block 3 "Waiting on CI"
+plan clear
+session list
+session ls
+session open 3
+session show 3
+history show
+history list
+history show 3
+auth status
+auth login
+auth login github
+auth logout
+update check
+update apply
+config show
+config set approval|strategy|sandbox|retries <value>
+status
+run cargo test -p harper-core
+help
+```
+
+Use `run ...` for operating-system commands. Harper routes that path through the existing command runner, approval policy, sandbox policy, and audit logging. Other native commands operate on Harper state such as the current plan, session history, auth state, update status, and execution policy.
+
+This is Harper-native command handling, not a Unix-compatible shell. Pipes, redirects, glob expansion, aliases beyond the documented Harper aliases, job control, and process substitution are intentionally not part of this command surface.
+
+For example:
+
+```bash
+cargo run -p harper-ui --bin harper-batch -- --prompt "plan add \"Inspect update flow\"" --prompt "plan show"
+cargo run -p harper-ui --bin harper-batch -- --prompt "session list" --prompt "config show"
+```
+
+## Slash Commands
 
 Harper supports slash commands for various operations. All commands start with `/`:
 
@@ -53,6 +97,8 @@ Available commands:
 ```
 
 Typing `/` in the TUI opens the slash-command list. Use `↑` / `↓` or `Tab` to move through suggestions, then keep typing or submit the selected command from the normal message input.
+
+Native shell commands can also use a leading slash, so `/plan show`, `/session list`, `/history show`, `/config show`, `/auth login`, `/status`, and `/run pwd` are accepted from the same input surface.
 
 `/update` shows the current cached update status from the header widget. Use `/update check` to re-run the manifest-backed update check on demand. The same refresh is also available from `Settings -> Execution Policy -> Updates`. Harper now checks the default GitHub release manifest automatically, and `HARPER_UPDATE_MANIFEST_URL` can override that source when needed. Published direct-install artifacts are verified with both a SHA-256 checksum and a detached signature before Harper replaces the local binary.
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -57,17 +57,12 @@ brew upgrade harpertoken/tap/harper-ai
    cd harper
    ```
 
-2. Build the release version:
+2. Build Harper:
    ```bash
    cargo build --release
    ```
 
-3. Build Harper:
-   ```bash
-   cargo build --release
-   ```
-
-4. Run Harper:
+3. Run Harper:
    ```bash
    # Option 1: Using cargo
    cargo run -p harper-ui --bin harper

--- a/lib/harper-core/src/core/mod.rs
+++ b/lib/harper-core/src/core/mod.rs
@@ -24,6 +24,7 @@ pub mod error;
 pub mod io_traits;
 pub mod llm_client;
 pub mod models;
+pub mod native_shell;
 pub mod plan;
 pub mod plan_events;
 

--- a/lib/harper-core/src/core/native_shell.rs
+++ b/lib/harper-core/src/core/native_shell.rs
@@ -1,0 +1,1033 @@
+// Copyright 2026 harpertoken
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::core::error::{HarperError, HarperResult};
+use crate::core::plan::{PlanItem, PlanState, PlanStepStatus};
+use rusqlite::Connection;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeShellCommand {
+    Ask(String),
+    Auth(AuthShellCommand),
+    Config(ConfigShellCommand),
+    Help,
+    History(HistoryShellCommand),
+    Session(SessionShellCommand),
+    Status,
+    Update(UpdateShellCommand),
+    Run(String),
+    Plan(PlanShellCommand),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NativeShellContext {
+    pub auth: Option<AuthShellContext>,
+    pub config: Option<ConfigShellContext>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthShellContext {
+    pub status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigShellContext {
+    pub provider: String,
+    pub model: String,
+    pub base_url: String,
+    pub database_path: String,
+    pub approval: String,
+    pub strategy: String,
+    pub sandbox: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthShellCommand {
+    Login { provider: String },
+    Status,
+    Logout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigShellCommand {
+    Show,
+    Set { key: String, value: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HistoryShellCommand {
+    Show(Option<String>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionShellCommand {
+    List,
+    Show(String),
+    Open(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateShellCommand {
+    Apply,
+    Check,
+    Status,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanShellCommand {
+    Show,
+    Add(String),
+    Done(usize),
+    Start(usize),
+    Block {
+        index: usize,
+        reason: Option<String>,
+    },
+    Clear,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NativeShellOutcome {
+    Handled(String),
+    Ask(String),
+    Run(String),
+    UpdateCheck,
+    UpdateApply,
+    UpdateStatus,
+    ConfigSet { key: String, value: String },
+    AuthLogin { provider: String },
+    AuthLogout,
+    OpenSession { target: String, preview: bool },
+}
+
+pub fn parse_native_shell_command(input: &str) -> HarperResult<Option<NativeShellCommand>> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let has_slash = trimmed.starts_with('/');
+    let normalized = trimmed.strip_prefix('/').unwrap_or(trimmed);
+    let tokens = tokenize(normalized)?;
+    let Some(command) = tokens.first().map(|token| token.as_str()) else {
+        return Ok(None);
+    };
+
+    match command {
+        "help" if has_slash || tokens.len() == 1 => Ok(Some(NativeShellCommand::Help)),
+        "status" if has_slash || tokens.len() == 1 => Ok(Some(NativeShellCommand::Status)),
+        "auth" => parse_auth_command(&tokens, has_slash)
+            .map(|command| command.map(NativeShellCommand::Auth)),
+        "config" => parse_config_command(&tokens, has_slash)
+            .map(|command| command.map(NativeShellCommand::Config)),
+        "history" => parse_history_command(&tokens, has_slash)
+            .map(|command| command.map(NativeShellCommand::History)),
+        "session" | "sessions" => parse_session_command(&tokens, has_slash)
+            .map(|command| command.map(NativeShellCommand::Session)),
+        "update" => parse_update_command(&tokens, has_slash)
+            .map(|command| command.map(NativeShellCommand::Update)),
+        "ask" if has_slash || looks_like_quoted_command_arg(normalized, "ask") => {
+            let prompt = rest_after_command(normalized, "ask");
+            if prompt.is_empty() {
+                return Err(HarperError::Validation(
+                    "ask requires a message".to_string(),
+                ));
+            }
+            Ok(Some(NativeShellCommand::Ask(unquote_if_wrapped(prompt))))
+        }
+        "run" if has_slash || looks_like_shell_command_arg(normalized, "run") => {
+            let command = rest_after_command(normalized, "run");
+            if command.is_empty() {
+                return Err(HarperError::Validation(
+                    "run requires a command".to_string(),
+                ));
+            }
+            Ok(Some(NativeShellCommand::Run(command.to_string())))
+        }
+        "plan" => parse_plan_command(&tokens, has_slash)
+            .map(|command| command.map(NativeShellCommand::Plan)),
+        _ => Ok(None),
+    }
+}
+
+pub fn execute_native_shell_command(
+    conn: &Connection,
+    session_id: &str,
+    command: NativeShellCommand,
+) -> HarperResult<NativeShellOutcome> {
+    execute_native_shell_command_with_context(
+        conn,
+        session_id,
+        command,
+        &NativeShellContext::default(),
+    )
+}
+
+pub fn execute_native_shell_command_with_context(
+    conn: &Connection,
+    session_id: &str,
+    command: NativeShellCommand,
+    context: &NativeShellContext,
+) -> HarperResult<NativeShellOutcome> {
+    match command {
+        NativeShellCommand::Ask(prompt) => Ok(NativeShellOutcome::Ask(prompt)),
+        NativeShellCommand::Run(command) => Ok(NativeShellOutcome::Run(command)),
+        NativeShellCommand::Config(ConfigShellCommand::Set { key, value }) => {
+            Ok(NativeShellOutcome::ConfigSet { key, value })
+        }
+        NativeShellCommand::Update(UpdateShellCommand::Apply) => {
+            Ok(NativeShellOutcome::UpdateApply)
+        }
+        NativeShellCommand::Update(UpdateShellCommand::Check) => {
+            Ok(NativeShellOutcome::UpdateCheck)
+        }
+        NativeShellCommand::Update(UpdateShellCommand::Status) => {
+            Ok(NativeShellOutcome::UpdateStatus)
+        }
+        NativeShellCommand::Auth(AuthShellCommand::Login { provider }) => {
+            Ok(NativeShellOutcome::AuthLogin { provider })
+        }
+        NativeShellCommand::Auth(AuthShellCommand::Logout) => Ok(NativeShellOutcome::AuthLogout),
+        NativeShellCommand::Auth(AuthShellCommand::Status) => Ok(NativeShellOutcome::Handled(
+            context
+                .auth
+                .as_ref()
+                .map(|auth| format!("Auth status: {}", auth.status))
+                .unwrap_or_else(|| "Auth status: not signed in".to_string()),
+        )),
+        NativeShellCommand::Config(ConfigShellCommand::Show) => Ok(NativeShellOutcome::Handled(
+            format_config_context(context.config.as_ref()),
+        )),
+        NativeShellCommand::History(HistoryShellCommand::Show(target)) => {
+            let target_session_id = match target {
+                Some(target) => resolve_session_target(conn, &target)?,
+                None => session_id.to_string(),
+            };
+            Ok(NativeShellOutcome::Handled(format_history(
+                conn,
+                &target_session_id,
+            )?))
+        }
+        NativeShellCommand::Session(SessionShellCommand::List) => {
+            Ok(NativeShellOutcome::Handled(format_sessions(conn)?))
+        }
+        NativeShellCommand::Session(SessionShellCommand::Show(target)) => {
+            Ok(NativeShellOutcome::OpenSession {
+                target,
+                preview: true,
+            })
+        }
+        NativeShellCommand::Session(SessionShellCommand::Open(target)) => {
+            Ok(NativeShellOutcome::OpenSession {
+                target,
+                preview: false,
+            })
+        }
+        NativeShellCommand::Help => Ok(NativeShellOutcome::Handled(help_text())),
+        NativeShellCommand::Status => Ok(NativeShellOutcome::Handled(
+            "Harper native shell is available. Use help for commands.".to_string(),
+        )),
+        NativeShellCommand::Plan(command) => {
+            execute_plan_command(conn, session_id, command).map(NativeShellOutcome::Handled)
+        }
+    }
+}
+
+fn parse_auth_command(tokens: &[String], strict: bool) -> HarperResult<Option<AuthShellCommand>> {
+    match tokens
+        .get(1)
+        .map(|token| token.as_str())
+        .unwrap_or("status")
+    {
+        "login" => Ok(Some(AuthShellCommand::Login {
+            provider: tokens
+                .get(2)
+                .cloned()
+                .unwrap_or_else(|| "github".to_string()),
+        })),
+        "status" => Ok(Some(AuthShellCommand::Status)),
+        "logout" => Ok(Some(AuthShellCommand::Logout)),
+        _ if !strict => Ok(None),
+        subcommand => Err(HarperError::Validation(format!(
+            "unknown auth command '{}'",
+            subcommand
+        ))),
+    }
+}
+
+fn parse_config_command(
+    tokens: &[String],
+    strict: bool,
+) -> HarperResult<Option<ConfigShellCommand>> {
+    match tokens.get(1).map(|token| token.as_str()).unwrap_or("show") {
+        "show" => Ok(Some(ConfigShellCommand::Show)),
+        "set" => {
+            let key = tokens
+                .get(2)
+                .cloned()
+                .ok_or_else(|| HarperError::Validation("config set requires a key".to_string()))?;
+            let value = join_args(&tokens[3..]);
+            if value.is_empty() {
+                return Err(HarperError::Validation(
+                    "config set requires a value".to_string(),
+                ));
+            }
+            Ok(Some(ConfigShellCommand::Set { key, value }))
+        }
+        _ if !strict => Ok(None),
+        subcommand => Err(HarperError::Validation(format!(
+            "unknown config command '{}'",
+            subcommand
+        ))),
+    }
+}
+
+fn parse_history_command(
+    tokens: &[String],
+    strict: bool,
+) -> HarperResult<Option<HistoryShellCommand>> {
+    match tokens.get(1).map(|token| token.as_str()).unwrap_or("show") {
+        "show" | "list" => Ok(Some(HistoryShellCommand::Show(tokens.get(2).cloned()))),
+        _ if !strict => Ok(None),
+        subcommand => Err(HarperError::Validation(format!(
+            "unknown history command '{}'",
+            subcommand
+        ))),
+    }
+}
+
+fn parse_session_command(
+    tokens: &[String],
+    strict: bool,
+) -> HarperResult<Option<SessionShellCommand>> {
+    match tokens.get(1).map(|token| token.as_str()).unwrap_or("list") {
+        "list" | "ls" => Ok(Some(SessionShellCommand::List)),
+        "show" | "view" => {
+            let target = tokens.get(2).cloned().ok_or_else(|| {
+                HarperError::Validation("session show requires a session number or id".to_string())
+            })?;
+            Ok(Some(SessionShellCommand::Show(target)))
+        }
+        "open" => {
+            let target = tokens.get(2).cloned().ok_or_else(|| {
+                HarperError::Validation("session open requires a session number or id".to_string())
+            })?;
+            Ok(Some(SessionShellCommand::Open(target)))
+        }
+        _ if !strict => Ok(None),
+        subcommand => Err(HarperError::Validation(format!(
+            "unknown session command '{}'",
+            subcommand
+        ))),
+    }
+}
+
+fn parse_update_command(
+    tokens: &[String],
+    strict: bool,
+) -> HarperResult<Option<UpdateShellCommand>> {
+    match tokens
+        .get(1)
+        .map(|token| token.as_str())
+        .unwrap_or("status")
+    {
+        "apply" => Ok(Some(UpdateShellCommand::Apply)),
+        "check" => Ok(Some(UpdateShellCommand::Check)),
+        "status" => Ok(Some(UpdateShellCommand::Status)),
+        _ if !strict => Ok(None),
+        subcommand => Err(HarperError::Validation(format!(
+            "unknown update command '{}'",
+            subcommand
+        ))),
+    }
+}
+
+fn parse_plan_command(tokens: &[String], strict: bool) -> HarperResult<Option<PlanShellCommand>> {
+    let Some(subcommand) = tokens.get(1).map(|token| token.as_str()) else {
+        return Ok(Some(PlanShellCommand::Show));
+    };
+
+    let command = match subcommand {
+        "show" | "list" | "ls" => PlanShellCommand::Show,
+        "add" => {
+            let step = join_args(&tokens[2..]);
+            if step.trim().is_empty() {
+                return Err(HarperError::Validation(
+                    "plan add requires a step".to_string(),
+                ));
+            }
+            PlanShellCommand::Add(step)
+        }
+        "done" => PlanShellCommand::Done(parse_one_based_index(tokens.get(2), "plan done")?),
+        "start" => PlanShellCommand::Start(parse_one_based_index(tokens.get(2), "plan start")?),
+        "block" => {
+            let index = parse_one_based_index(tokens.get(2), "plan block")?;
+            let reason = (!tokens[3..].is_empty()).then(|| join_args(&tokens[3..]));
+            PlanShellCommand::Block { index, reason }
+        }
+        "clear" => PlanShellCommand::Clear,
+        _ if !strict => return Ok(None),
+        _ => {
+            return Err(HarperError::Validation(format!(
+                "unknown plan command '{}'",
+                subcommand
+            )));
+        }
+    };
+    Ok(Some(command))
+}
+
+fn execute_plan_command(
+    conn: &Connection,
+    session_id: &str,
+    command: PlanShellCommand,
+) -> HarperResult<String> {
+    match command {
+        PlanShellCommand::Show => Ok(format_plan_state(
+            crate::memory::storage::load_plan_state(conn, session_id)?.as_ref(),
+        )),
+        PlanShellCommand::Add(step) => {
+            let mut plan = crate::memory::storage::load_plan_state(conn, session_id)?
+                .unwrap_or_else(|| PlanState {
+                    explanation: Some("Updated from Harper native shell".to_string()),
+                    items: Vec::new(),
+                    runtime: None,
+                    updated_at: None,
+                });
+            plan.items.push(PlanItem {
+                step,
+                status: PlanStepStatus::Pending,
+                job_id: None,
+            });
+            crate::memory::storage::save_plan_state(conn, session_id, &plan)?;
+            Ok(format!("Plan updated: {} steps.", plan.items.len()))
+        }
+        PlanShellCommand::Done(index) => {
+            ensure_plan_step_exists(conn, session_id, index)?;
+            crate::tools::plan::set_plan_step_status(
+                conn,
+                session_id,
+                index,
+                PlanStepStatus::Completed,
+            )?;
+            Ok(format!("Plan step {} marked completed.", index + 1))
+        }
+        PlanShellCommand::Start(index) => {
+            ensure_plan_step_exists(conn, session_id, index)?;
+            crate::tools::plan::set_plan_step_status(
+                conn,
+                session_id,
+                index,
+                PlanStepStatus::InProgress,
+            )?;
+            Ok(format!("Plan step {} marked in progress.", index + 1))
+        }
+        PlanShellCommand::Block { index, reason } => {
+            ensure_plan_step_exists(conn, session_id, index)?;
+            crate::tools::plan::set_plan_step_status(
+                conn,
+                session_id,
+                index,
+                PlanStepStatus::Blocked,
+            )?;
+            match reason {
+                Some(reason) => Ok(format!("Plan step {} blocked: {}", index + 1, reason)),
+                None => Ok(format!("Plan step {} marked blocked.", index + 1)),
+            }
+        }
+        PlanShellCommand::Clear => {
+            crate::tools::plan::clear_plan_state(conn, session_id)?;
+            Ok("Plan cleared.".to_string())
+        }
+    }
+}
+
+fn ensure_plan_step_exists(conn: &Connection, session_id: &str, index: usize) -> HarperResult<()> {
+    let Some(plan) = crate::memory::storage::load_plan_state(conn, session_id)? else {
+        return Err(HarperError::Validation("No active plan.".to_string()));
+    };
+    if index >= plan.items.len() {
+        return Err(HarperError::Validation(format!(
+            "plan step {} is out of bounds",
+            index + 1
+        )));
+    }
+    Ok(())
+}
+
+fn format_plan_state(plan: Option<&PlanState>) -> String {
+    let Some(plan) = plan else {
+        return "No active plan.".to_string();
+    };
+    if plan.items.is_empty() {
+        return "Plan is empty.".to_string();
+    }
+
+    let mut lines = Vec::new();
+    if let Some(explanation) = plan
+        .explanation
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(explanation.to_string());
+    }
+    for (index, item) in plan.items.iter().enumerate() {
+        lines.push(format!(
+            "{}. [{}] {}",
+            index + 1,
+            status_label(item.status),
+            item.step
+        ));
+    }
+    lines.join("\n")
+}
+
+fn format_sessions(conn: &Connection) -> HarperResult<String> {
+    let sessions =
+        crate::memory::session_service::SessionService::new(conn).list_sessions_data()?;
+    if sessions.is_empty() {
+        return Ok("No previous sessions found.".to_string());
+    }
+
+    let mut lines = vec!["Sessions:".to_string()];
+    for (index, session) in sessions.iter().take(20).enumerate() {
+        let title = session
+            .title
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(&session.id);
+        lines.push(format!("{}. {} ({})", index + 1, title, session.created_at));
+    }
+    if sessions.len() > 20 {
+        lines.push(format!("{} more sessions", sessions.len() - 20));
+    }
+    Ok(lines.join("\n"))
+}
+
+pub fn resolve_session_target(conn: &Connection, target: &str) -> HarperResult<String> {
+    let trimmed = target.trim();
+    if trimmed.is_empty() {
+        return Err(HarperError::Validation(
+            "session target cannot be empty".to_string(),
+        ));
+    }
+
+    if let Ok(index) = trimmed.parse::<usize>() {
+        let zero_based = index
+            .checked_sub(1)
+            .ok_or_else(|| HarperError::Validation("session numbers start at 1".to_string()))?;
+        let sessions =
+            crate::memory::session_service::SessionService::new(conn).list_sessions_data()?;
+        let session = sessions.get(zero_based).ok_or_else(|| {
+            HarperError::Validation(format!("session {} is out of bounds", index))
+        })?;
+        return Ok(session.id.clone());
+    }
+
+    Ok(trimmed.to_string())
+}
+
+fn format_history(conn: &Connection, session_id: &str) -> HarperResult<String> {
+    let history = crate::memory::storage::load_history(conn, session_id)?;
+    if history.is_empty() {
+        return Ok("No history for this session yet.".to_string());
+    }
+
+    let mut lines = vec!["History:".to_string()];
+    for (index, message) in history.iter().rev().take(10).enumerate() {
+        let preview = message
+            .content
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .chars()
+            .take(120)
+            .collect::<String>();
+        lines.push(format!("{}. {}: {}", index + 1, message.role, preview));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn format_config_context(config: Option<&ConfigShellContext>) -> String {
+    let Some(config) = config else {
+        return "Config summary unavailable.".to_string();
+    };
+    [
+        "Config:".to_string(),
+        format!("provider: {}", config.provider),
+        format!("model: {}", config.model),
+        format!("base_url: {}", config.base_url),
+        format!("database: {}", config.database_path),
+        format!("approval: {}", config.approval),
+        format!("strategy: {}", config.strategy),
+        format!("sandbox: {}", config.sandbox),
+    ]
+    .join("\n")
+}
+
+fn status_label(status: PlanStepStatus) -> &'static str {
+    match status {
+        PlanStepStatus::Pending => "pending",
+        PlanStepStatus::InProgress => "in_progress",
+        PlanStepStatus::Completed => "completed",
+        PlanStepStatus::Blocked => "blocked",
+    }
+}
+
+fn help_text() -> String {
+    [
+        "Harper native shell commands:",
+        "  ask \"message\"",
+        "  plan show",
+        "  plan list",
+        "  plan add \"step\"",
+        "  plan start <number>",
+        "  plan done <number>",
+        "  plan block <number> \"reason\"",
+        "  plan clear",
+        "  session list",
+        "  session ls",
+        "  session show <number|id>",
+        "  session open <number|id>",
+        "  history show [number|id]",
+        "  history list [number|id]",
+        "  auth status",
+        "  auth login [provider]",
+        "  auth logout",
+        "  config show",
+        "  config set approval|strategy|sandbox|retries <value>",
+        "  update check",
+        "  update apply",
+        "  status",
+        "  run <command>",
+        "",
+        "Existing slash commands also remain available:",
+        "  /strategy auto|grounded|deterministic|model",
+        "  /agents on|off|status",
+        "  /audit [limit]",
+        "  /clear",
+        "  /exit",
+    ]
+    .join("\n")
+}
+
+fn parse_one_based_index(value: Option<&String>, command: &str) -> HarperResult<usize> {
+    let raw = value
+        .ok_or_else(|| HarperError::Validation(format!("{} requires a step number", command)))?;
+    let parsed = raw.parse::<usize>().map_err(|_| {
+        HarperError::Validation(format!("{} requires a numeric step number", command))
+    })?;
+    parsed
+        .checked_sub(1)
+        .ok_or_else(|| HarperError::Validation("plan step numbers start at 1".to_string()))
+}
+
+fn tokenize(input: &str) -> HarperResult<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = input.chars().peekable();
+    let mut quote: Option<char> = None;
+
+    while let Some(ch) = chars.next() {
+        match (quote, ch) {
+            (Some(active), current_ch) if current_ch == active => quote = None,
+            (Some(_), '\\') => {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            (Some(_), current_ch) => current.push(current_ch),
+            (None, '"' | '\'') => quote = Some(ch),
+            (None, current_ch) if current_ch.is_whitespace() => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            (None, current_ch) => current.push(current_ch),
+        }
+    }
+
+    if quote.is_some() {
+        return Err(HarperError::Validation(
+            "unterminated quoted string".to_string(),
+        ));
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    Ok(tokens)
+}
+
+fn join_args(args: &[String]) -> String {
+    args.join(" ").trim().to_string()
+}
+
+fn rest_after_command<'a>(input: &'a str, command: &str) -> &'a str {
+    input.strip_prefix(command).unwrap_or(input).trim_start()
+}
+
+fn looks_like_quoted_command_arg(input: &str, command: &str) -> bool {
+    let arg = rest_after_command(input, command).trim_start();
+    arg.starts_with('"') || arg.starts_with('\'')
+}
+
+fn looks_like_shell_command_arg(input: &str, command: &str) -> bool {
+    let first_arg = rest_after_command(input, command)
+        .split_whitespace()
+        .next()
+        .unwrap_or_default();
+
+    if first_arg.is_empty() {
+        return true;
+    }
+
+    first_arg.contains('/')
+        || first_arg.starts_with('.')
+        || matches!(
+            first_arg,
+            "awk"
+                | "bash"
+                | "cargo"
+                | "cat"
+                | "cd"
+                | "cp"
+                | "curl"
+                | "echo"
+                | "find"
+                | "git"
+                | "grep"
+                | "ls"
+                | "make"
+                | "mkdir"
+                | "node"
+                | "npm"
+                | "pnpm"
+                | "pwd"
+                | "rg"
+                | "sed"
+                | "sh"
+                | "touch"
+                | "yarn"
+        )
+}
+
+fn unquote_if_wrapped(input: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.len() >= 2
+        && ((trimmed.starts_with('"') && trimmed.ends_with('"'))
+            || (trimmed.starts_with('\'') && trimmed.ends_with('\'')))
+    {
+        trimmed[1..trimmed.len() - 1].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("open db");
+        crate::memory::storage::init_db(&conn).expect("init db");
+        conn
+    }
+
+    #[test]
+    fn parses_plan_add_with_quoted_step() {
+        let parsed = parse_native_shell_command(r#"plan add "Inspect files""#)
+            .expect("parse")
+            .expect("command");
+        assert_eq!(
+            parsed,
+            NativeShellCommand::Plan(PlanShellCommand::Add("Inspect files".to_string()))
+        );
+    }
+
+    #[test]
+    fn parses_slash_plan_done_as_one_based_index() {
+        let parsed = parse_native_shell_command("/plan done 2")
+            .expect("parse")
+            .expect("command");
+        assert_eq!(parsed, NativeShellCommand::Plan(PlanShellCommand::Done(1)));
+        assert_eq!(
+            parse_native_shell_command("plan list")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Plan(PlanShellCommand::Show)
+        );
+        assert_eq!(
+            parse_native_shell_command("plan ls")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Plan(PlanShellCommand::Show)
+        );
+    }
+
+    #[test]
+    fn parses_read_only_service_commands() {
+        assert_eq!(
+            parse_native_shell_command("session list")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Session(SessionShellCommand::List)
+        );
+        assert_eq!(
+            parse_native_shell_command("session ls")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Session(SessionShellCommand::List)
+        );
+        assert_eq!(
+            parse_native_shell_command("history show")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::History(HistoryShellCommand::Show(None))
+        );
+        assert_eq!(
+            parse_native_shell_command("history show 2")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::History(HistoryShellCommand::Show(Some("2".to_string())))
+        );
+        assert_eq!(
+            parse_native_shell_command("session open 2")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Session(SessionShellCommand::Open("2".to_string()))
+        );
+        assert_eq!(
+            parse_native_shell_command("session show abc")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Session(SessionShellCommand::Show("abc".to_string()))
+        );
+        assert_eq!(
+            parse_native_shell_command("history list")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::History(HistoryShellCommand::Show(None))
+        );
+        assert_eq!(
+            parse_native_shell_command("auth login")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Auth(AuthShellCommand::Login {
+                provider: "github".to_string()
+            })
+        );
+        assert_eq!(
+            parse_native_shell_command("auth login google")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Auth(AuthShellCommand::Login {
+                provider: "google".to_string()
+            })
+        );
+        assert_eq!(
+            parse_native_shell_command("auth status")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Auth(AuthShellCommand::Status)
+        );
+        assert_eq!(
+            parse_native_shell_command("auth logout")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Auth(AuthShellCommand::Logout)
+        );
+        assert_eq!(
+            parse_native_shell_command("config show")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Config(ConfigShellCommand::Show)
+        );
+        assert_eq!(
+            parse_native_shell_command("config set strategy deterministic")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Config(ConfigShellCommand::Set {
+                key: "strategy".to_string(),
+                value: "deterministic".to_string()
+            })
+        );
+        assert_eq!(
+            parse_native_shell_command("/config set retries 2")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Config(ConfigShellCommand::Set {
+                key: "retries".to_string(),
+                value: "2".to_string()
+            })
+        );
+        assert_eq!(
+            parse_native_shell_command("update check")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Update(UpdateShellCommand::Check)
+        );
+        assert_eq!(
+            parse_native_shell_command("update apply")
+                .expect("parse")
+                .expect("command"),
+            NativeShellCommand::Update(UpdateShellCommand::Apply)
+        );
+    }
+
+    #[test]
+    fn help_mentions_native_and_slash_commands() {
+        let output =
+            execute_native_shell_command(&setup_conn(), "session-a", NativeShellCommand::Help)
+                .expect("help");
+
+        assert!(
+            matches!(output, NativeShellOutcome::Handled(text) if text.contains("auth login [provider]") && text.contains("/strategy auto|grounded|deterministic|model"))
+        );
+    }
+
+    #[test]
+    fn execution_returns_structured_outcomes_for_routed_commands() {
+        let conn = setup_conn();
+
+        assert_eq!(
+            execute_native_shell_command(
+                &conn,
+                "session-a",
+                NativeShellCommand::Auth(AuthShellCommand::Login {
+                    provider: "github".to_string()
+                })
+            )
+            .expect("auth login"),
+            NativeShellOutcome::AuthLogin {
+                provider: "github".to_string()
+            }
+        );
+        assert_eq!(
+            execute_native_shell_command(
+                &conn,
+                "session-a",
+                NativeShellCommand::Run("pwd".to_string())
+            )
+            .expect("run"),
+            NativeShellOutcome::Run("pwd".to_string())
+        );
+        assert_eq!(
+            execute_native_shell_command(
+                &conn,
+                "session-a",
+                NativeShellCommand::Config(ConfigShellCommand::Set {
+                    key: "strategy".to_string(),
+                    value: "deterministic".to_string()
+                })
+            )
+            .expect("config set"),
+            NativeShellOutcome::ConfigSet {
+                key: "strategy".to_string(),
+                value: "deterministic".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_text_is_not_a_shell_command() {
+        assert_eq!(
+            parse_native_shell_command("please inspect this repo").expect("parse"),
+            None
+        );
+        assert_eq!(
+            parse_native_shell_command("help me debug this").expect("parse"),
+            None
+        );
+        assert_eq!(
+            parse_native_shell_command("plan the migration").expect("parse"),
+            None
+        );
+        assert_eq!(
+            parse_native_shell_command("run the tests").expect("parse"),
+            None
+        );
+        assert_eq!(
+            parse_native_shell_command("ask how updates work").expect("parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn slash_commands_remain_strict() {
+        let err = parse_native_shell_command("/plan the migration").expect_err("strict slash");
+        assert!(err.to_string().contains("unknown plan command 'the'"));
+        assert!(parse_native_shell_command("/ask how updates work")
+            .expect("slash ask parses")
+            .is_some());
+        assert!(parse_native_shell_command("/run the tests")
+            .expect("slash run parses")
+            .is_some());
+    }
+
+    #[test]
+    fn update_status_returns_structured_outcome() {
+        let conn = setup_conn();
+        let output = execute_native_shell_command(
+            &conn,
+            "session-a",
+            NativeShellCommand::Update(UpdateShellCommand::Status),
+        )
+        .expect("update status");
+
+        assert_eq!(output, NativeShellOutcome::UpdateStatus);
+    }
+
+    #[test]
+    fn plan_commands_update_persisted_state() {
+        let conn = setup_conn();
+        execute_native_shell_command(
+            &conn,
+            "session-a",
+            NativeShellCommand::Plan(PlanShellCommand::Add("Inspect files".to_string())),
+        )
+        .expect("add step");
+        execute_native_shell_command(
+            &conn,
+            "session-a",
+            NativeShellCommand::Plan(PlanShellCommand::Start(0)),
+        )
+        .expect("start step");
+
+        let output = execute_native_shell_command(
+            &conn,
+            "session-a",
+            NativeShellCommand::Plan(PlanShellCommand::Show),
+        )
+        .expect("show");
+        assert!(
+            matches!(output, NativeShellOutcome::Handled(text) if text.contains("[in_progress] Inspect files"))
+        );
+    }
+
+    #[test]
+    fn plan_done_requires_existing_plan() {
+        let conn = setup_conn();
+        let err = execute_native_shell_command(
+            &conn,
+            "session-a",
+            NativeShellCommand::Plan(PlanShellCommand::Done(0)),
+        )
+        .expect_err("missing plan should fail");
+
+        assert!(err.to_string().contains("No active plan"));
+    }
+}

--- a/lib/harper-core/src/lib.rs
+++ b/lib/harper-core/src/lib.rs
@@ -29,6 +29,11 @@ pub use crate::core::constants::VERSION;
 pub use crate::core::error::{HarperError, HarperResult};
 pub use crate::core::llm_client::call_llm;
 pub use crate::core::models::ProviderModels;
+pub use crate::core::native_shell::{
+    execute_native_shell_command, execute_native_shell_command_with_context,
+    parse_native_shell_command, resolve_session_target, AuthShellContext, ConfigShellContext,
+    NativeShellCommand, NativeShellContext, NativeShellOutcome, PlanShellCommand,
+};
 pub use crate::core::plan::{PlanItem, PlanRuntime, PlanState, PlanStepStatus};
 pub use crate::core::{ApiConfig, ApiProvider, Message};
 

--- a/lib/harper-ui/src/bin/batch.rs
+++ b/lib/harper-ui/src/bin/batch.rs
@@ -17,7 +17,9 @@ use harper_core::core::io_traits::{DenyApproval, RuntimeEventSink, StdinApproval
 use harper_core::runtime::config::HarperConfig;
 use harper_core::{
     agent::chat::{ChatService, ChatTurnDebugSummary},
-    create_connection, init_db, ApiConfig, HarperError, Message, PlanState, ResolvedAgents,
+    create_connection, execute_native_shell_command_with_context, init_db,
+    parse_native_shell_command, resolve_session_target, ApiConfig, ConfigShellContext, HarperError,
+    Message, NativeShellContext, NativeShellOutcome, PlanState, ResolvedAgents,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -121,6 +123,61 @@ struct TurnResult {
     debug: TurnDebugOutput,
 }
 
+async fn execute_batch_run_command(
+    command: &str,
+    api_config: &ApiConfig,
+    exec_policy: &harper_core::ExecPolicyConfig,
+    approver: Arc<dyn harper_core::core::io_traits::UserApproval>,
+    runtime_events: Arc<BatchRuntimeEvents>,
+    conn: &rusqlite::Connection,
+    session_id: &str,
+) -> Result<String, HarperError> {
+    let audit_ctx = harper_core::tools::shell::CommandAuditContext {
+        conn,
+        session_id: Some(session_id),
+        source: "native_shell_batch",
+    };
+    let response = format!(
+        r#"[RUN_COMMAND {{"command":{}}}]"#,
+        serde_json::to_string(command)
+            .map_err(|err| HarperError::Validation(format!("Failed to encode command: {}", err)))?
+    );
+    harper_core::tools::shell::execute_command(
+        &response,
+        api_config,
+        exec_policy,
+        None,
+        Some(&audit_ctx),
+        Some(approver),
+        Some(runtime_events),
+    )
+    .await
+}
+
+fn format_batch_run_response(tool_response: &str, debug: &TurnDebugOutput) -> String {
+    if debug
+        .activity
+        .iter()
+        .any(|status| status == "approval rejected")
+        || tool_response
+            .trim()
+            .eq_ignore_ascii_case("Command execution cancelled by user")
+    {
+        return "Command was not run: approval rejected.".to_string();
+    }
+
+    if debug.command_error {
+        return "Command failed.".to_string();
+    }
+
+    let output = tool_response.trim_end();
+    if output.is_empty() {
+        "Command finished.".to_string()
+    } else {
+        output.to_string()
+    }
+}
+
 fn print_help() {
     println!("Harper Batch Processor");
     println!();
@@ -215,6 +272,21 @@ fn build_api_config(config: &HarperConfig) -> Result<ApiConfig, HarperError> {
     })
 }
 
+fn build_native_shell_context(config: &HarperConfig) -> NativeShellContext {
+    NativeShellContext {
+        auth: None,
+        config: Some(ConfigShellContext {
+            provider: config.api.provider.clone(),
+            model: config.api.model_name.clone(),
+            base_url: config.api.base_url.clone(),
+            database_path: config.database.path.clone(),
+            approval: format!("{:?}", config.exec_policy.effective_approval_profile()),
+            strategy: format!("{:?}", config.exec_policy.effective_execution_strategy()),
+            sandbox: format!("{:?}", config.exec_policy.effective_sandbox_profile()),
+        }),
+    }
+}
+
 async fn init_mcp_client(config: &HarperConfig) -> Option<McpClient> {
     if !config.mcp.enabled {
         return None;
@@ -237,6 +309,105 @@ fn latest_assistant_response(history: &[Message]) -> String {
         .unwrap_or_default()
 }
 
+fn format_session_messages(messages: &[Message]) -> String {
+    if messages.is_empty() {
+        return "Session has no messages.".to_string();
+    }
+    let mut lines = Vec::new();
+    for (index, message) in messages.iter().enumerate().take(20) {
+        let preview = message
+            .content
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .chars()
+            .take(160)
+            .collect::<String>();
+        lines.push(format!("{}. {}: {}", index + 1, message.role, preview));
+    }
+    if messages.len() > 20 {
+        lines.push(format!("{} more messages", messages.len() - 20));
+    }
+    lines.join("\n")
+}
+
+fn apply_config_set(config: &HarperConfig, key: &str, value: &str) -> Result<String, HarperError> {
+    let mut approval = config.exec_policy.effective_approval_profile();
+    let mut execution_strategy = config.exec_policy.effective_execution_strategy();
+    let mut sandbox = config.exec_policy.effective_sandbox_profile();
+    let mut retry_max_attempts = config.exec_policy.effective_retry_max_attempts();
+
+    match key.trim().to_ascii_lowercase().as_str() {
+        "approval" | "approval_profile" => {
+            approval = harper_ui::interfaces::ui::settings::parse_approval_profile(value)
+                .ok_or_else(|| {
+                    HarperError::Validation(
+                        "approval must be one of: strict, allow_listed, allow_all".to_string(),
+                    )
+                })?;
+        }
+        "strategy" | "execution_strategy" => {
+            execution_strategy = harper_ui::interfaces::ui::settings::parse_execution_strategy(
+                value,
+            )
+            .ok_or_else(|| {
+                HarperError::Validation(
+                    "strategy must be one of: auto, grounded, deterministic, model".to_string(),
+                )
+            })?;
+        }
+        "sandbox" | "sandbox_profile" => {
+            sandbox = harper_ui::interfaces::ui::settings::parse_sandbox_profile(value)
+                .ok_or_else(|| {
+                    HarperError::Validation(
+                        "sandbox must be one of: disabled, workspace, networked_workspace"
+                            .to_string(),
+                    )
+                })?;
+        }
+        "retries" | "retry_max_attempts" => {
+            retry_max_attempts = value.trim().parse::<u32>().map_err(|_| {
+                HarperError::Validation("retries must be a non-negative integer".to_string())
+            })?;
+        }
+        other => {
+            return Err(HarperError::Validation(format!(
+                "unsupported config key '{}'",
+                other
+            )));
+        }
+    }
+
+    let header_widgets = harper_ui::interfaces::ui::settings::parse_header_widgets(
+        &config.ui.effective_header_widgets(),
+    );
+    harper_ui::interfaces::ui::settings::save_execution_policy_settings(
+        harper_ui::interfaces::ui::settings::ExecPolicySettings {
+            approval,
+            execution_strategy,
+            sandbox,
+            retry_max_attempts,
+            allowed_commands: config
+                .exec_policy
+                .allowed_commands
+                .as_deref()
+                .unwrap_or(&[]),
+            blocked_commands: config
+                .exec_policy
+                .blocked_commands
+                .as_deref()
+                .unwrap_or(&[]),
+            header_widgets: &header_widgets,
+        },
+    )
+    .map_err(|err| HarperError::Io(format!("Failed to save config: {}", err)))?;
+
+    Ok(format!(
+        "Saved config {} = {} in config/local.toml",
+        key, value
+    ))
+}
+
 #[tokio::main]
 async fn main() -> Result<(), HarperError> {
     let _ = dotenvy::dotenv();
@@ -255,7 +426,7 @@ async fn main() -> Result<(), HarperError> {
         ));
     }
 
-    let config = HarperConfig::new()?;
+    let mut config = HarperConfig::new()?;
     let api_config = build_api_config(&config)?;
     let conn = create_connection(&config.database.path)?;
     init_db(&conn)?;
@@ -273,13 +444,17 @@ async fn main() -> Result<(), HarperError> {
     )
     .with_runtime_events(runtime_events.clone());
 
-    if io::stdin().is_terminal() {
-        chat_service = chat_service.with_approver(Arc::new(StdinApproval));
+    let approver: Arc<dyn harper_core::core::io_traits::UserApproval> = if io::stdin().is_terminal()
+    {
+        Arc::new(StdinApproval)
     } else {
-        chat_service = chat_service.with_approver(Arc::new(DenyApproval));
-    }
+        Arc::new(DenyApproval)
+    };
+
+    chat_service = chat_service.with_approver(approver.clone());
 
     let (mut history, session_id) = chat_service.create_session(args.web).await?;
+    let mut shell_context = build_native_shell_context(&config);
 
     if let Some(strategy) = args.strategy.as_deref() {
         let strategy_command = format!("/strategy {}", strategy);
@@ -291,7 +466,134 @@ async fn main() -> Result<(), HarperError> {
 
     let mut results = Vec::new();
     for prompt in args.prompts {
+        let mut prompt = prompt;
         let routing = chat_service.debug_turn_summary(&history, &prompt);
+        if let Some(command) = parse_native_shell_command(&prompt)? {
+            match execute_native_shell_command_with_context(
+                &conn,
+                &session_id,
+                command,
+                &shell_context,
+            )? {
+                NativeShellOutcome::Handled(response) => {
+                    results.push(TurnResult {
+                        prompt,
+                        response,
+                        routing,
+                        debug: TurnDebugOutput::default(),
+                    });
+                    continue;
+                }
+                NativeShellOutcome::Ask(message) => {
+                    prompt = message;
+                }
+                NativeShellOutcome::Run(command) => {
+                    let tool_response = execute_batch_run_command(
+                        &command,
+                        &api_config,
+                        &config.exec_policy,
+                        approver.clone(),
+                        runtime_events.clone(),
+                        &conn,
+                        &session_id,
+                    )
+                    .await?;
+                    let debug = runtime_events.take_turn(&session_id);
+                    let response = format_batch_run_response(&tool_response, &debug);
+                    results.push(TurnResult {
+                        prompt,
+                        response,
+                        routing,
+                        debug,
+                    });
+                    continue;
+                }
+                NativeShellOutcome::UpdateCheck => {
+                    let response = harper_ui::update::fetch_update_status()
+                        .await
+                        .map(|status| status.unwrap_or_else(|| "No update status.".to_string()))
+                        .unwrap_or_else(|err| format!("Update check failed: {}", err));
+                    results.push(TurnResult {
+                        prompt,
+                        response,
+                        routing,
+                        debug: TurnDebugOutput::default(),
+                    });
+                    continue;
+                }
+                NativeShellOutcome::UpdateStatus => {
+                    results.push(TurnResult {
+                        prompt,
+                        response: "No update status is cached in batch. Use update check."
+                            .to_string(),
+                        routing,
+                        debug: TurnDebugOutput::default(),
+                    });
+                    continue;
+                }
+                NativeShellOutcome::UpdateApply => {
+                    results.push(TurnResult {
+                        prompt,
+                        response: "Update apply is intentionally explicit. Run: harper self-update"
+                            .to_string(),
+                        routing,
+                        debug: TurnDebugOutput::default(),
+                    });
+                    continue;
+                }
+                NativeShellOutcome::ConfigSet { key, value } => {
+                    let response = apply_config_set(&config, &key, &value)?;
+                    config = HarperConfig::new()?;
+                    shell_context = build_native_shell_context(&config);
+                    results.push(TurnResult {
+                        prompt,
+                        response,
+                        routing,
+                        debug: TurnDebugOutput::default(),
+                    });
+                    continue;
+                }
+                NativeShellOutcome::AuthLogin { provider } => {
+                    results.push(TurnResult {
+                        prompt,
+                        response: format!(
+                            "Auth login for '{}' is interactive. Run Harper in the TUI and use: auth login {}",
+                            provider, provider
+                        ),
+                        routing,
+                        debug: TurnDebugOutput::default(),
+                    });
+                    continue;
+                }
+                NativeShellOutcome::AuthLogout => {
+                    results.push(TurnResult {
+                        prompt,
+                        response: "Auth logout is only available in the interactive TUI."
+                            .to_string(),
+                        routing,
+                        debug: TurnDebugOutput::default(),
+                    });
+                    continue;
+                }
+                NativeShellOutcome::OpenSession { target, .. } => {
+                    let response =
+                        match resolve_session_target(&conn, &target).and_then(|session_id| {
+                            harper_core::memory::session_service::SessionService::new(&conn)
+                                .view_session_data(&session_id)
+                        }) {
+                            Ok(messages) => format_session_messages(&messages),
+                            Err(err) => format!("Session open failed: {}", err),
+                        };
+                    results.push(TurnResult {
+                        prompt,
+                        response,
+                        routing,
+                        debug: TurnDebugOutput::default(),
+                    });
+                    continue;
+                }
+            }
+        }
         chat_service
             .send_message(&prompt, &mut history, args.web, &session_id)
             .await?;
@@ -363,4 +665,32 @@ async fn main() -> Result<(), HarperError> {
 
 fn result_looks_like_backend_unavailable(response: &str) -> bool {
     response.trim().starts_with("Model backend unavailable.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_batch_run_response, TurnDebugOutput};
+
+    #[test]
+    fn batch_run_response_reports_rejected_approval() {
+        let debug = TurnDebugOutput {
+            activity: vec![
+                "waiting approval: pwd".to_string(),
+                "approval rejected".to_string(),
+            ],
+            ..TurnDebugOutput::default()
+        };
+
+        assert_eq!(
+            format_batch_run_response("Command execution cancelled by user", &debug),
+            "Command was not run: approval rejected."
+        );
+    }
+
+    #[test]
+    fn batch_run_response_returns_successful_output() {
+        let debug = TurnDebugOutput::default();
+
+        assert_eq!(format_batch_run_response("hello\n", &debug), "hello");
+    }
 }

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -1381,8 +1381,32 @@ fn slash_command_candidates(input: &str) -> Vec<String> {
         "/auth login github",
         "/auth login google",
         "/auth login apple",
+        "/auth login",
         "/auth logout",
         "/auth status",
+        "/plan show",
+        "/plan list",
+        "/plan ls",
+        "/plan add",
+        "/plan start",
+        "/plan done",
+        "/plan block",
+        "/plan clear",
+        "/session list",
+        "/session ls",
+        "/session show",
+        "/session open",
+        "/history show",
+        "/history list",
+        "/config show",
+        "/config set approval",
+        "/config set strategy",
+        "/config set sandbox",
+        "/config set retries",
+        "/status",
+        "/update apply",
+        "/run",
+        "/ask",
     ];
     let mut matches = commands
         .into_iter()
@@ -2008,6 +2032,36 @@ mod tests {
     }
 
     #[test]
+    fn enter_submits_native_shell_commands_from_chat_input() {
+        for command in [
+            "/plan show",
+            "/session list",
+            "/config show",
+            "/status",
+            "/run pwd",
+        ] {
+            let mut app = TuiApp::new();
+            let mut chat_state = create_chat_state("session".to_string(), vec![], None, None, true);
+            chat_state.input = command.to_string();
+            app.state = AppState::Chat(Box::new(chat_state));
+            let conn = rusqlite::Connection::open_in_memory().unwrap();
+            harper_core::memory::storage::init_db(&conn).unwrap();
+            let session_service = SessionService::new(&conn);
+
+            let result = handle_event(
+                Event::Key(KeyCode::Enter.into()),
+                &mut app,
+                &session_service,
+            );
+            assert!(matches!(result, EventResult::SendMessage(message) if message == command));
+            let AppState::Chat(chat_state) = &app.state else {
+                panic!("expected chat state");
+            };
+            assert!(chat_state.input.is_empty());
+        }
+    }
+
+    #[test]
     fn test_enter_menu_load_sessions_returns_async_event() {
         let mut app = TuiApp::new();
         app.state = AppState::Menu(1); // Sessions
@@ -2137,6 +2191,25 @@ mod tests {
             .completion_candidates
             .iter()
             .any(|candidate| candidate == "/update check"));
+    }
+
+    #[test]
+    fn slash_completion_includes_native_shell_commands() {
+        let mut chat_state = create_chat_state("session".to_string(), vec![], None, None, true);
+        chat_state.input = "/h".to_string();
+        refresh_chat_completions(&mut chat_state);
+
+        assert!(chat_state
+            .completion_candidates
+            .iter()
+            .any(|candidate| candidate == "/history list"));
+
+        chat_state.input = "/auth l".to_string();
+        refresh_chat_completions(&mut chat_state);
+        assert!(chat_state
+            .completion_candidates
+            .iter()
+            .any(|candidate| candidate == "/auth login"));
     }
 
     #[test]

--- a/lib/harper-ui/src/interfaces/ui/settings.rs
+++ b/lib/harper-ui/src/interfaces/ui/settings.rs
@@ -174,6 +174,36 @@ pub fn sandbox_profile_name(profile: SandboxProfile) -> &'static str {
     }
 }
 
+pub fn parse_approval_profile(value: &str) -> Option<ApprovalProfile> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "strict" => Some(ApprovalProfile::Strict),
+        "allow_listed" | "allow-listed" | "allowlisted" => Some(ApprovalProfile::AllowListed),
+        "allow_all" | "allow-all" | "allowall" => Some(ApprovalProfile::AllowAll),
+        _ => None,
+    }
+}
+
+pub fn parse_execution_strategy(value: &str) -> Option<ExecutionStrategy> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "auto" => Some(ExecutionStrategy::Auto),
+        "grounded" => Some(ExecutionStrategy::Grounded),
+        "deterministic" => Some(ExecutionStrategy::Deterministic),
+        "model" | "model_only" | "model-only" => Some(ExecutionStrategy::ModelOnly),
+        _ => None,
+    }
+}
+
+pub fn parse_sandbox_profile(value: &str) -> Option<SandboxProfile> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "disabled" | "off" => Some(SandboxProfile::Disabled),
+        "workspace" => Some(SandboxProfile::Workspace),
+        "networked_workspace" | "networked-workspace" | "networked" => {
+            Some(SandboxProfile::NetworkedWorkspace)
+        }
+        _ => None,
+    }
+}
+
 pub fn next_approval_profile(profile: ApprovalProfile) -> ApprovalProfile {
     match profile {
         ApprovalProfile::Strict => ApprovalProfile::AllowListed,

--- a/lib/harper-ui/src/interfaces/ui/tui.rs
+++ b/lib/harper-ui/src/interfaces/ui/tui.rs
@@ -170,6 +170,11 @@ enum WorkerMsg {
         web_search: bool,
         auth_user_id: Option<String>,
     },
+    ExecuteShellCommand {
+        command: String,
+        session_id: String,
+        auth_user_id: Option<String>,
+    },
     RetryPlanCommand {
         command: String,
         session_id: String,
@@ -327,6 +332,118 @@ fn parse_update_command(input: &str) -> Option<UpdateCommand> {
     }
 }
 
+fn build_native_shell_context(
+    app: &TuiApp,
+    api_config: &ApiConfig,
+    exec_policy: &ExecPolicyConfig,
+    db_path: Option<&str>,
+) -> harper_core::NativeShellContext {
+    let auth = app.auth_session.as_ref().map(|session| {
+        let user = session
+            .user
+            .email
+            .clone()
+            .or_else(|| session.user.display_name.clone())
+            .unwrap_or_else(|| session.user.user_id.clone());
+        harper_core::AuthShellContext {
+            status: format!("signed in as {}", user),
+        }
+    });
+
+    harper_core::NativeShellContext {
+        auth,
+        config: Some(harper_core::ConfigShellContext {
+            provider: api_config.provider.to_string(),
+            model: api_config.model_name.clone(),
+            base_url: api_config.base_url.clone(),
+            database_path: db_path.unwrap_or(":memory:").to_string(),
+            approval: format!("{:?}", exec_policy.effective_approval_profile()),
+            strategy: format!("{:?}", exec_policy.effective_execution_strategy()),
+            sandbox: format!("{:?}", exec_policy.effective_sandbox_profile()),
+        }),
+    }
+}
+
+fn apply_tui_config_set(app: &mut TuiApp, key: &str, value: &str) -> Result<String, String> {
+    match key.trim().to_ascii_lowercase().as_str() {
+        "approval" | "approval_profile" => {
+            app.approval_profile = settings::parse_approval_profile(value)
+                .ok_or("approval must be one of: strict, allow_listed, allow_all")?;
+        }
+        "strategy" | "execution_strategy" => {
+            app.execution_strategy = settings::parse_execution_strategy(value)
+                .ok_or("strategy must be one of: auto, grounded, deterministic, model")?;
+        }
+        "sandbox" | "sandbox_profile" => {
+            app.sandbox_profile = settings::parse_sandbox_profile(value)
+                .ok_or("sandbox must be one of: disabled, workspace, networked_workspace")?;
+        }
+        "retries" | "retry_max_attempts" => {
+            app.retry_max_attempts = value
+                .trim()
+                .parse::<u32>()
+                .map_err(|_| "retries must be a non-negative integer")?;
+        }
+        other => return Err(format!("unsupported config key '{}'", other)),
+    }
+
+    settings::save_execution_policy_settings(settings::ExecPolicySettings {
+        approval: app.approval_profile,
+        execution_strategy: app.execution_strategy,
+        sandbox: app.sandbox_profile,
+        retry_max_attempts: app.retry_max_attempts,
+        allowed_commands: &app.allowed_commands,
+        blocked_commands: &app.blocked_commands,
+        header_widgets: &app.header_widgets,
+    })
+    .map_err(|err| format!("Failed to save config: {}", err))?;
+
+    Ok(format!(
+        "Saved config {} = {} in config/local.toml",
+        key, value
+    ))
+}
+
+fn sync_exec_policy_from_app(app: &TuiApp, exec_policy: &Arc<Mutex<ExecPolicyConfig>>) {
+    if let Ok(mut policy) = exec_policy.lock() {
+        policy.approval_profile = Some(app.approval_profile);
+        policy.execution_strategy = Some(app.execution_strategy);
+        policy.sandbox_profile = Some(app.sandbox_profile);
+        policy.allowed_commands = if app.allowed_commands.is_empty() {
+            None
+        } else {
+            Some(app.allowed_commands.clone())
+        };
+        policy.blocked_commands = if app.blocked_commands.is_empty() {
+            None
+        } else {
+            Some(app.blocked_commands.clone())
+        };
+        policy.retry_max_attempts = Some(app.retry_max_attempts);
+    }
+}
+
+async fn start_tui_auth_login(app: &mut TuiApp, auth_client: &reqwest::Client, provider: &str) {
+    let Some(base_url) = app.auth_server_base_url.clone() else {
+        app.set_error_message("TUI auth requires the Harper server to be enabled".to_string());
+        return;
+    };
+    match auth::start_tui_auth_flow(auth_client, &base_url, provider).await {
+        Ok(flow) => {
+            app.auth_flow_id = Some(flow.flow_id.clone());
+            app.auth_last_poll_at = None;
+            match auth::launch_browser(&flow.login_url) {
+                Ok(_) => app.set_status_message(format!("Opened browser for {} sign-in", provider)),
+                Err(_) => {
+                    app.set_info_message(format!("Open this URL to sign in:\n{}", flow.login_url))
+                }
+            }
+            app.set_activity_status(Some("waiting for browser sign-in".to_string()));
+        }
+        Err(err) => app.set_error_message(format!("Auth login failed: {}", err)),
+    }
+}
+
 pub async fn run_tui(
     conn: &Connection,
     api_config: &ApiConfig,
@@ -377,6 +494,7 @@ pub async fn run_tui(
     let db_path = conn
         .path()
         .and_then(|p| Path::new(p).to_str().map(|s| s.to_string()));
+    let db_path_for_shell = db_path.clone();
 
     // Wrap MCP client in Arc if present
     // Note: This requires McpClient to be thread-safe (Send + Sync)
@@ -517,6 +635,81 @@ pub async fn run_tui(
                             let _ = ui_tx_clone.send(UiUpdate::Error(err.to_string())).await;
                         }
                     }
+                    WorkerMsg::ExecuteShellCommand {
+                        command,
+                        session_id,
+                        auth_user_id,
+                    } => {
+                        let exec_policy = worker_exec_policy
+                            .lock()
+                            .expect("worker exec policy lock")
+                            .clone();
+                        let audit_ctx = harper_core::tools::shell::CommandAuditContext {
+                            conn: &worker_conn,
+                            session_id: Some(&session_id),
+                            source: "native_shell_tui",
+                        };
+                        let response = format!(
+                            r#"[RUN_COMMAND {{"command":{}}}]"#,
+                            serde_json::to_string(&command)
+                                .expect("serialize native shell command payload")
+                        );
+                        let result = harper_core::tools::shell::execute_command(
+                            &response,
+                            &worker_api_config,
+                            &exec_policy,
+                            None,
+                            Some(&audit_ctx),
+                            Some(approver.clone()),
+                            Some(runtime_events.clone()),
+                        )
+                        .await;
+                        match result {
+                            Ok(_) => {
+                                let session_service = SessionService::new(&worker_conn);
+                                let session_view = match auth_user_id.as_deref() {
+                                    Some(user_id) => session_service
+                                        .load_session_state_view_for_user(&session_id, user_id)
+                                        .ok()
+                                        .flatten()
+                                        .unwrap_or_else(|| SessionStateView {
+                                            session_id: session_id.clone(),
+                                            user_id: Some(user_id.to_string()),
+                                            messages: harper_core::memory::storage::load_history(
+                                                &worker_conn,
+                                                &session_id,
+                                            )
+                                            .unwrap_or_default(),
+                                            plan: None,
+                                            agents: None,
+                                            agents_rendered: None,
+                                            agents_effective_rendered: None,
+                                        }),
+                                    None => session_service
+                                        .load_session_state_view(&session_id)
+                                        .unwrap_or_else(|_| SessionStateView {
+                                            session_id: session_id.clone(),
+                                            user_id: None,
+                                            messages: harper_core::memory::storage::load_history(
+                                                &worker_conn,
+                                                &session_id,
+                                            )
+                                            .unwrap_or_default(),
+                                            plan: None,
+                                            agents: None,
+                                            agents_rendered: None,
+                                            agents_effective_rendered: None,
+                                        }),
+                                };
+                                let _ = ui_tx_clone
+                                    .send(UiUpdate::MessageProcessed(session_view))
+                                    .await;
+                            }
+                            Err(err) => {
+                                let _ = ui_tx_clone.send(UiUpdate::Error(err.to_string())).await;
+                            }
+                        }
+                    }
                 }
             }
         });
@@ -544,8 +737,135 @@ pub async fn run_tui(
                 if let Some(event) = event {
                     match events::handle_event(event, &mut app, session_service) {
                         EventResult::Quit => break,
-                        EventResult::SendMessage(msg) => {
+                        EventResult::SendMessage(mut msg) => {
+                            let shell_context = build_native_shell_context(
+                                &app,
+                                api_config,
+                                exec_policy,
+                                db_path_for_shell.as_deref(),
+                            );
                             if let AppState::Chat(chat_state) = &mut app.state {
+                                match harper_core::parse_native_shell_command(&msg) {
+                                    Ok(Some(command)) => {
+                                        let session_id = chat_state.session_id.clone();
+                                        match harper_core::execute_native_shell_command_with_context(
+                                            conn,
+                                            &session_id,
+                                            command,
+                                            &shell_context,
+                                        ) {
+                                            Ok(harper_core::NativeShellOutcome::Handled(response)) => {
+                                                chat_state.active_plan = harper_core::memory::storage::load_plan_state(conn, &session_id).ok().flatten();
+                                                app.set_info_message(response);
+                                                continue;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::Ask(prompt)) => {
+                                                msg = prompt;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::Run(command)) => {
+                                                chat_state.command_output = None;
+                                                app.set_activity_status(Some(format!("running: {}", command)));
+                                                let _ = worker_tx.send(WorkerMsg::ExecuteShellCommand {
+                                                    command,
+                                                    session_id,
+                                                    auth_user_id: app
+                                                        .auth_session
+                                                        .as_ref()
+                                                        .map(|session| session.user.user_id.clone()),
+                                                }).await;
+                                                continue;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::UpdateCheck) => {
+                                                app.set_activity_status(Some("checking updates".to_string()));
+                                                spawn_update_status_refresh(&ui_tx, true);
+                                                continue;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::UpdateStatus) => {
+                                                if let Some(status) = &app.update_status {
+                                                    app.set_info_message(format!("Current {}", status));
+                                                } else {
+                                                    app.set_info_message(
+                                                        "No update status is cached yet. Use /update check."
+                                                            .to_string(),
+                                                    );
+                                                }
+                                                continue;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::UpdateApply) => {
+                                                app.set_info_message(
+                                                    "Update apply is intentionally explicit. Run: harper self-update".to_string(),
+                                                );
+                                                continue;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::ConfigSet { key, value }) => {
+                                                match apply_tui_config_set(&mut app, &key, &value) {
+                                                    Ok(message) => {
+                                                        sync_exec_policy_from_app(&app, &ui_exec_policy);
+                                                        app.set_status_message(message);
+                                                    }
+                                                    Err(err) => app.set_error_message(err),
+                                                }
+                                                continue;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::AuthLogin { provider }) => {
+                                                start_tui_auth_login(&mut app, &auth_client, &provider).await;
+                                                continue;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::AuthLogout) => {
+                                                if let Err(err) = auth::clear_auth_session() {
+                                                    app.set_error_message(format!("Auth logout failed: {}", err));
+                                                } else {
+                                                    app.auth_session = None;
+                                                    app.auth_flow_id = None;
+                                                    app.auth_last_poll_at = None;
+                                                    app.set_status_message("Cleared local TUI auth session".to_string());
+                                                }
+                                                continue;
+                                            }
+                                            Ok(harper_core::NativeShellOutcome::OpenSession { target, preview }) => {
+                                                match harper_core::resolve_session_target(conn, &target) {
+                                                    Ok(target_session_id) => {
+                                                        if preview {
+                                                            match session_service.view_session_data(&target_session_id) {
+                                                                Ok(messages) => {
+                                                                    app.state = AppState::ViewSession(target_session_id, messages, 0);
+                                                                }
+                                                                Err(err) => app.set_error_message(format!("Error loading session preview: {}", err)),
+                                                            }
+                                                        } else {
+                                                            match session_service.load_session_state_view(&target_session_id) {
+                                                                Ok(session_view) => {
+                                                                    app.state = AppState::Chat(Box::new(events::create_chat_state(
+                                                                        session_view.session_id,
+                                                                        session_view.messages,
+                                                                        session_view.plan,
+                                                                        session_view.agents,
+                                                                        app.agents_context_enabled,
+                                                                    )));
+                                                                    if let AppState::Chat(chat_state) = &mut app.state {
+                                                                        spawn_sidebar_gathering(chat_state, &ui_tx);
+                                                                    }
+                                                                }
+                                                                Err(err) => app.set_error_message(format!("Error loading session: {}", err)),
+                                                            }
+                                                        }
+                                                    }
+                                                    Err(err) => app.set_error_message(err.to_string()),
+                                                }
+                                                continue;
+                                            }
+                                            Err(err) => {
+                                                app.set_error_message(err.to_string());
+                                                continue;
+                                            }
+                                        }
+                                    }
+                                    Ok(None) => {}
+                                    Err(err) => {
+                                        app.set_error_message(err.to_string());
+                                        continue;
+                                    }
+                                }
                                 if let Some(strategy) = parse_strategy_command(&msg, app.execution_strategy) {
                                     match strategy {
                                         Ok(new_strategy) => {
@@ -617,25 +937,7 @@ pub async fn run_tui(
                                 if let Some(command) = auth::parse_tui_auth_command(&msg) {
                                     match command {
                                         auth::TuiAuthCommand::Login { provider } => {
-                                            let Some(base_url) = app.auth_server_base_url.clone() else {
-                                                app.set_error_message("TUI auth requires the Harper server to be enabled".to_string());
-                                                continue;
-                                            };
-                                            match auth::start_tui_auth_flow(&auth_client, &base_url, &provider).await {
-                                                Ok(flow) => {
-                                                    app.auth_flow_id = Some(flow.flow_id.clone());
-                                                    app.auth_last_poll_at = None;
-                                                    match auth::launch_browser(&flow.login_url) {
-                                                        Ok(_) => app.set_status_message(format!("Opened browser for {} sign-in", provider)),
-                                                        Err(_) => app.set_info_message(format!(
-                                                            "Open this URL to sign in:\n{}",
-                                                            flow.login_url
-                                                        )),
-                                                    }
-                                                    app.set_activity_status(Some("waiting for browser sign-in".to_string()));
-                                                }
-                                                Err(err) => app.set_error_message(format!("Auth login failed: {}", err)),
-                                            }
+                                            start_tui_auth_login(&mut app, &auth_client, &provider).await;
                                             continue;
                                         }
                                         auth::TuiAuthCommand::Logout => {
@@ -1102,25 +1404,7 @@ pub async fn run_tui(
                             }
                         }
                         EventResult::StartProfileLogin { provider } => {
-                            let Some(base_url) = app.auth_server_base_url.clone() else {
-                                app.set_error_message("TUI auth requires the Harper server to be enabled".to_string());
-                                continue;
-                            };
-                            match auth::start_tui_auth_flow(&auth_client, &base_url, &provider).await {
-                                Ok(flow) => {
-                                    app.auth_flow_id = Some(flow.flow_id.clone());
-                                    app.auth_last_poll_at = None;
-                                    match auth::launch_browser(&flow.login_url) {
-                                        Ok(_) => app.set_status_message(format!("Opened browser for {} sign-in", provider)),
-                                        Err(_) => app.set_info_message(format!(
-                                            "Open this URL to sign in:\n{}",
-                                            flow.login_url
-                                        )),
-                                    }
-                                    app.set_activity_status(Some("waiting for browser sign-in".to_string()));
-                                }
-                                Err(err) => app.set_error_message(format!("Auth login failed: {}", err)),
-                            }
+                            start_tui_auth_login(&mut app, &auth_client, &provider).await;
                         }
                         EventResult::Continue => {}
                         EventResult::GatherSidebarEntries => {

--- a/website/blog.html
+++ b/website/blog.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Blog</title>
-    <meta name="harper-update-version" content="2026-05-01-blog-v6" />
+    <meta name="harper-update-version" content="2026-05-09-blog-shell" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -29,6 +29,13 @@
             <div class="content-container">
                 <h1 class="hero-title">Notes from the codebase.</h1>
                 <p class="hero-lede">Short product and engineering notes from Harper. This page stays high level. The <a href="changelog.html">changelog</a> keeps the version-by-version detail.</p>
+
+                <article>
+                    <h2>May 2026 · Shell</h2>
+                    <p>Harper now has a native command surface for Harper state. Instead of treating every operational action as either prose or an operating-system command, the TUI and batch mode can both understand commands such as <code>plan show</code>, <code>session list</code>, <code>history show</code>, <code>config show</code>, <code>auth login</code>, and <code>update check</code>.</p>
+                    <p>The boundary is intentional. This is not a Unix-compatible shell, and it does not try to support pipes, redirects, glob expansion, or job control. Operating-system commands stay explicit behind <code>run ...</code>, which keeps them on Harper's existing approval, sandbox, and audit path. Native commands are for Harper concepts: plans, sessions, history, auth, config, update status, and diagnostics.</p>
+                    <p>The practical win is consistency. The same parser is used from the interactive TUI and from <code>harper-batch</code>, so a workflow can be checked headlessly before it is exercised in the UI. That gives Harper a clearer command model without hiding the underlying actions.</p>
+                </article>
 
                 <article>
                     <h2>May 2026 · Harper now supports native self-update</h2>

--- a/website/docs.html
+++ b/website/docs.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Docs</title>
-    <meta name="harper-update-version" content="2026-05-05-docs-adx" />
+    <meta name="harper-update-version" content="2026-05-09-docs-shell" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -28,7 +28,7 @@
         <main class="surface">
             <div class="content-container">
                 <h1 class="hero-title">Docs<br/><span>for daily use and debugging.</span></h1>
-                <p class="hero-lede">Start with installation and configuration, use the shell-first verification flow for routing checks, then move to the TUI only for UI-specific validation.</p>
+                <p class="hero-lede">Start with installation and configuration, use native Harper commands for stateful work, and use batch mode for routing checks before UI-specific validation.</p>
 
                 <div class="actions">
                     <a class="button primary" href="installation.html">Install Guide</a>
@@ -36,7 +36,7 @@
                 </div>
 
                 <h2>Start here</h2>
-                <p>The <a href="installation.html">installation guide</a> is the best entry point for most people. It covers setup, the current slash commands, execution policy, routing behavior, Azure Data Explorer queries, and the shell-first verification flow. If you are running Harper with the local HTTP interface enabled, the <a href="server.html">API Server</a> page explains the runtime model, configuration, and integration details. When something goes wrong in local development, the <a href="troubleshooting.html">troubleshooting guide</a> is the right place to check for auth, shell, and runtime issues.</p>
+                <p>The <a href="installation.html">installation guide</a> is the best entry point for most people. It covers setup, native Harper commands, slash commands, execution policy, routing behavior, Azure Data Explorer queries, and the batch verification flow. If you are running Harper with the local HTTP interface enabled, the <a href="server.html">API Server</a> page explains the runtime model, configuration, and integration details. When something goes wrong in local development, the <a href="troubleshooting.html">troubleshooting guide</a> is the right place to check for auth, shell, and runtime issues.</p>
 
                 <h2>Verification workflow</h2>
                 <p>Use <code>harper-batch</code> before opening the TUI when you need to verify routing, normalization, or follow-up behavior. This keeps the verification path close to the core chat flow and removes UI state from the first debugging step.</p>

--- a/website/index.html
+++ b/website/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Terminal AI</title>
-    <meta name="harper-update-version" content="2026-05-01-home-v2" />
+    <meta name="harper-update-version" content="2026-05-09-home-shell" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -28,7 +28,7 @@
         <main class="surface">
             <div class="content-container">
                 <h1 class="hero-title">Terminal workflows<br/><span>without ceremony.</span></h1>
-                <p class="hero-lede">Natural language for code and shell work, with visible commands, approvals when needed, and an audit trail.</p>
+                <p class="hero-lede">Natural language and native Harper commands for code and shell work, with visible commands, approvals when needed, and an audit trail.</p>
 
                 <div class="actions">
                     <a class="button primary" href="https://github.com/harpertoken/harper">GitHub</a>
@@ -36,13 +36,14 @@
                 </div>
 
                 <h2>How it works</h2>
-                <p>You describe what you want in plain text. Harper can inspect files, edit code, run commands, and keep track of multi-step work while still showing you the concrete actions it plans to take.</p>
+                <p>You describe what you want in plain text or use native commands such as <code>plan show</code>, <code>session list</code>, <code>config show</code>, <code>update check</code>, and explicit <code>run ...</code>. Harper can inspect files, edit code, run commands, and keep track of multi-step work while still showing you the concrete actions it plans to take.</p>
 
                 <h2>Features</h2>
                 <ul>
                     <li>Preview commands before execution</li>
                     <li>Approval gates for sensitive operations</li>
                     <li>Session history with readable titles, plan tracking, and audit logs</li>
+                    <li>Native shell commands in the TUI and batch mode</li>
                     <li>Works with OpenAI, Gemini, SambaNova, Cerebras, or Ollama</li>
                 </ul>
 

--- a/website/installation.html
+++ b/website/installation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Installation</title>
-    <meta name="harper-update-version" content="2026-05-05-install-adx" />
+    <meta name="harper-update-version" content="2026-05-09-install-shell" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -64,8 +64,40 @@ SUPABASE_ALLOWED_PROVIDERS=github</code></pre>
                     <button class="copy-btn"></button>
                 </div>
 
-                <h2>Slash commands in the TUI</h2>
-                <p>Harper accepts slash commands directly in the chat input. Start a conversation, place focus in the message box, type <code>/</code>, and then enter a command just like a normal message.</p>
+                <h2>Native commands and slash commands</h2>
+                <p>Harper accepts native commands directly in the chat input. Start a conversation, place focus in the message box, and enter a command just like a normal message.</p>
+                <div class="code-wrapper">
+                    <pre><code>ask "question or instruction"
+plan show
+plan list
+plan add "Inspect current planner state"
+plan done 1
+plan start 2
+plan block 3 "Waiting on CI"
+plan clear
+session list
+session ls
+session open 3
+session show 3
+history show
+history list
+history show 3
+auth status
+auth login
+auth login github
+auth logout
+update check
+update apply
+config show
+config set approval|strategy|sandbox|retries &lt;value&gt;
+status
+run cargo test -p harper-core
+help</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <p>Use <code>run ...</code> for operating-system commands. Harper routes that path through the existing command runner, approval policy, sandbox policy, and audit logging.</p>
+                <p>This is Harper-native command handling, not a Unix-compatible shell. Pipes, redirects, glob expansion, job control, and process substitution are intentionally outside this command surface.</p>
+                <p>Native commands can also use a leading slash. Typing <code>/</code> opens the full slash-command list in the TUI. Use <code>↑</code>/<code>↓</code> or <code>Tab</code> to move through suggestions, then keep typing or submit the command directly from the chat input.</p>
                 <div class="code-wrapper">
                     <pre><code>/help
 /agents
@@ -85,7 +117,6 @@ SUPABASE_ALLOWED_PROVIDERS=github</code></pre>
 /auth logout</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p>Typing <code>/</code> opens the full slash-command list in the TUI. Use <code>↑</code>/<code>↓</code> or <code>Tab</code> to move through suggestions, then keep typing or submit the command directly from the chat input.</p>
                 <p>For auth commands, <code>/auth login github</code> opens the browser, Harper polls the local server for completion, and <code>/auth status</code> reports the currently stored local TUI session.</p>
                 <p><code>/strategy</code> shows the current execution strategy. Use <code>/strategy auto</code>, <code>/strategy grounded</code>, <code>/strategy deterministic</code>, or <code>/strategy model</code> to switch the live chat session without leaving the conversation.</p>
                 <p><code>/update</code> reports the current cached update state from the chat header. Use <code>/update check</code> to re-run the release-manifest check and refresh that header status. The same action is also available in <code>Settings -&gt; Execution Policy -&gt; Updates</code>. Harper uses the default GitHub release manifest automatically, and <code>HARPER_UPDATE_MANIFEST_URL</code> can override that source when needed.</p>

--- a/website/nav-updates.json
+++ b/website/nav-updates.json
@@ -1,9 +1,9 @@
 {
-  "index.html": "2026-05-01-home-v2",
-  "docs.html": "2026-05-05-docs-adx",
-  "installation.html": "2026-05-05-install-adx",
+  "index.html": "2026-05-09-home-shell",
+  "docs.html": "2026-05-09-docs-shell",
+  "installation.html": "2026-05-09-install-shell",
   "troubleshooting.html": "2026-05-01-troubleshooting-v2",
-  "blog.html": "2026-05-01-blog-v6",
+  "blog.html": "2026-05-09-blog-shell",
   "changelog.html": "2026-04-28-changelog",
   "server.html": "2026-05-01-server-v8",
   "terms.html": "2026-04-28-terms",


### PR DESCRIPTION
## Changes

- Introduced native Harper commands for TUI and batch mode:
  - `plan`, `session`, `history`, `auth`, `config`, `update`, `status`, `help`, `ask`, and explicit `run ...`.
- Routed native commands through structured outcomes so TUI and batch can handle auth, config, updates, sessions, and command execution without model routing.
- Kept natural-language prompts model-bound unless the input is an exact native command or explicit slash command.
- Updated completions, docs, README, website pages, and nav update markers for the native command surface.

## Validation

- `cargo test -p harper-core native_shell --lib`
- `cargo test -p harper-ui slash_completion --lib`
- `cargo test -p harper-ui --bin harper-batch batch_run_response`
- `cargo clippy --all-targets --all-features --workspace -- -A clippy::pedantic -D warnings`
- `cargo run -q -p harper-ui --bin harper-batch -- --prompt 'help me debug this' --prompt 'plan the migration' --prompt 'update status' --json`
- Batch smoke checked native plan, session, history, auth, config, update, and `run` approval-rejection paths.
