### PR TITLE
[feat] compact menu and scrollable completion popup for small terminals

### DIFF
--- a/lib/harper-ui/src/interfaces/ui/app.rs
+++ b/lib/harper-ui/src/interfaces/ui/app.rs
@@ -29,6 +29,7 @@ use tokio::sync::oneshot;
 const MAX_SIDEBAR_PROBE_ENTRIES: usize = 5;
 const MAX_SIDEBAR_GIT_ENTRIES: usize = 4;
 const MAX_SIDEBAR_FILE_ENTRIES: usize = 6;
+pub const MAIN_MENU_ITEM_COUNT: usize = 6;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct ReviewFindingState {
@@ -649,6 +650,10 @@ impl TuiApp {
         self.set_message(content, MessageType::Info, Some(Duration::from_secs(3)));
     }
 
+    pub fn set_persistent_info_message(&mut self, content: String) {
+        self.set_message(content, MessageType::Info, None);
+    }
+
     pub fn clear_message(&mut self) {
         self.message = None;
         self.help_selected = 0;
@@ -725,7 +730,7 @@ impl TuiApp {
         let profile_action_count = self.profile_action_count();
         let execution_policy_row_count = self.execution_policy_row_count();
         match &mut self.state {
-            AppState::Menu(sel) => *sel = (*sel + 1) % 6,
+            AppState::Menu(sel) => *sel = (*sel + 1) % MAIN_MENU_ITEM_COUNT,
             AppState::Chat(chat_state) => {
                 chat_state.normalize_navigation_focus();
                 match chat_state.navigation_focus {
@@ -801,7 +806,13 @@ impl TuiApp {
         let profile_action_count = self.profile_action_count();
         let execution_policy_row_count = self.execution_policy_row_count();
         match &mut self.state {
-            AppState::Menu(sel) => *sel = if *sel == 0 { 5 } else { *sel - 1 },
+            AppState::Menu(sel) => {
+                *sel = if *sel == 0 {
+                    MAIN_MENU_ITEM_COUNT - 1
+                } else {
+                    *sel - 1
+                }
+            }
             AppState::Chat(chat_state) => {
                 chat_state.normalize_navigation_focus();
                 match chat_state.navigation_focus {
@@ -939,6 +950,19 @@ mod tests {
             message_type: MessageType::Help,
             expires_at: None,
         });
+
+        app.refresh_message();
+        assert!(app.message.is_some());
+    }
+
+    #[test]
+    fn persistent_info_messages_do_not_expire() {
+        let mut app = TuiApp::new();
+        app.set_persistent_info_message("Help".to_string());
+
+        let message = app.message.as_ref().expect("info message");
+        assert!(matches!(message.message_type, MessageType::Info));
+        assert!(message.expires_at.is_none());
 
         app.refresh_message();
         assert!(app.message.is_some());

--- a/lib/harper-ui/src/interfaces/ui/tui.rs
+++ b/lib/harper-ui/src/interfaces/ui/tui.rs
@@ -268,6 +268,10 @@ fn final_chat_loop_outcome(
     }
 }
 
+fn display_command_info(app: &mut TuiApp, response: String) {
+    app.set_persistent_info_message(response);
+}
+
 fn parse_strategy_command(
     input: &str,
     current: ExecutionStrategy,
@@ -756,7 +760,7 @@ pub async fn run_tui(
                                         ) {
                                             Ok(harper_core::NativeShellOutcome::Handled(response)) => {
                                                 chat_state.active_plan = harper_core::memory::storage::load_plan_state(conn, &session_id).ok().flatten();
-                                                app.set_info_message(response);
+                                                display_command_info(&mut app, response);
                                                 continue;
                                             }
                                             Ok(harper_core::NativeShellOutcome::Ask(prompt)) => {
@@ -781,10 +785,11 @@ pub async fn run_tui(
                                                 continue;
                                             }
                                             Ok(harper_core::NativeShellOutcome::UpdateStatus) => {
-                                                if let Some(status) = &app.update_status {
-                                                    app.set_info_message(format!("Current {}", status));
+                                                if let Some(status) = app.update_status.clone() {
+                                                    display_command_info(&mut app, format!("Current {}", status));
                                                 } else {
-                                                    app.set_info_message(
+                                                    display_command_info(
+                                                        &mut app,
                                                         "No update status is cached yet. Use /update check."
                                                             .to_string(),
                                                     );
@@ -792,7 +797,8 @@ pub async fn run_tui(
                                                 continue;
                                             }
                                             Ok(harper_core::NativeShellOutcome::UpdateApply) => {
-                                                app.set_info_message(
+                                                display_command_info(
+                                                    &mut app,
                                                     "Update apply is intentionally explicit. Run: harper self-update".to_string(),
                                                 );
                                                 continue;
@@ -879,7 +885,7 @@ pub async fn run_tui(
                                             ));
                                         }
                                         Err(current_only) => {
-                                            app.set_info_message(format!(
+                                            display_command_info(&mut app, format!(
                                                 "Current execution strategy: {}",
                                                 settings::execution_strategy_name(current_only)
                                             ));
@@ -895,7 +901,7 @@ pub async fn run_tui(
                                             } else {
                                                 "off"
                                             };
-                                            app.set_info_message(format!("AGENTS context: {}", status));
+                                            display_command_info(&mut app, format!("AGENTS context: {}", status));
                                         }
                                         AgentsCommand::Set(enabled) => {
                                             app.agents_context_enabled = enabled;
@@ -918,10 +924,11 @@ pub async fn run_tui(
                                 if let Some(command) = parse_update_command(&msg) {
                                     match command {
                                         UpdateCommand::ShowStatus => {
-                                            if let Some(status) = &app.update_status {
-                                                app.set_info_message(format!("Current {}", status));
+                                            if let Some(status) = app.update_status.clone() {
+                                                display_command_info(&mut app, format!("Current {}", status));
                                             } else {
-                                                app.set_info_message(
+                                                display_command_info(
+                                                    &mut app,
                                                     "No update status is cached yet. Use /update check."
                                                         .to_string(),
                                                 );
@@ -955,7 +962,7 @@ pub async fn run_tui(
                                             let status = app.auth_session.as_ref().map(|session| {
                                                 session.user.email.clone().unwrap_or_else(|| session.user.user_id.clone())
                                             }).unwrap_or_else(|| "not signed in".to_string());
-                                            app.set_info_message(format!("TUI auth status: {}", status));
+                                            display_command_info(&mut app, format!("TUI auth status: {}", status));
                                             continue;
                                         }
                                     }
@@ -1685,7 +1692,8 @@ pub async fn run_tui(
 
 #[cfg(test)]
 mod tests {
-    use super::{final_chat_loop_outcome, infer_chat_loop_stage};
+    use super::{display_command_info, final_chat_loop_outcome, infer_chat_loop_stage};
+    use crate::interfaces::ui::app::{MessageType, TuiApp};
     use harper_core::core::plan::{PlanLoopOutcome, PlanLoopStage};
 
     #[test]
@@ -1706,5 +1714,27 @@ mod tests {
             final_chat_loop_outcome(Some(&PlanLoopStage::Responding), None),
             PlanLoopOutcome::Responded
         );
+    }
+
+    #[test]
+    fn native_shell_help_uses_persistent_info_message() {
+        let mut app = TuiApp::new();
+
+        display_command_info(&mut app, "Help".to_string());
+
+        let message = app.message.as_ref().expect("help message");
+        assert!(matches!(message.message_type, MessageType::Info));
+        assert!(message.expires_at.is_none());
+    }
+
+    #[test]
+    fn command_info_messages_do_not_expire() {
+        let mut app = TuiApp::new();
+
+        display_command_info(&mut app, "Current execution strategy: auto".to_string());
+
+        let message = app.message.as_ref().expect("command info message");
+        assert!(matches!(message.message_type, MessageType::Info));
+        assert!(message.expires_at.is_none());
     }
 }

--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -18,13 +18,18 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Padding, Paragraph, Wrap};
 
-use super::app::{AppState, ApprovalState, ReviewState, SessionInfo, TuiApp, UiMessage};
+use super::app::{
+    AppState, ApprovalState, ReviewState, SessionInfo, TuiApp, UiMessage, MAIN_MENU_ITEM_COUNT,
+};
 use super::settings;
 use super::theme::Theme;
 use harper_core::core::plan::{
     PlanFollowup, PlanJobRecord, PlanJobStatus, PlanLoopOutcome, PlanLoopStage,
 };
 use harper_core::{PlanRuntime, PlanState, PlanStepStatus, ResolvedAgents};
+
+const MAX_COMPLETION_POPUP_HEIGHT: u16 = 12;
+const MENU_BLOCK_VERTICAL_OVERHEAD: u16 = 3;
 
 // Refined shortcuts for a cleaner footer
 const CHAT_FOOTER_SHORTCUTS: &[&[(&str, &str)]] = &[
@@ -216,12 +221,14 @@ pub fn refresh_chat_render_cache(chat_state: &mut super::app::ChatState, theme: 
 
 pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
     let area = frame.area();
+    let compact_menu =
+        matches!(app.state, AppState::Menu(_)) && area.height <= MAIN_MENU_ITEM_COUNT as u16 + 4;
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(0), Constraint::Length(2)])
         .split(area);
 
-    let main_area = chunks[0];
+    let main_area = if compact_menu { area } else { chunks[0] };
     let footer_area = chunks[1];
 
     match &app.state {
@@ -275,7 +282,6 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 .as_ref()
                 .map(|review| review_panel_height(review, chat_state.review_selected))
                 .unwrap_or(0);
-            let completion_height = completion_popup_height(chat_state);
             let input_height = input_area_height(&chat_state.input, chat_area.width);
 
             let mut constraints = vec![Constraint::Length(3), Constraint::Min(5)];
@@ -460,6 +466,10 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
                 + usize::from(has_agents);
             frame.render_widget(input_widget, chunks[input_index]);
 
+            let completion_height = completion_popup_height(
+                chat_state,
+                chunks[input_index].y.saturating_sub(chat_area.y),
+            );
             if completion_height > 0 {
                 let popup_area = Rect {
                     x: chunks[input_index].x,
@@ -493,7 +503,7 @@ pub fn draw(frame: &mut Frame, app: &TuiApp, theme: &Theme) {
         AppState::Stats(stats) => draw_stats(frame, stats, theme, main_area),
     }
 
-    if !matches!(app.state, AppState::Chat(_)) {
+    if !matches!(app.state, AppState::Chat(_)) && !compact_menu {
         draw_zen_footer(frame, app, theme, footer_area);
     }
 
@@ -1406,12 +1416,41 @@ fn plan_panel_height(plan: &PlanState) -> u16 {
     lines as u16
 }
 
-fn completion_popup_height(chat_state: &super::app::ChatState) -> u16 {
+fn completion_popup_height(chat_state: &super::app::ChatState, available_height: u16) -> u16 {
     if chat_state.input.starts_with('/') && !chat_state.completion_candidates.is_empty() {
-        (chat_state.completion_candidates.len() as u16) + 2
+        ((chat_state.completion_candidates.len() as u16) + 2)
+            .min(MAX_COMPLETION_POPUP_HEIGHT)
+            .min(available_height)
     } else {
         0
     }
+}
+
+fn completion_visible_range(
+    total: usize,
+    selected: usize,
+    visible_capacity: usize,
+) -> (usize, usize) {
+    selected_visible_range(total, selected, visible_capacity)
+}
+
+fn selected_visible_range(
+    total: usize,
+    selected: usize,
+    visible_capacity: usize,
+) -> (usize, usize) {
+    if total == 0 || visible_capacity == 0 {
+        return (0, 0);
+    }
+
+    let selected = selected.min(total.saturating_sub(1));
+    let visible_capacity = visible_capacity.min(total);
+    let half_window = visible_capacity / 2;
+    let max_start = total.saturating_sub(visible_capacity);
+    let start = selected.saturating_sub(half_window).min(max_start);
+    let end = start + visible_capacity;
+
+    (start, end)
 }
 
 fn draw_completion_popup(
@@ -1420,9 +1459,23 @@ fn draw_completion_popup(
     theme: &Theme,
     area: Rect,
 ) {
+    let selected_index = chat_state
+        .completion_candidates
+        .iter()
+        .position(|candidate| candidate == &chat_state.input)
+        .unwrap_or(chat_state.completion_index)
+        .min(chat_state.completion_candidates.len().saturating_sub(1));
+    let visible_capacity = area.height.saturating_sub(2) as usize;
+    let (window_start, window_end) = completion_visible_range(
+        chat_state.completion_candidates.len(),
+        selected_index,
+        visible_capacity,
+    );
     let items = chat_state
         .completion_candidates
         .iter()
+        .skip(window_start)
+        .take(window_end.saturating_sub(window_start))
         .map(|candidate| {
             let style = if candidate == &chat_state.input {
                 theme
@@ -2401,12 +2454,29 @@ fn draw_zen_menu(frame: &mut Frame, selected: usize, theme: &Theme, area: Rect) 
         "Settings",
         "Quit",
     ];
+    debug_assert_eq!(menu_items.len(), MAIN_MENU_ITEM_COUNT);
 
-    let area = centered_rect(40, 35, area);
+    let compact = area.height <= MAIN_MENU_ITEM_COUNT as u16 + MENU_BLOCK_VERTICAL_OVERHEAD;
+    let area = if compact {
+        centered_rect_width(40, area)
+    } else {
+        let min_menu_height = MAIN_MENU_ITEM_COUNT as u16 + MENU_BLOCK_VERTICAL_OVERHEAD;
+        centered_rect_with_min_height(40, 35, min_menu_height, area)
+    };
+    let visible_capacity = if compact {
+        area.height as usize
+    } else {
+        area.height.saturating_sub(MENU_BLOCK_VERTICAL_OVERHEAD) as usize
+    };
+    let selected = selected.min(menu_items.len().saturating_sub(1));
+    let (window_start, window_end) =
+        selected_visible_range(menu_items.len(), selected, visible_capacity);
 
     let items: Vec<ListItem> = menu_items
         .iter()
         .enumerate()
+        .skip(window_start)
+        .take(window_end.saturating_sub(window_start))
         .map(|(i, label)| {
             let (prefix, style) = if i == selected {
                 (
@@ -2426,16 +2496,20 @@ fn draw_zen_menu(frame: &mut Frame, selected: usize, theme: &Theme, area: Rect) 
         })
         .collect();
 
-    let menu = List::new(items).block(
-        Block::default()
-            .title("Harper")
-            .title_style(
-                Style::default()
-                    .fg(theme.foreground)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .padding(Padding::uniform(1)),
-    );
+    let menu = if compact {
+        List::new(items)
+    } else {
+        List::new(items).block(
+            Block::default()
+                .title("Harper")
+                .title_style(
+                    Style::default()
+                        .fg(theme.foreground)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .padding(Padding::uniform(1)),
+        )
+    };
 
     frame.render_widget(menu, area);
 }
@@ -2458,6 +2532,30 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(popup_layout[1])[1]
+}
+
+fn centered_rect_width(percent_x: u16, area: Rect) -> Rect {
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(area)[1]
+}
+
+fn centered_rect_with_min_height(
+    percent_x: u16,
+    percent_y: u16,
+    min_height: u16,
+    area: Rect,
+) -> Rect {
+    let rect = centered_rect(percent_x, percent_y, area);
+    let height = rect.height.max(min_height).min(area.height);
+    let y = area.y + area.height.saturating_sub(height) / 2;
+
+    Rect { y, height, ..rect }
 }
 
 fn footer_shortcuts_for_state(
@@ -3631,7 +3729,9 @@ mod tests {
     use super::*;
     use crate::interfaces::ui::app;
     use harper_core::{core::Message, PlanItem};
+    use ratatui::backend::TestBackend;
     use ratatui::style::Color;
+    use ratatui::Terminal;
 
     fn setup() -> (SyntaxSet, ThemeSet) {
         (
@@ -3681,6 +3781,107 @@ mod tests {
             rendered_transcript_lines: Vec::new(),
             render_cache_theme_key: String::new(),
         }
+    }
+
+    #[test]
+    fn draw_slash_completion_popup_fits_small_terminal() {
+        let mut chat_state = empty_chat_state();
+        chat_state.input = "/".to_string();
+        chat_state.completion_candidates = (0..40)
+            .map(|index| format!("/command-{index}"))
+            .collect::<Vec<_>>();
+
+        let mut app = app::TuiApp::default();
+        app.state = app::AppState::Chat(Box::new(chat_state));
+
+        let backend = TestBackend::new(80, 20);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let theme = Theme::default();
+
+        terminal
+            .draw(|frame| draw(frame, &app, &theme))
+            .expect("slash completion popup should render");
+    }
+
+    #[test]
+    fn completion_visible_range_tracks_middle_selection() {
+        assert_eq!(completion_visible_range(40, 25, 10), (20, 30));
+    }
+
+    #[test]
+    fn completion_visible_range_clamps_near_end() {
+        assert_eq!(completion_visible_range(40, 39, 10), (30, 40));
+    }
+
+    #[test]
+    fn menu_rect_keeps_all_rows_visible_on_small_terminal() {
+        let area = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 18,
+        };
+
+        let menu_area = centered_rect_with_min_height(
+            40,
+            35,
+            MAIN_MENU_ITEM_COUNT as u16 + MENU_BLOCK_VERTICAL_OVERHEAD,
+            area,
+        );
+
+        assert_eq!(menu_area.height, 9);
+        assert_eq!(menu_area.y, 4);
+    }
+
+    #[test]
+    fn menu_visible_range_tracks_selection_like_completion_popup() {
+        assert_eq!(selected_visible_range(MAIN_MENU_ITEM_COUNT, 5, 3), (3, 6));
+    }
+
+    #[test]
+    fn menu_visible_range_shows_all_items_when_capacity_allows() {
+        assert_eq!(
+            selected_visible_range(MAIN_MENU_ITEM_COUNT, 5, MAIN_MENU_ITEM_COUNT),
+            (0, MAIN_MENU_ITEM_COUNT)
+        );
+    }
+
+    #[test]
+    fn draw_menu_fits_exact_item_height_terminal() {
+        let mut app = app::TuiApp::default();
+        app.state = app::AppState::Menu(MAIN_MENU_ITEM_COUNT - 1);
+
+        let backend = TestBackend::new(80, MAIN_MENU_ITEM_COUNT as u16);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let theme = Theme::default();
+
+        terminal
+            .draw(|frame| draw(frame, &app, &theme))
+            .expect("compact menu should render");
+    }
+
+    #[test]
+    fn draw_menu_shows_quit_at_twenty_six_rows() {
+        let mut app = app::TuiApp::default();
+        app.state = app::AppState::Menu(MAIN_MENU_ITEM_COUNT - 1);
+
+        let backend = TestBackend::new(80, 26);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let theme = Theme::default();
+
+        terminal
+            .draw(|frame| draw(frame, &app, &theme))
+            .expect("menu should render");
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+
+        assert!(rendered.contains("Quit"));
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- Kept native command info panels visible until dismissed or replaced:
  - help
  - status
  - config show
  - plan show
  - current strategy, agents, update, and auth status queries
- Updated slash command completion rendering:
  - clamps popup height to available terminal space
  - keeps the selected candidate visible while cycling
- Updated main menu rendering for short terminal heights:
  - uses shared selected-window behavior
  - switches to compact mode when needed
  - keeps all menu rows visible when the terminal has enough physical rows
- Added focused UI regression tests for popup overflow, menu clipping, and persistent command messages.
- Storage changes: none.
- Migrations: none.
- Config changes: none.
- Docs updates: none.

## Validation

- cargo fmt --check
- cargo test -p harper-ui menu --lib
- cargo test -p harper-ui slash_completion --lib
- cargo test -p harper-ui command_info_messages_do_not_expire --lib
- cargo test -p harper-ui native_shell_help_uses_persistent_info_message --lib
- cargo test -p harper-ui persistent_info_messages_do_not_expire --lib
- cargo check -p harper-ui --lib
- Push hooks passed: fmt, clippy, cargo check