### PR TITLE
[fix] use github app token for release prs

### DIFF
--- a/.github/actions/rust/action.yml
+++ b/.github/actions/rust/action.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 harpertoken
+# Copyright 2026 harpertoken
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 name: rust
-description: 'Setup Rust toolchain and cache'
+description: "Setup Rust toolchain and cache"
 inputs:
   components:
-    description: 'Additional Rust components to install'
+    description: "Additional Rust components to install"
     required: false
-    default: ''
+    default: ""
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Install Rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,11 +136,19 @@ jobs:
       head_sha: ${{ steps.head.outputs.sha }}
       harper_core_version: ${{ steps.version.outputs.harper_core_version }}
     steps:
+      - id: release-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.HARPER_APP_ID }}
+          private-key: ${{ secrets.HARPER_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
       - id: release
         uses: libnudget/release@v1.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release_token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          release_token: ${{ steps.release-app-token.outputs.token }}
           packages: '[{"path": ".", "name": "harper-workspace"}, {"path": "lib/harper-core", "name": "harper-core"}, {"path": "lib/harper-ui", "name": "harper-ui"}, {"path": "lib/harper-firmware", "name": "harper-firmware"}, {"path": "lib/harper-mcp-server", "name": "harper-mcp-server"}, {"path": "lib/harper-sandbox", "name": "harper-sandbox"}]'
           version_bump: ${{ github.event.inputs.version_bump || 'patch' }}
           release_mode: ${{ github.event.inputs.release_mode || 'pr' }}


### PR DESCRIPTION
## Changes

- Mint a GitHub App installation token in the release workflow before creating release PRs.
- Pass the app token to `libnudget/release` as `release_token` so release PRs are authored by the installed app.
- Update the Rust composite action copyright year.

## Validation

- `python3` YAML parse check for `.github/workflows/release.yml` and `.github/actions/rust/action.yml`
- push hooks: `check yaml`, `fmt`, `clippy`, `cargo check`
