### PR TITLE
[fix] recognize release app cla signer

### DIFF
--- a/signed.json
+++ b/signed.json
@@ -2,7 +2,7 @@
   "signed": [
     "bniladridas",
     "dependabot[bot]",
-    "harper-rel-hq",
-    "github-actions[bot]"
+    "github-actions[bot]",
+    "harpertoken-engineering[bot]"
   ]
 }


### PR DESCRIPTION
## Changes

- Replaced stale `harper-rel-hq` CLA signer with `harpertoken-engineering[bot]`.
- Kept the CLA signer list sorted.

## Validation

- `python3 -m json.tool signed.json`
- pre-push checks