### PR TITLE
[fix] stabilize harper workflow checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | Dependency Review | `dependency-review.yml` | Uses GitHub's dependency-review action on PRs. | PR events |
 | Docs | `docs.yml` | Builds mkdocs documentation and deploys to GitHub Pages. | Push/PR touching docs |
 | PR Title | `fix-pr-title.yml` | Rewrites PR titles into `[scope] message` format via `libnudget/title@v1`. Title edits run through the Harper app token. | PR events on `main` |
-| Harper | `harper-check.yml` | Publishes a lightweight app-backed check so Harper automation appears as the Harper GitHub App in PR checks. | PR target events |
+| Harper | `harper-check.yml` | Publishes a lightweight app-backed check so Harper automation appears as the Harper GitHub App in PR checks and on `main`. | PR target events, push to `main` |
 | Labels | `label-sync.yml` | Syncs repository labels from `config/labeler.yml` via custom script. Label writes run through the Harper app token. | Weekly cron, manual dispatch |
 | Lock PRs | `lock-merged-prs.yml` | Locks PRs after merge (via `gh pr lock`). Auto Merge path is handled by `post-auto-merge-ci.yml`. Lock actions run through the Harper app token. | PR closed (merged) |
 | Nightly | `nightly.yml` | Uses `libnudget/rust-nightly` reusable workflow: runs tests, builds release, creates prerelease with tag `nightly-{sha}`. Benchmarks disabled for faster runs. | Daily cron (midnight UTC), manual dispatch |

--- a/.github/workflows/assign-pr-milestone.yml
+++ b/.github/workflows/assign-pr-milestone.yml
@@ -13,7 +13,8 @@ jobs:
     if: github.repository_owner == 'harpertoken'
     permissions:
       contents: read
-      pull-requests: read
+      issues: write
+      pull-requests: write
     steps:
       - id: app-token
         name: Create Harper app token
@@ -22,7 +23,7 @@ jobs:
           app-id: ${{ secrets.HARPER_APP_ID }}
           private-key: ${{ secrets.HARPER_APP_PRIVATE_KEY }}
           permission-issues: write
-          permission-pull-requests: read
+          permission-pull-requests: write
 
       - name: Assign milestone
         env:

--- a/.github/workflows/harper-check.yml
+++ b/.github/workflows/harper-check.yml
@@ -3,6 +3,8 @@
 name: Harper
 
 on:
+  push:
+    branches: [main]
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
 
@@ -29,7 +31,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
 
@@ -40,5 +42,5 @@ jobs:
             -f status='completed' \
             -f conclusion='success' \
             -f output[title]='Harper automation' \
-            -f output[summary]='Harper app automation is active for this pull request.' \
+            -f output[summary]='Harper app automation is active for this ref.' \
             --silent


### PR DESCRIPTION
## Changes

- Allows the milestone workflow to edit PR milestones with the Harper app token.
- Runs the Harper app-owned check on `main` pushes as well as PR events.
- Updates workflow documentation for the expanded Harper trigger.

## Validation

- README workflow list matches actual workflow files.
- `git diff --check`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'`
- pre-push hooks: yaml, fmt, clippy, cargo check
