### PR TITLE
[feat] include windows package manifests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -35,6 +35,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | Cancel Runs | `cancel-runs.yml` | Cancels in-progress runs when `/cancel-runs` is commented on PRs via `libnudget/cancel@v1`. Also triggers on `cancel-runs` label. | Issue comment on PRs, `cancel-runs` label |
 | Lockfiles | `update-lockfiles.yml` | Runs `cargo update` + `CARGO_BAZEL_REPIN=true bazel build :harper_bin` (repins `cargo-bazel-lock.json`), opens PR. PR creation runs through the Harper app token. | Weekly cron (Sunday midnight UTC), manual dispatch |
 | Homebrew | `update-homebrew-tap.yml` | Manually updates `harpertoken/homebrew-tap/Formula/harper-ai.rb` for a published `harper-*` release by downloading the release tarball, recomputing sha256, patching the formula, and opening a PR in the tap repo. Requires `HOMEBREW_TAP_TOKEN`. | Manual dispatch |
+| Windows Packages | `windows-packages.yml` | Generates Scoop and winget manifests from a published Windows release artifact and uploads them for package-channel submission. | Manual dispatch |
 | Website | `website.yml` | Builds and deploys the website bundle to GitHub Pages. | Push to `main` touching `website/**`, manual dispatch |
 
 > **Tip:** Run `rg -n '^name:' .github/workflows` to see the canonical name shown in the Actions UI.

--- a/.github/workflows/windows-packages.yml
+++ b/.github/workflows/windows-packages.yml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+---
+name: Windows Packages
+
+"on":
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Installable Harper release tag"
+        required: true
+        type: string
+
+jobs:
+  manifests:
+    name: Manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Harper
+        uses: actions/checkout@v4
+
+      - name: Validate release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ github.event.inputs.release_tag }}" in
+            harper-*) ;;
+            *)
+              echo "release_tag must start with harper-"
+              exit 1
+              ;;
+          esac
+
+      - name: Download Windows release artifact
+        id: artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ github.event.inputs.release_tag }}"
+          asset_url="https://github.com/harpertoken/harper/releases/download/${release_tag}/harper-windows-x86_64.zip"
+          curl -L "$asset_url" -o harper-windows-x86_64.zip
+          sha256=$(sha256sum harper-windows-x86_64.zip | awk '{print $1}')
+          echo "asset_url=$asset_url" >> "$GITHUB_OUTPUT"
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Generate manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/generate-windows-package-manifests.py \
+            --release-tag "${{ github.event.inputs.release_tag }}" \
+            --asset-url "${{ steps.artifact.outputs.asset_url }}" \
+            --sha256 "${{ steps.artifact.outputs.sha256 }}" \
+            --output-dir windows-package-manifests
+
+      - name: Upload manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-package-manifests-${{ github.event.inputs.release_tag }}
+          path: windows-package-manifests

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -84,6 +84,10 @@ harper self-update
 
 Direct self-update verifies the published manifest, checksum, and detached signature before replacing the local binary.
 
+### Windows package managers
+
+Windows package-manager channels are being prepared from the same signed GitHub release artifacts. Until winget or Scoop manifests are published, use the direct Windows release artifact and update through Harper's direct updater.
+
 ### Method 4: Using Make
 
 If the project includes a Makefile:

--- a/scripts/generate-windows-package-manifests.py
+++ b/scripts/generate-windows-package-manifests.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import pathlib
+import re
+
+
+PACKAGE_IDENTIFIER = "HarperToken.Harper"
+PACKAGE_NAME = "Harper"
+PUBLISHER = "HarperToken"
+HOMEPAGE = "https://github.com/harpertoken/harper"
+LICENSE = "MIT OR Apache-2.0"
+DESCRIPTION = "Terminal assistant for code and shell work."
+
+
+def version_from_tag(release_tag: str) -> str:
+    prefix = "harper-"
+    if not release_tag.startswith(prefix):
+        raise ValueError(f"release tag must start with '{prefix}': {release_tag}")
+    version = release_tag[len(prefix) :]
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", version):
+        raise ValueError(f"release tag does not contain a package version: {release_tag}")
+    return version
+
+
+def default_windows_asset_url(release_tag: str) -> str:
+    return (
+        f"https://github.com/harpertoken/harper/releases/download/"
+        f"{release_tag}/harper-windows-x86_64.zip"
+    )
+
+
+def write_scoop_manifest(output_dir: pathlib.Path, version: str, asset_url: str, sha256: str) -> None:
+    autoupdate_url = (
+        "https://github.com/harpertoken/harper/releases/download/"
+        "harper-$version/harper-windows-x86_64.zip"
+    )
+    manifest = {
+        "version": version,
+        "description": DESCRIPTION,
+        "homepage": HOMEPAGE,
+        "license": LICENSE,
+        "architecture": {
+            "64bit": {
+                "url": asset_url,
+                "hash": sha256,
+            }
+        },
+        "bin": "harper.exe",
+        "checkver": {
+            "github": HOMEPAGE,
+            "regex": r"harper-([\d.]+)",
+        },
+        "autoupdate": {
+            "architecture": {
+                "64bit": {
+                    "url": autoupdate_url,
+                }
+            }
+        },
+    }
+
+    path = output_dir / "scoop" / "harper.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def write_winget_manifests(output_dir: pathlib.Path, version: str, asset_url: str, sha256: str) -> None:
+    manifest_dir = (
+        output_dir
+        / "winget"
+        / "manifests"
+        / "h"
+        / PUBLISHER
+        / PACKAGE_NAME
+        / version
+    )
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+
+    version_manifest = f"""PackageIdentifier: {PACKAGE_IDENTIFIER}
+PackageVersion: {version}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+"""
+    locale_manifest = f"""PackageIdentifier: {PACKAGE_IDENTIFIER}
+PackageVersion: {version}
+PackageLocale: en-US
+Publisher: {PUBLISHER}
+PackageName: {PACKAGE_NAME}
+License: {LICENSE}
+ShortDescription: {DESCRIPTION}
+PackageUrl: {HOMEPAGE}
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+"""
+    installer_manifest = f"""PackageIdentifier: {PACKAGE_IDENTIFIER}
+PackageVersion: {version}
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: harper.exe
+    PortableCommandAlias: harper
+Installers:
+  - Architecture: x64
+    InstallerUrl: {asset_url}
+    InstallerSha256: {sha256.upper()}
+ManifestType: installer
+ManifestVersion: 1.10.0
+"""
+
+    (manifest_dir / f"{PACKAGE_IDENTIFIER}.yaml").write_text(version_manifest, encoding="utf-8")
+    (manifest_dir / f"{PACKAGE_IDENTIFIER}.locale.en-US.yaml").write_text(
+        locale_manifest, encoding="utf-8"
+    )
+    (manifest_dir / f"{PACKAGE_IDENTIFIER}.installer.yaml").write_text(
+        installer_manifest, encoding="utf-8"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate Windows package-manager manifests for a Harper release."
+    )
+    parser.add_argument("--release-tag", required=True, help="Release tag like harper-0.20.1")
+    parser.add_argument("--sha256", required=True, help="SHA256 of harper-windows-x86_64.zip")
+    parser.add_argument("--asset-url", help="Override the Windows release asset URL")
+    parser.add_argument("--output-dir", required=True, help="Directory to write manifests into")
+    args = parser.parse_args()
+
+    sha256 = args.sha256.lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", sha256):
+        raise SystemExit("sha256 must be 64 lowercase or uppercase hexadecimal characters")
+
+    try:
+        version = version_from_tag(args.release_tag)
+    except ValueError as err:
+        raise SystemExit(str(err)) from err
+
+    asset_url = args.asset_url or default_windows_asset_url(args.release_tag)
+    output_dir = pathlib.Path(args.output_dir)
+    write_scoop_manifest(output_dir, version, asset_url, sha256)
+    write_winget_manifests(output_dir, version, asset_url, sha256)
+    print(f"generated Windows package manifests for {args.release_tag} in {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Changes

- Included a Windows package manifest generator for Scoop and winget.
- Included a manual workflow that downloads a published Windows release artifact, computes its SHA-256, and uploads generated manifests.
- Documented the workflow and clarified that Windows package-manager channels are being prepared, not yet published.

## Validation

- Generated sample manifests for `harper-0.20.1` with a test checksum.
- Parsed generated Scoop JSON and winget YAML manifests.
- Verified workflow README entries match actual workflow files.
- `git diff --check`
- pre-push hooks: yaml, fmt, clippy, cargo check
