### PR TITLE
[feat] include linux native packages

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,6 +26,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | PR Title | `fix-pr-title.yml` | Rewrites PR titles into `[scope] message` format via `libnudget/title@v1`. Title edits run through the Harper app token. | PR events on `main` |
 | Harper | `harper-check.yml` | Publishes a lightweight app-backed check so Harper automation appears as the Harper GitHub App in PR checks and on `main`. | PR target events, push to `main` |
 | Labels | `label-sync.yml` | Syncs repository labels from `config/labeler.yml` via custom script. Label writes run through the Harper app token. | Weekly cron, manual dispatch |
+| Linux Packages | `linux-packages.yml` | Generates Debian packages from published Linux release artifacts and uploads them for package-channel validation. | Manual dispatch |
 | Lock PRs | `lock-merged-prs.yml` | Locks PRs after merge (via `gh pr lock`). Auto Merge path is handled by `post-auto-merge-ci.yml`. Lock actions run through the Harper app token. | PR closed (merged) |
 | Nightly | `nightly.yml` | Uses `libnudget/rust-nightly` reusable workflow: runs tests, builds release, creates prerelease with tag `nightly-{sha}`. Benchmarks disabled for faster runs. | Daily cron (midnight UTC), manual dispatch |
 | PR Checks | `pr-checks.yml` | Validates PR metadata and auto-labels via `config/labeler.yml`. Auto-label writes run through the Harper app token. | PR workflow_call, push to `main` |

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+---
+name: Linux Packages
+
+"on":
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Installable Harper release tag"
+        required: true
+        type: string
+
+jobs:
+  deb:
+    name: Debian
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Harper
+        uses: actions/checkout@v4
+
+      - name: Validate release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ github.event.inputs.release_tag }}" in
+            harper-*) ;;
+            *)
+              echo "release_tag must start with harper-"
+              exit 1
+              ;;
+          esac
+
+      - name: Download Linux release artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ github.event.inputs.release_tag }}"
+          mkdir -p linux-release-artifacts
+          for asset in harper-linux-x86_64.tar.gz harper-linux-aarch64.tar.gz; do
+            curl -L \
+              "https://github.com/harpertoken/harper/releases/download/${release_tag}/${asset}" \
+              -o "linux-release-artifacts/${asset}"
+          done
+
+      - name: Generate Debian packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/generate-linux-packages.py \
+            --release-tag "${{ github.event.inputs.release_tag }}" \
+            --artifacts-dir linux-release-artifacts \
+            --output-dir linux-packages
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-packages-${{ github.event.inputs.release_tag }}
+          path: linux-packages/*.deb

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -88,6 +88,10 @@ Direct self-update verifies the published manifest, checksum, and detached signa
 
 Windows package-manager channels are being prepared from the same signed GitHub release artifacts. Until winget or Scoop manifests are published, use the direct Windows release artifact and update through Harper's direct updater.
 
+### Linux native packages
+
+Debian packages are being prepared from the same Linux release artifacts. Until `.deb` packages are published, use the direct Linux release artifact and update through Harper's direct updater.
+
 ### Method 4: Using Make
 
 If the project includes a Makefile:

--- a/scripts/generate-linux-packages.py
+++ b/scripts/generate-linux-packages.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import tarfile
+
+
+PACKAGE_NAME = "harper"
+MAINTAINER = "HarperToken <maintainers@harpertoken.com>"
+HOMEPAGE = "https://github.com/harpertoken/harper"
+DESCRIPTION = "Terminal assistant for code and shell work."
+
+
+ARCHIVES = {
+    "amd64": "harper-linux-x86_64.tar.gz",
+    "arm64": "harper-linux-aarch64.tar.gz",
+}
+
+
+def version_from_tag(release_tag: str) -> str:
+    prefix = "harper-"
+    if not release_tag.startswith(prefix):
+        raise ValueError(f"release tag must start with '{prefix}': {release_tag}")
+    version = release_tag[len(prefix) :]
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+~][0-9A-Za-z.]+)?", version):
+        raise ValueError(f"release tag does not contain a Debian-compatible version: {release_tag}")
+    return version
+
+
+def extract_binary(archive_path: pathlib.Path, work_dir: pathlib.Path) -> pathlib.Path:
+    extract_dir = work_dir / "extract"
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "r:gz") as archive:
+        archive.extractall(extract_dir, filter="data")
+
+    matches = [path for path in extract_dir.rglob("harper") if path.is_file()]
+    if len(matches) != 1:
+        raise ValueError(f"expected one harper binary in {archive_path}, found {len(matches)}")
+    return matches[0]
+
+
+def installed_size_kib(path: pathlib.Path) -> int:
+    return max(1, (path.stat().st_size + 1023) // 1024)
+
+
+def build_deb(archive_path: pathlib.Path, output_dir: pathlib.Path, version: str, arch: str) -> pathlib.Path:
+    if shutil.which("dpkg-deb") is None:
+        raise RuntimeError("dpkg-deb is required to build Debian packages")
+
+    package_root = output_dir / "work" / arch / f"{PACKAGE_NAME}_{version}_{arch}"
+    debian_dir = package_root / "DEBIAN"
+    bin_dir = package_root / "usr" / "bin"
+    debian_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    binary = extract_binary(archive_path, output_dir / "work" / arch)
+    target_binary = bin_dir / "harper"
+    shutil.copy2(binary, target_binary)
+    target_binary.chmod(0o755)
+
+    control = f"""Package: {PACKAGE_NAME}
+Version: {version}
+Section: utils
+Priority: optional
+Architecture: {arch}
+Maintainer: {MAINTAINER}
+Installed-Size: {installed_size_kib(target_binary)}
+Homepage: {HOMEPAGE}
+Description: {DESCRIPTION}
+"""
+    (debian_dir / "control").write_text(control, encoding="utf-8")
+
+    output_path = output_dir / f"{PACKAGE_NAME}_{version}_{arch}.deb"
+    subprocess.run(
+        ["dpkg-deb", "--build", "--root-owner-group", str(package_root), str(output_path)],
+        check=True,
+    )
+    return output_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate Linux native packages for Harper.")
+    parser.add_argument("--release-tag", required=True, help="Release tag like harper-0.20.1")
+    parser.add_argument("--artifacts-dir", required=True, help="Directory containing Linux release tarballs")
+    parser.add_argument("--output-dir", required=True, help="Directory to write packages into")
+    parser.add_argument(
+        "--arch",
+        action="append",
+        choices=sorted(ARCHIVES),
+        help="Architecture to package. Defaults to all supported architectures.",
+    )
+    args = parser.parse_args()
+
+    try:
+        version = version_from_tag(args.release_tag)
+    except ValueError as err:
+        raise SystemExit(str(err)) from err
+
+    artifacts_dir = pathlib.Path(args.artifacts_dir)
+    output_dir = pathlib.Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    arches = args.arch or sorted(ARCHIVES)
+
+    for arch in arches:
+        archive_path = artifacts_dir / ARCHIVES[arch]
+        if not archive_path.is_file():
+            raise SystemExit(f"missing release artifact: {archive_path}")
+        try:
+            package_path = build_deb(archive_path, output_dir, version, arch)
+        except RuntimeError as err:
+            raise SystemExit(str(err)) from err
+        print(f"generated {package_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Changes

- Included a Linux package generator for Debian packages from Harper release tarballs.
- Included a manual workflow that downloads published Linux release artifacts and uploads generated `.deb` packages.
- Documented the workflow and clarified that Linux native package channels are being prepared, not published yet.

## Validation

- Exercised the generator with a synthetic Linux tarball; local macOS validation stops cleanly because `dpkg-deb` is unavailable.
- Parsed workflow YAML.
- Verified workflow README entries match actual workflow files.
- `git diff --check`
- pre-push hooks: yaml, fmt, clippy, cargo check
