### PR TITLE
[feat] include direct install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ cp .env.example .env
 cargo harper
 ```
 
+For release installs, use Homebrew, direct GitHub release artifacts, or the install script at `scripts/install-harper.sh`.
+
 You can use Harper to inspect files, patch code, run commands, and manage multi-step work. Native commands cover plans, sessions, config, and updates. OS commands stay explicit through `run ...`, with approvals and audit logs where configured.
 
 In GitHub Actions, Harper can be installed from release artifacts with `uses: harpertoken/harper@main`.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -75,6 +75,19 @@ brew upgrade harpertoken/tap/harper-ai
 
 Download the release artifact for your platform from GitHub Releases, extract it, and place the `harper` binary somewhere on your `PATH`.
 
+You can also use the direct install script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/harpertoken/harper/main/scripts/install-harper.sh | sh
+```
+
+To pin a specific release or install directory:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/harpertoken/harper/main/scripts/install-harper.sh |
+  HARPER_INSTALL_TAG=harper-0.20.1 HARPER_INSTALL_DIR="$HOME/bin" sh
+```
+
 Direct installs support Harper's built-in updater:
 
 ```bash

--- a/scripts/install-harper.sh
+++ b/scripts/install-harper.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env sh
+
+set -eu
+
+REPO="${HARPER_INSTALL_REPO:-harpertoken/harper}"
+TAG="${HARPER_INSTALL_TAG:-latest}"
+INSTALL_DIR="${HARPER_INSTALL_DIR:-$HOME/.local/bin}"
+TMP_DIR="${TMPDIR:-/tmp}/harper-install.$$"
+DRY_RUN="${HARPER_INSTALL_DRY_RUN:-0}"
+
+error() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || error "$1 is required"
+}
+
+detect_asset() {
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os:$arch" in
+    Darwin:arm64) printf '%s\n' "harper-macos-aarch64.tar.gz" ;;
+    Darwin:x86_64) printf '%s\n' "harper-macos-x86_64.tar.gz" ;;
+    Linux:aarch64) printf '%s\n' "harper-linux-aarch64.tar.gz" ;;
+    Linux:x86_64) printf '%s\n' "harper-linux-x86_64.tar.gz" ;;
+    MINGW*:x86_64 | MSYS*:x86_64 | CYGWIN*:x86_64) printf '%s\n' "harper-windows-x86_64.zip" ;;
+    *) error "unsupported platform: $os/$arch" ;;
+  esac
+}
+
+latest_tag() {
+  need curl
+  need sed
+  curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
+    sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' |
+    head -n 1
+}
+
+extract_archive() {
+  archive="$1"
+  case "$archive" in
+    *.zip)
+      need unzip
+      unzip -q "$archive" -d "$TMP_DIR/extract"
+      ;;
+    *.tar.gz)
+      need tar
+      mkdir -p "$TMP_DIR/extract"
+      tar -xzf "$archive" -C "$TMP_DIR/extract"
+      ;;
+    *) error "unsupported archive: $archive" ;;
+  esac
+}
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT INT TERM
+
+asset="$(detect_asset)"
+if [ "$TAG" = "latest" ]; then
+  TAG="$(latest_tag)"
+fi
+[ -n "$TAG" ] || error "could not resolve Harper release tag"
+
+archive="$TMP_DIR/$asset"
+download_url="https://github.com/$REPO/releases/download/$TAG/$asset"
+binary_name="harper"
+case "$asset" in
+  *.zip) binary_name="harper.exe" ;;
+esac
+
+if [ "$DRY_RUN" = "1" ]; then
+  printf 'release_tag=%s\n' "$TAG"
+  printf 'asset=%s\n' "$asset"
+  printf 'install_dir=%s\n' "$INSTALL_DIR"
+  printf 'download_url=%s\n' "$download_url"
+  exit 0
+fi
+
+need curl
+mkdir -p "$TMP_DIR" "$INSTALL_DIR"
+curl -fL "$download_url" -o "$archive"
+extract_archive "$archive"
+
+binary_path="$(find "$TMP_DIR/extract" -type f -name "$binary_name" | head -n 1)"
+[ -n "$binary_path" ] || error "Harper binary was not found in $asset"
+
+cp "$binary_path" "$INSTALL_DIR/$binary_name"
+chmod +x "$INSTALL_DIR/$binary_name"
+
+printf 'installed Harper %s to %s\n' "$TAG" "$INSTALL_DIR/$binary_name"
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *) printf 'add %s to PATH if needed\n' "$INSTALL_DIR" ;;
+esac


### PR DESCRIPTION
## Changes

- Added `scripts/install-harper.sh` for direct release installs:
  - maps the local OS/architecture to published Harper release assets
  - supports `HARPER_INSTALL_TAG`, `HARPER_INSTALL_DIR`, and dry-run validation
  - installs the resolved binary into the selected bin directory
- Updated README and installation docs with direct install script usage.

## Validation

- `sh -n scripts/install-harper.sh`
- `shellcheck scripts/install-harper.sh`
- `HARPER_INSTALL_DRY_RUN=1 HARPER_INSTALL_TAG=harper-0.20.1 sh scripts/install-harper.sh`
- pre-commit hooks on push: `fmt`, `clippy`, `cargo check`
