### PR TITLE
[fix] clarify container install channel

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,8 +79,7 @@ USER appuser
 # Set environment variables (can be overridden)
 ENV DATABASE_PATH=/app/data/harper.db
 
-# Expose any ports if needed (Harper is CLI, so probably not)
-# EXPOSE 8080
+EXPOSE 8080
 
 # Set the entrypoint
 ENTRYPOINT ["./harper"]

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -124,6 +124,14 @@ Use the Harper GitHub Action to install the CLI in CI from a published release a
 - run: harper --help
 ```
 
+### Container image
+
+Harper container images are published on merge to `main`:
+
+```bash
+docker run --rm -it ghcr.io/harpertoken/harper/harper:latest
+```
+
 ### Method 4: Using Make
 
 If the project includes a Makefile:

--- a/docs/user-guide/server.md
+++ b/docs/user-guide/server.md
@@ -187,5 +187,5 @@ To use a different port, update these files:
 In Docker, the server is enabled by default:
 
 ```bash
-docker run --rm -it -p 8080:8080 harper
+docker run --rm -it -p 8080:8080 ghcr.io/harpertoken/harper/harper:latest
 ```


### PR DESCRIPTION
## Changes

- Documented the published GHCR container image in the installation guide.
- Updated server Docker example to use the fully qualified image name.
- Added `EXPOSE 8080` to the Dockerfile to match the Docker server config.

## Validation

- `rg -n "ghcr.io/harpertoken/harper/harper|EXPOSE 8080|docker run" docker/Dockerfile docs/user-guide/installation.md docs/user-guide/server.md`
- pre-commit hooks on push: `fmt`, `clippy`, `cargo check`
