### PR TITLE
[feat] include vscode extension package workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,6 +39,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | Lockfiles | `update-lockfiles.yml` | Runs `cargo update` + `CARGO_BAZEL_REPIN=true bazel build :harper_bin` (repins `cargo-bazel-lock.json`), opens PR. PR creation runs through the Harper app token. | Weekly cron (Sunday midnight UTC), manual dispatch |
 | Homebrew | `update-homebrew-tap.yml` | Manually updates `harpertoken/homebrew-tap/Formula/harper-ai.rb` for a published `harper-*` release by downloading the release tarball, recomputing sha256, patching the formula, and opening a PR in the tap repo. Requires `HOMEBREW_TAP_TOKEN`. | Manual dispatch |
 | Windows Packages | `windows-packages.yml` | Generates Scoop and winget manifests from a published Windows release artifact and uploads them for package-channel submission. | Manual dispatch |
+| VS Code Extension | `vscode-extension.yml` | Packages the Harper Review VS Code extension and uploads the `.vsix` artifact for validation. | PRs touching extension files, manual dispatch |
 | Website | `website.yml` | Builds and deploys the website bundle to GitHub Pages. | Push to `main` touching `website/**`, manual dispatch |
 
 > **Tip:** Run `rg -n '^name:' .github/workflows` to see the canonical name shown in the Actions UI.

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+---
+name: VS Code Extension
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/vscode-extension.yml'
+      - 'extensions/harper-review-vscode/**'
+  workflow_dispatch:
+
+jobs:
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Harper
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Package extension
+        working-directory: extensions/harper-review-vscode
+        run: npx --yes @vscode/vsce package --out harper-review.vsix
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: harper-review-vscode
+          path: extensions/harper-review-vscode/harper-review.vsix

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -132,6 +132,10 @@ Harper container images are published on merge to `main`:
 docker run --rm -it ghcr.io/harpertoken/harper/harper:latest
 ```
 
+### VS Code extension
+
+The Harper Review VS Code extension is available in `extensions/harper-review-vscode` for local packaging and validation. It connects VS Code to a running local Harper server.
+
 ### Method 4: Using Make
 
 If the project includes a Makefile:


### PR DESCRIPTION
## Changes

- Added `VS Code Extension` workflow:
  - packages `extensions/harper-review-vscode` with `@vscode/vsce`
  - uploads the generated `.vsix` for validation
  - runs on extension PR changes and manual dispatch
- Updated workflow and installation docs to surface the VS Code extension channel.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/vscode-extension.yml"); puts "workflow yaml ok"'`
- `actionlint .github/workflows/vscode-extension.yml`
- pre-commit hooks on push: `fmt`, `clippy`, `cargo check`
