### PR TITLE
[feat] validate direct install script

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,6 +14,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | Bazel Smoke | `bazel-smoke.yml` | Daily `bazel test //...` to catch dependency drift outside PRs. | Daily cron, manual dispatch |
 | Benchmarks | `benchmarks.yml` | Runs `cargo bench` nightly and stores results as artifacts. | Daily cron, manual dispatch |
 | Integration | `integration.yml` | Executes `cargo test -- --include-ignored` against real services (requires secrets). | PRs touching app code, manual dispatch (with environment input) |
+| Install Script | `install-script.yml` | Dry-runs `scripts/install-harper.sh` on Linux, macOS, and Windows to validate platform-to-asset mapping. | PRs touching installer files, manual dispatch |
 | Package | `package-test.yml` | Calls `libnudget/release-assets` in preflight mode to build, package, and smoke-test Harper release artifacts for Linux x86_64, Linux aarch64, macOS x86_64, macOS aarch64, and Windows x86_64 without publishing them. | Tag push (`harper-*`), manual dispatch |
 | Post-Merge CI | `post-auto-merge-ci.yml` | Re-runs fmt/clippy/tests on `main` after Auto Merge completes; also locks the merged PR via `gh pr lock`. PR lookups and lock actions run through the Harper app token. | Completion of Auto Merge workflow |
 | PR Description | `normalize-pr-description.yml` | Rewrites `## Summary`/`## Testing` bullet-style PR bodies into a single paragraph with backtick-wrapped technical terms via `libnudget/prune@v1`. Skips forks and dependabot. | PR opened/edited/ready_for_review |

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+---
+name: Install Script
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/install-script.yml'
+      - 'scripts/install-harper.sh'
+  workflow_dispatch:
+
+jobs:
+  dry-run:
+    name: Dry Run (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout Harper
+        uses: actions/checkout@v4
+
+      - name: Validate shell syntax
+        if: runner.os != 'Windows'
+        run: sh -n scripts/install-harper.sh
+
+      - name: Dry-run installer
+        shell: bash
+        env:
+          HARPER_INSTALL_DRY_RUN: "1"
+          HARPER_INSTALL_TAG: harper-0.20.1
+        run: |
+          set -euo pipefail
+          sh scripts/install-harper.sh | tee install-plan.txt
+          grep '^release_tag=harper-0.20.1$' install-plan.txt
+          grep '^asset=harper-' install-plan.txt
+          grep '^download_url=https://github.com/harpertoken/harper/releases/download/harper-0.20.1/harper-' install-plan.txt


### PR DESCRIPTION
## Changes

- Added `Install Script` workflow:
  - dry-runs `scripts/install-harper.sh` on Linux, macOS, and Windows
  - validates release tag, asset name, and download URL output
  - runs on installer PR changes and manual dispatch
- Updated the workflow index with the new installer validation workflow.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/install-script.yml"); puts "workflow yaml ok"'`
- `actionlint .github/workflows/install-script.yml`
- `sh -n scripts/install-harper.sh`
- `HARPER_INSTALL_DRY_RUN=1 HARPER_INSTALL_TAG=harper-0.20.1 sh scripts/install-harper.sh`
- pre-commit hooks on push: `fmt`, `clippy`, `cargo check`
