### PR TITLE
[fix] select cli release in installer

### DIFF
--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -39,3 +39,16 @@ jobs:
           grep '^release_tag=harper-0.20.1$' install-plan.txt
           grep '^asset=harper-' install-plan.txt
           grep '^download_url=https://github.com/harpertoken/harper/releases/download/harper-0.20.1/harper-' install-plan.txt
+
+      - name: Dry-run latest CLI release
+        shell: bash
+        env:
+          HARPER_INSTALL_DRY_RUN: "1"
+          HARPER_INSTALL_GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sh scripts/install-harper.sh | tee latest-install-plan.txt
+          grep '^release_tag=harper-[0-9]' latest-install-plan.txt
+          ! grep '^release_tag=harper-workspace-' latest-install-plan.txt
+          grep '^asset=harper-' latest-install-plan.txt
+          grep '^download_url=https://github.com/harpertoken/harper/releases/download/harper-[0-9]' latest-install-plan.txt

--- a/scripts/install-harper.sh
+++ b/scripts/install-harper.sh
@@ -7,6 +7,7 @@ TAG="${HARPER_INSTALL_TAG:-latest}"
 INSTALL_DIR="${HARPER_INSTALL_DIR:-$HOME/.local/bin}"
 TMP_DIR="${TMPDIR:-/tmp}/harper-install.$$"
 DRY_RUN="${HARPER_INSTALL_DRY_RUN:-0}"
+GITHUB_TOKEN="${HARPER_INSTALL_GITHUB_TOKEN:-}"
 
 error() {
   printf '%s\n' "$*" >&2
@@ -34,8 +35,20 @@ detect_asset() {
 latest_tag() {
   need curl
   need sed
-  curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
-    sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' |
+  if [ -n "$GITHUB_TOKEN" ]; then
+    curl -fsSL \
+      -H "Authorization: Bearer $GITHUB_TOKEN" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "https://api.github.com/repos/$REPO/releases?per_page=20"
+  else
+    curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=20"
+  fi |
+    sed -n '
+      /"tag_name":[[:space:]]*"harper-[0-9][^"]*"/{
+        s/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/
+        p
+      }
+    ' |
     head -n 1
 }
 


### PR DESCRIPTION
## Changes

- Fixed `scripts/install-harper.sh` latest-release resolution:
  - selects installable CLI tags like `harper-0.20.0`
  - skips package/workspace releases like `harper-workspace-*`
- Added optional `HARPER_INSTALL_GITHUB_TOKEN` support for release listing so CI avoids unauthenticated API failures.
- Added install-script workflow coverage for default latest resolution.
- Kept explicit `HARPER_INSTALL_TAG` overrides unchanged.

## Validation

- `sh -n scripts/install-harper.sh`
- `HARPER_INSTALL_DRY_RUN=1 sh scripts/install-harper.sh`
- `HARPER_INSTALL_DRY_RUN=1 HARPER_INSTALL_TAG=harper-0.20.1 sh scripts/install-harper.sh`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/install-script.yml'); puts 'yaml ok'"`
- `sh scripts/install-harper.sh`
- `/Users/niladri/.local/bin/harper --version`
