### PR TITLE
[fix] surface sandbox product behavior

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -35,6 +35,7 @@ This directory contains all automation that runs in GitHub Actions for the Harpe
 | PR Checks | `pr-checks.yml` | Validates PR metadata. | PR events, push to `main` |
 | PR Labels | `pr-labels.yml` | Auto-labels PRs via `config/labeler.yml`. Label writes run through the Harper app token. | PR target events |
 | Release | `release.yml` | Creates release PRs or direct package releases for harper-core, harper-ui, harper-firmware, harper-mcp-server, harper-sandbox via `libnudget/release@v1.0.0`, then publishes the installable Harper CLI binary as a dedicated `harper-*` release through `libnudget/release-assets`. Release PR creation and stale overlapping release PR cleanup run through the Harper app token. Merge/direct release flows invoke `release-assets` inline, and manual `harper-*` tag pushes still trigger the same asset publishing path. The workflow passes `HARPER_UPDATE_SIGNING_KEY_PEM_B64` plus the repo-shipped updater public key into that reusable release-assets workflow. | Push to `main` touching lib dirs, tag push (`harper-*`), PR merged, manual dispatch |
+| Sandbox | `sandbox.yml` | Tests the sandbox crate, profile config contract, and visible command status line on Linux, macOS, and Windows. It does not require real OS sandbox privileges in CI. | PR/push touching sandbox paths, manual dispatch |
 | Stale | `stale-issues.yml` | Reminds on issues inactive for 30 days, adds `needs-response`, and closes them after 14 more days without a human reply. Issue comments and label changes run through the Harper app token. | Daily cron, manual dispatch, issue comments |
 | Rust Fix | `rust-auto-fix.yml` | Applies automated `cargo fmt`/`clippy --fix` patches via `libnudget/rust-fix@v1` when `/rust-fix` comment is confirmed with `/confirm`. | Issue comment on PRs |
 | Cancel Runs | `cancel-runs.yml` | Cancels in-progress runs when `/cancel-runs` is commented on PRs via `libnudget/cancel@v1`. Also triggers on `cancel-runs` label. | Issue comment on PRs, `cancel-runs` label |
@@ -85,4 +86,4 @@ Current rules:
 Feel free to expand this file with additional details (matrix descriptions, secrets used, etc.) as workflows evolve.
 
 ## Last Updated
-2026-05-15
+2026-05-17

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+---
+name: Sandbox
+
+"on":
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/sandbox.yml"
+      - "config/default.toml"
+      - "docs/user-guide/sandbox.md"
+      - "lib/harper-core/src/runtime/config.rs"
+      - "lib/harper-core/src/tools/shell.rs"
+      - "lib/harper-sandbox/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/sandbox.yml"
+      - "config/default.toml"
+      - "docs/user-guide/sandbox.md"
+      - "lib/harper-core/src/runtime/config.rs"
+      - "lib/harper-core/src/tools/shell.rs"
+      - "lib/harper-sandbox/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Sandbox (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout Harper
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Test sandbox crate
+        run: cargo test -p harper-sandbox --lib
+
+      - name: Test sandbox config contract
+        run: cargo test -p harper-core runtime::config::tests::default_file_does_not_override_sandbox_profile_defaults --lib
+
+      - name: Test sandbox status surface
+        run: cargo test -p harper-core tools::shell::tests::sandbox_status_line --lib

--- a/config/BUILD
+++ b/config/BUILD
@@ -1,0 +1,1 @@
+exports_files(["default.toml"])

--- a/config/default.toml
+++ b/config/default.toml
@@ -87,9 +87,9 @@ enabled = true
 # port = "/dev/ttyUSB1"
 
 [exec_policy.sandbox]
-enabled = false
-allowed_dirs = []
-writable_dirs = []
+# enabled = false
+# allowed_dirs = []
+# writable_dirs = []
 # network_access = false
 # readonly_home = true
 # max_execution_time_secs = 30

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -152,16 +152,20 @@ Execution approval, sandbox presets, and bounded retry behavior for `run_command
 
 ### `[exec_policy.sandbox]`
 
+These values override the selected `sandbox_profile`. Omit them unless a built-in profile needs a narrower or broader boundary.
+
 | Key              | Type             | Default | Description |
 | ---------------- | ---------------- | ------- | ----------- |
 | `allowed_dirs`   | array of strings | `[]`    | Readable roots inside the sandbox |
 | `writable_dirs`  | array of strings | `[]`    | Writable roots inside the sandbox |
+| `enabled`        | bool             | profile | Explicitly force sandbox execution on or off |
 | `network_access` | bool             | profile | Whether sandboxed commands may reach the network |
 | `readonly_home`  | bool             | profile | Whether `$HOME` is mounted read-only |
 
 ### Notes
 
 - `allow_listed` still prompts when a command declares network access or writes outside configured writable roots.
+- Enabled sandboxing fails closed when no supported backend is available.
 - Retry behavior remains conservative: Harper uses declared intent plus configured command classes, not blind command replay.
 
 ---

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -51,6 +51,8 @@ writable_dirs = ["./tmp", "./build"]
 - Direct self-update verifies both the published checksum and detached signature before replacing the local executable.
 - `allowed_dirs` are readable roots.
 - `writable_dirs` are writable roots.
+- Omit `[exec_policy.sandbox]` fields when a built-in `sandbox_profile` is enough.
+- Enabled sandboxing fails instead of silently running unsandboxed when the platform backend is unavailable.
 
 Supported `header_widgets` values:
 

--- a/docs/user-guide/sandbox.md
+++ b/docs/user-guide/sandbox.md
@@ -1,42 +1,49 @@
-# Sandbox Isolation
+# Sandbox
 
-Harper includes sandbox isolation for secure command execution.
+Harper can run shell commands with a filesystem and network boundary.
 
-## Supported Backends
+## Modes
 
-- **Linux**: bubblewrap (bwrap)
-- **macOS**: sandbox-exec
+Use `sandbox_profile` under `[exec_policy]`:
 
-## Enabling Sandbox
+```toml
+[exec_policy]
+sandbox_profile = "workspace"
+```
 
-Add to your config (`config/local.toml`):
+| Mode | Behavior |
+| --- | --- |
+| `disabled` | Runs commands without a sandbox. |
+| `workspace` | Allows workspace reads/writes, makes `$HOME` read-only, and blocks network by default. |
+| `networked_workspace` | Allows workspace reads/writes, makes `$HOME` read-only, and allows network. |
+
+Each command output starts with the active mode, for example:
+
+```text
+sandbox: workspace (bubblewrap (bwrap), network: off)
+```
+
+## Backends
+
+| Platform | Backend |
+| --- | --- |
+| Linux | `bubblewrap` (`bwrap`) |
+| macOS | `sandbox-exec` |
+| Windows | Not supported yet |
+
+If sandboxing is enabled and Harper cannot find a supported backend, the command fails instead of silently running unsandboxed.
+
+## Custom policy
+
+Profiles can be overridden with explicit paths:
 
 ```toml
 [exec_policy.sandbox]
-enabled = true
-allowed_dirs = ["/app"]
+allowed_dirs = ["."]
+writable_dirs = ["."]
 network_access = false
 readonly_home = true
 max_execution_time_secs = 30
 ```
 
-## Configuration Options
-
-| Option | Type | Default | Description |
-|-------|------|---------|-------------|
-| enabled | bool | false | Enable sandbox |
-| allowed_dirs | list | [] | Directories to allow |
-| network_access | bool | false | Allow network access |
-| readonly_home | bool | true | Read-only home |
-| max_execution_time_secs | int | 30 | Command timeout |
-
-## Docker
-
-In Docker, sandbox is enabled by default with bubblewrap.
-
-## Security
-
-- Commands run in isolated namespace
-- Filesystem access restricted to allowed directories
-- Network disabled by default
-- Commands timeout after 30 seconds
+Use this only when the built-in profiles are too broad or too narrow.

--- a/lib/harper-core/BUILD
+++ b/lib/harper-core/BUILD
@@ -21,6 +21,7 @@ rust_library(
 rust_test(
     name = "harper_core_test",
     crate = ":harper_core",
+    data = ["//config:default.toml"],
     deps = all_crate_deps(normal_dev = True) + [
         "//lib/harper-firmware:harper_firmware",
         "//lib/harper-sandbox:harper_sandbox",

--- a/lib/harper-core/src/runtime/config.rs
+++ b/lib/harper-core/src/runtime/config.rs
@@ -598,7 +598,7 @@ mod tests {
         should_enable_server, ApprovalProfile, ExecPolicyConfig, HarperConfig, SandboxConfig,
         SandboxProfile, ServerConfig,
     };
-    use config::ConfigBuilder;
+    use config::{ConfigBuilder, File};
     use std::env;
     use std::path::Path;
 
@@ -803,6 +803,40 @@ mod tests {
         assert_eq!(sandbox.network_access, Some(false));
         assert_eq!(sandbox.readonly_home, Some(true));
         assert_eq!(sandbox.max_execution_time_secs, Some(30));
+    }
+
+    #[test]
+    fn default_file_does_not_override_sandbox_profile_defaults() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root");
+        let default_config_path = repo_root
+            .join("config/default.toml")
+            .exists()
+            .then(|| repo_root.join("config/default.toml"))
+            .or_else(|| {
+                env::var("RUNFILES_DIR").ok().and_then(|runfiles_dir| {
+                    let path = Path::new(&runfiles_dir).join("_main/config/default.toml");
+                    path.exists().then_some(path)
+                })
+            })
+            .expect("config/default.toml is available");
+        let config: HarperConfig = ConfigBuilder::<config::builder::DefaultState>::default()
+            .add_source(File::from(default_config_path))
+            .set_override("exec_policy.sandbox_profile", "workspace")
+            .expect("sandbox profile override")
+            .build()
+            .expect("default config builds")
+            .try_deserialize()
+            .expect("default config deserializes");
+
+        let sandbox = config.exec_policy.effective_sandbox_config();
+        assert_eq!(sandbox.enabled, Some(true));
+        assert_eq!(sandbox.allowed_dirs, Some(vec![".".to_string()]));
+        assert_eq!(sandbox.writable_dirs, Some(vec![".".to_string()]));
+        assert_eq!(sandbox.network_access, Some(false));
+        assert_eq!(sandbox.readonly_home, Some(true));
     }
 
     #[test]

--- a/lib/harper-core/src/tools/shell.rs
+++ b/lib/harper-core/src/tools/shell.rs
@@ -20,7 +20,7 @@
 use crate::core::plan::PlanJobStatus;
 use crate::core::{error::HarperError, ApiConfig};
 use crate::memory::storage::{self, CommandLogRecord};
-use crate::runtime::config::{ApprovalProfile, ExecPolicyConfig};
+use crate::runtime::config::{ApprovalProfile, ExecPolicyConfig, SandboxProfile};
 use crate::tools::parsing;
 use colored::*;
 use harper_sandbox::{Sandbox, SandboxRequest};
@@ -403,6 +403,35 @@ fn configured_sandbox(exec_policy: &ExecPolicyConfig) -> Option<harper_sandbox::
     })
 }
 
+fn sandbox_profile_name(profile: SandboxProfile) -> &'static str {
+    match profile {
+        SandboxProfile::Disabled => "disabled",
+        SandboxProfile::Workspace => "workspace",
+        SandboxProfile::NetworkedWorkspace => "networked_workspace",
+    }
+}
+
+fn sandbox_status_line(exec_policy: &ExecPolicyConfig, sandbox: Option<&Sandbox>) -> String {
+    let config = exec_policy.effective_sandbox_config();
+    if !config.enabled.unwrap_or(false) {
+        return "sandbox: disabled".to_string();
+    }
+
+    let profile = exec_policy.effective_sandbox_profile();
+    let mode = match profile {
+        SandboxProfile::Disabled => "custom",
+        _ => sandbox_profile_name(profile),
+    };
+    let backend = sandbox.map(Sandbox::backend_name).unwrap_or("unavailable");
+    let network = if config.network_access.unwrap_or(true) {
+        "on"
+    } else {
+        "off"
+    };
+
+    format!("sandbox: {mode} ({backend}, network: {network})")
+}
+
 fn path_within_root(base_dir: &Path, path: &Path, root: &Path) -> bool {
     let normalized_path = if path.is_absolute() {
         path.to_path_buf()
@@ -554,7 +583,7 @@ async fn execute_sandboxed_once(
         audit_ctx.and_then(|ctx| ctx.session_id),
         command_str,
         String::new(),
-        false,
+        has_error_output,
         true,
     )
     .await;
@@ -693,7 +722,7 @@ async fn execute_direct_once(
         audit_ctx.and_then(|ctx| ctx.session_id),
         command_str,
         String::new(),
-        false,
+        !status.success() || !stderr_text.trim().is_empty(),
         true,
     )
     .await;
@@ -930,13 +959,21 @@ pub async fn execute_command(
         approved = true;
     }
 
+    let sandbox = configured_sandbox(exec_policy)
+        .filter(|config| config.enabled)
+        .map(Sandbox::new);
+    let sandbox_status = sandbox_status_line(exec_policy, sandbox.as_ref());
+
     if let Some(ctx) =
         audit_ctx.and_then(|ctx| ctx.session_id.map(|session_id| (ctx.conn, session_id)))
     {
         emit_activity_update(
             runtime_events.as_ref(),
             Some(ctx.1),
-            Some(format!("running command: {}", command_str)),
+            Some(format!(
+                "running command: {}; {}",
+                command_str, sandbox_status
+            )),
         )
         .await;
         let has_active_job = crate::memory::storage::load_plan_state(ctx.0, ctx.1)
@@ -965,9 +1002,15 @@ pub async fn execute_command(
         requires_approval,
         resolved_intent.as_ref(),
     );
-    let sandbox = configured_sandbox(exec_policy)
-        .filter(|config| config.enabled)
-        .map(Sandbox::new);
+    emit_command_output(
+        runtime_events.as_ref(),
+        audit_ctx.and_then(|ctx| ctx.session_id),
+        command_str,
+        format!("{}\n", sandbox_status),
+        false,
+        false,
+    )
+    .await;
     let mut attempt = 0;
     loop {
         let attempt_result = if let Some(sandbox) = sandbox.as_ref() {
@@ -1137,7 +1180,8 @@ mod tests {
     use super::{
         approval_required_for_command, autonomous_retry_safe, build_sandbox_request,
         configured_sandbox, execute_command, infer_path_intent, looks_like_network_command,
-        parse_run_command_response, CommandAuditContext, CommandRetryPolicy, CommandSandboxIntent,
+        parse_run_command_response, sandbox_status_line, CommandAuditContext, CommandRetryPolicy,
+        CommandSandboxIntent,
     };
     use crate::core::plan::{PlanFollowup, PlanItem, PlanState, PlanStepStatus};
     use crate::core::{ApiConfig, ApiProvider};
@@ -1348,6 +1392,43 @@ mod tests {
         assert!(!sandbox.network_access);
         assert!(sandbox.readonly_home);
         assert_eq!(sandbox.max_execution_time_secs, Some(15));
+    }
+
+    #[test]
+    fn sandbox_status_line_reports_disabled_mode() {
+        let exec_policy = ExecPolicyConfig {
+            approval_profile: None,
+            execution_strategy: None,
+            allowed_commands: None,
+            blocked_commands: None,
+            sandbox_profile: Some(SandboxProfile::Disabled),
+            sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
+        };
+
+        assert_eq!(sandbox_status_line(&exec_policy, None), "sandbox: disabled");
+    }
+
+    #[test]
+    fn sandbox_status_line_reports_enabled_mode() {
+        let exec_policy = ExecPolicyConfig {
+            approval_profile: None,
+            execution_strategy: None,
+            allowed_commands: None,
+            blocked_commands: None,
+            sandbox_profile: Some(SandboxProfile::Workspace),
+            sandbox: None,
+            retry_max_attempts: None,
+            retry_network_commands: None,
+            retry_write_commands: None,
+        };
+        let sandbox = configured_sandbox(&exec_policy).map(harper_sandbox::Sandbox::new);
+
+        let status = sandbox_status_line(&exec_policy, sandbox.as_ref());
+        assert!(status.starts_with("sandbox: workspace ("));
+        assert!(status.ends_with(", network: off)"));
     }
 
     #[test]

--- a/lib/harper-sandbox/examples/basic.rs
+++ b/lib/harper-sandbox/examples/basic.rs
@@ -27,6 +27,6 @@ fn main() {
     println!("\n✓ harper-sandbox crate is working!");
 
     println!("\nTo enable sandbox, set in config:");
-    println!("  [exec_policy.sandbox]");
-    println!("  enabled = true");
+    println!("  [exec_policy]");
+    println!("  sandbox_profile = \"workspace\"");
 }

--- a/lib/harper-sandbox/src/backend.rs
+++ b/lib/harper-sandbox/src/backend.rs
@@ -15,6 +15,8 @@
 use crate::errors::{Result, SandboxError};
 use crate::policy::SandboxConfig;
 use crate::request::SandboxRequest;
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
@@ -38,7 +40,9 @@ pub fn detect_backend() -> SandboxBackend {
     }
     #[cfg(target_os = "macos")]
     {
-        return SandboxBackend::SandboxExec;
+        if std::path::Path::new("/usr/bin/sandbox-exec").exists() {
+            return SandboxBackend::SandboxExec;
+        }
     }
     #[allow(unreachable_code)]
     SandboxBackend::None
@@ -103,23 +107,23 @@ async fn execute_bwrap(
     bpush(&mut bwrap_args, "--ro-bind", "/lib".to_string());
     bpush(&mut bwrap_args, "--ro-bind", "/lib64".to_string());
 
-    for dir in &config.allowed_dirs {
-        if dir.exists() {
-            bpush(&mut bwrap_args, "--ro-bind", dir.display().to_string());
-        }
-    }
-    for dir in &config.writable_dirs {
-        if dir.exists() {
-            bpush(&mut bwrap_args, "--bind", dir.display().to_string());
-        }
-    }
-
     if config.readonly_home {
         if let Ok(home) = std::env::var("HOME") {
             bpush(&mut bwrap_args, "--ro-bind", home);
         }
     } else if let Ok(home) = std::env::var("HOME") {
         bpush(&mut bwrap_args, "--ro-bind", home);
+    }
+
+    for dir in &config.allowed_dirs {
+        if let Some(dir) = existing_mount_path(dir, &request.working_dir) {
+            bpush(&mut bwrap_args, "--ro-bind", dir.display().to_string());
+        }
+    }
+    for dir in &config.writable_dirs {
+        if let Some(dir) = existing_mount_path(dir, &request.working_dir) {
+            bpush(&mut bwrap_args, "--bind", dir.display().to_string());
+        }
     }
 
     bpush(
@@ -159,32 +163,7 @@ async fn execute_sandbox_exec(
     request: &SandboxRequest,
     on_output: impl FnMut(String, bool) + Send + 'static,
 ) -> Result<std::process::Output> {
-    let mut sandbox_rules = vec!["(version 1)".to_string()];
-
-    if !config.network_access {
-        sandbox_rules.push("(deny network*)\n(allow default)".to_string());
-    }
-
-    sandbox_rules.push("(allow process-exec)".to_string());
-
-    for dir in &config.allowed_dirs {
-        if dir.exists() {
-            sandbox_rules.push(format!(
-                "(allow file-read* (subpath \"{}\"))",
-                dir.display()
-            ));
-        }
-    }
-    for dir in &config.writable_dirs {
-        if dir.exists() {
-            sandbox_rules.push(format!(
-                "(allow file-write* (subpath \"{}\"))",
-                dir.display()
-            ));
-        }
-    }
-
-    let sandbox_profile = sandbox_rules.join("\n");
+    let sandbox_profile = build_sandbox_exec_profile(config, &request.working_dir);
 
     let mut cmd = Command::new("sandbox-exec");
     cmd.arg("-p")
@@ -198,6 +177,66 @@ async fn execute_sandbox_exec(
         cmd.env(key, value);
     }
     run_command_with_timeout_streaming(config, cmd, on_output).await
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
+fn existing_mount_path(path: &Path, working_dir: &Path) -> Option<PathBuf> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        working_dir.join(path)
+    };
+    if candidate.exists() {
+        Some(candidate.canonicalize().unwrap_or(candidate))
+    } else {
+        None
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn escape_sandbox_string(value: &Path) -> String {
+    value
+        .display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn build_sandbox_exec_profile(config: &SandboxConfig, working_dir: &Path) -> String {
+    let mut sandbox_rules = vec![
+        "(version 1)".to_string(),
+        "(deny default)".to_string(),
+        "(allow process*)".to_string(),
+        "(allow sysctl-read)".to_string(),
+        "(allow file-read-metadata)".to_string(),
+    ];
+
+    for system_path in ["/bin", "/usr", "/System", "/Library", "/dev/null"] {
+        sandbox_rules.push(format!("(allow file-read* (subpath \"{}\"))", system_path));
+    }
+
+    for dir in &config.allowed_dirs {
+        if let Some(dir) = existing_mount_path(dir, working_dir) {
+            sandbox_rules.push(format!(
+                "(allow file-read* (subpath \"{}\"))",
+                escape_sandbox_string(&dir)
+            ));
+        }
+    }
+    for dir in &config.writable_dirs {
+        if let Some(dir) = existing_mount_path(dir, working_dir) {
+            let escaped = escape_sandbox_string(&dir);
+            sandbox_rules.push(format!("(allow file-read* (subpath \"{}\"))", escaped));
+            sandbox_rules.push(format!("(allow file-write* (subpath \"{}\"))", escaped));
+        }
+    }
+
+    if config.network_access {
+        sandbox_rules.push("(allow network*)".to_string());
+    }
+
+    sandbox_rules.join("\n")
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -297,4 +336,62 @@ async fn read_stream(
 fn bpush(args: &mut Vec<String>, flag: &str, val: impl Into<String>) {
     args.push(flag.to_string());
     args.push(val.into());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_sandbox_exec_profile, escape_sandbox_string, existing_mount_path};
+    use crate::policy::SandboxConfig;
+    use std::path::Path;
+
+    #[test]
+    fn relative_mounts_are_resolved_against_working_dir() {
+        let working_dir = std::env::current_dir().expect("current dir");
+        let mounted = existing_mount_path(Path::new("."), &working_dir).expect("mount path");
+
+        assert!(mounted.is_absolute());
+        assert_eq!(mounted, working_dir.canonicalize().expect("canonical cwd"));
+    }
+
+    #[test]
+    fn sandbox_exec_profile_denies_default_and_scopes_paths() {
+        let working_dir = std::env::current_dir().expect("current dir");
+        let config = SandboxConfig {
+            enabled: true,
+            allowed_dirs: vec![Path::new(".").to_path_buf()],
+            writable_dirs: vec![Path::new(".").to_path_buf()],
+            network_access: false,
+            ..SandboxConfig::default()
+        };
+
+        let profile = build_sandbox_exec_profile(&config, &working_dir);
+
+        assert!(profile.contains("(deny default)"));
+        assert!(!profile.contains("(allow default)"));
+        assert!(!profile.contains("(allow network*)"));
+        let escaped_working_dir =
+            escape_sandbox_string(&working_dir.canonicalize().expect("canonical cwd"));
+        assert!(profile.contains(&format!(
+            "(allow file-read* (subpath \"{}\"))",
+            escaped_working_dir
+        )));
+        assert!(profile.contains(&format!(
+            "(allow file-write* (subpath \"{}\"))",
+            escaped_working_dir
+        )));
+    }
+
+    #[test]
+    fn sandbox_exec_profile_allows_network_when_configured() {
+        let config = SandboxConfig {
+            enabled: true,
+            network_access: true,
+            ..SandboxConfig::default()
+        };
+
+        let profile =
+            build_sandbox_exec_profile(&config, &std::env::current_dir().expect("current dir"));
+
+        assert!(profile.contains("(allow network*)"));
+    }
 }

--- a/lib/harper-sandbox/src/lib.rs
+++ b/lib/harper-sandbox/src/lib.rs
@@ -39,6 +39,11 @@ impl Sandbox {
         Self { config, backend }
     }
 
+    #[cfg(test)]
+    fn with_backend(config: SandboxConfig, backend: SandboxBackend) -> Self {
+        Self { config, backend }
+    }
+
     #[must_use]
     pub fn is_available(&self) -> bool {
         self.backend != SandboxBackend::None
@@ -73,6 +78,10 @@ impl Sandbox {
         let backend = if !self.config.enabled {
             log::warn!("Sandbox disabled - executing directly");
             SandboxBackend::None
+        } else if self.backend == SandboxBackend::None {
+            return Err(SandboxError::BackendUnavailable(
+                "sandbox is enabled but no supported backend is available".to_string(),
+            ));
         } else {
             self.backend
         };
@@ -458,6 +467,33 @@ mod tests {
             String::from_utf8_lossy(&result.output.stdout).trim(),
             "hello"
         );
+    }
+
+    #[test]
+    fn test_enabled_sandbox_without_backend_fails_closed() {
+        let sandbox = Sandbox::with_backend(
+            SandboxConfig {
+                enabled: true,
+                ..Default::default()
+            },
+            SandboxBackend::None,
+        );
+        let request = SandboxRequest {
+            command: "echo".to_string(),
+            args: vec!["hello".to_string()],
+            working_dir: std::env::current_dir().unwrap(),
+            env: vec![],
+            declared_read_paths: vec![],
+            declared_write_paths: vec![],
+            requires_network: false,
+        };
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = runtime.block_on(sandbox.execute_request(request));
+        assert!(matches!(result, Err(SandboxError::BackendUnavailable(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- Made sandbox behavior visible in command output.
- Show the active sandbox mode, backend, and network state when commands run.
- Fail closed when sandboxing is enabled but no supported backend is available.
- Keep profile config first: `sandbox_profile = "workspace"` is no longer overwritten by default sandbox fields.
- Resolve relative sandbox paths from the command working directory.
- Tighten macOS sandbox policy to deny by default and only open required paths/network.
- Add Bazel runfiles support for `config/default.toml` in the core test.
- Add a cross-platform Sandbox workflow for Linux, macOS, and Windows.
- Update sandbox docs and examples to use the profile-first config path.

## Validation

- `RUSTFLAGS='-D warnings' cargo check --workspace`
- `cargo test -p harper-sandbox --lib`
- `bash scripts/validate.sh`
- `bazel test //lib/harper-core:harper_core_test`
- `bazel test //...`
