### PR TITLE
[fix] simplify homebrew update path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,6 +1876,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syntect",
+ "tempfile",
  "tokio",
  "turul-mcp-client",
  "uuid",

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -49,6 +49,22 @@ To update later:
 brew upgrade harpertoken/tap/harper-ai
 ```
 
+If `harper --version` still shows an older version after upgrading, another `harper` binary is earlier in your `PATH`. Check with:
+
+```bash
+which harper
+$(brew --prefix)/bin/harper --version
+```
+
+Harper also shows a `Fix Homebrew PATH` action in `Settings -> Execution Policy -> Updates` when it detects this common shadowed-binary case. To do the same fix manually:
+
+```bash
+backup="$HOME/.local/bin/harper.old"; i=1; while [ -e "$backup" ]; do backup="$HOME/.local/bin/harper.old.$i"; i=$((i + 1)); done
+mv "$HOME/.local/bin/harper" "$backup"
+ln -sfn "$(brew --prefix)/bin/harper" "$HOME/.local/bin/harper"
+hash -r
+```
+
 ### Method 2: Build from Source
 
 1. Clone the repository:

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -4,6 +4,29 @@ This guide helps you resolve common issues you might encounter while using Harpe
 
 ## Common Issues
 
+### Wrong Harper Version After Updating
+
+**Symptom**: Homebrew upgraded Harper, but `harper --version` still shows an older version.
+
+**Solutions**:
+1. Check which binary your shell runs:
+   ```bash
+   which harper
+   harper --version
+   $(brew --prefix)/bin/harper --version
+   ```
+2. If `which harper` points to `~/.local/bin/harper`, use `Settings -> Execution Policy -> Updates -> Fix Homebrew PATH`, or run:
+   ```bash
+   backup="$HOME/.local/bin/harper.old"; i=1; while [ -e "$backup" ]; do backup="$HOME/.local/bin/harper.old.$i"; i=$((i + 1)); done
+   mv "$HOME/.local/bin/harper" "$backup"
+   ln -sfn "$(brew --prefix)/bin/harper" "$HOME/.local/bin/harper"
+   hash -r
+   ```
+3. Update future Homebrew installs with:
+   ```bash
+   brew upgrade harpertoken/tap/harper-ai
+   ```
+
 ### API Key Problems
 
 #### "Invalid API Key" Error

--- a/lib/harper-ui/Cargo.toml
+++ b/lib/harper-ui/Cargo.toml
@@ -46,6 +46,9 @@ turul-mcp-client = "0.3.44"
 uuid = { version = "1.17.0", features = ["v4"] }
 async-trait = "0.1"
 
+[dev-dependencies]
+tempfile = "3.3.0"
+
 [[bin]]
 name = "harper"
 path = "src/main.rs"

--- a/lib/harper-ui/src/interfaces/ui/app.rs
+++ b/lib/harper-ui/src/interfaces/ui/app.rs
@@ -23,6 +23,7 @@ use serde::Deserialize;
 use std::cell::Cell;
 use std::collections::BTreeSet;
 use std::fs;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::oneshot;
@@ -585,6 +586,7 @@ pub struct TuiApp {
     pub execution_policy_editor: Option<ExecutionPolicyEditorState>,
     pub header_widgets: Vec<HeaderWidget>,
     pub update_status: Option<String>,
+    pub homebrew_path_fix: Option<PathBuf>,
     pub show_menu_logo: bool,
     pub mouse_capture: bool,
     pub drag_scroll: Option<DragScrollState>,
@@ -649,6 +651,7 @@ impl Default for TuiApp {
                 HeaderWidget::Activity,
             ],
             update_status: None,
+            homebrew_path_fix: None,
             show_menu_logo: true,
             mouse_capture: false,
             drag_scroll: None,
@@ -687,7 +690,11 @@ impl TuiApp {
     }
 
     pub fn execution_policy_row_count(&self) -> usize {
-        9
+        if self.homebrew_path_fix.is_some() {
+            10
+        } else {
+            9
+        }
     }
 
     pub fn set_error_message(&mut self, content: String) {

--- a/lib/harper-ui/src/interfaces/ui/events.rs
+++ b/lib/harper-ui/src/interfaces/ui/events.rs
@@ -54,6 +54,7 @@ pub enum EventResult {
     SaveExecutionPolicy,
     SaveAppearance,
     CheckForUpdates,
+    ConfirmHomebrewPathFix,
     SetPlanStepStatus {
         session_id: String,
         step_index: usize,
@@ -1243,6 +1244,7 @@ fn handle_enter(app: &mut TuiApp, session_service: &SessionService) -> EventResu
             6 => start_execution_policy_editor(app, ExecutionPolicyListField::BlockedCommands),
             7 => return EventResult::SaveExecutionPolicy,
             8 => return EventResult::CheckForUpdates,
+            9 if app.homebrew_path_fix.is_some() => return EventResult::ConfirmHomebrewPathFix,
             _ => {}
         },
         AppState::ViewSession(session_id, _, _) => {

--- a/lib/harper-ui/src/interfaces/ui/tui.rs
+++ b/lib/harper-ui/src/interfaces/ui/tui.rs
@@ -212,7 +212,11 @@ enum UiUpdate {
     },
     UpdateStatus {
         status: Result<Option<String>, String>,
+        homebrew_path_fix: Option<crate::update::HomebrewPathFix>,
         manual: bool,
+    },
+    HomebrewPathFixApplied {
+        result: Result<String, String>,
     },
     Error(String),
 }
@@ -323,10 +327,77 @@ fn spawn_update_status_refresh(ui_tx: &mpsc::Sender<UiUpdate>, manual: bool) {
     let update_ui_tx = ui_tx.clone();
     tokio::spawn(async move {
         let status = crate::update::fetch_update_status().await;
+        let homebrew_path_fix = crate::update::detect_homebrew_path_fix();
         let _ = update_ui_tx
-            .send(UiUpdate::UpdateStatus { status, manual })
+            .send(UiUpdate::UpdateStatus {
+                status,
+                homebrew_path_fix,
+                manual,
+            })
             .await;
     });
+}
+
+fn spawn_homebrew_path_fix(
+    ui_tx: &mpsc::Sender<UiUpdate>,
+    approval_tx: &mpsc::Sender<ApprovalMessage>,
+    fix: crate::update::HomebrewPathFix,
+) {
+    let ui_tx = ui_tx.clone();
+    let approval_tx = approval_tx.clone();
+    tokio::spawn(async move {
+        let command = format!(
+            "move {} aside and link it to {}",
+            fix.shadow_path.display(),
+            fix.homebrew_path.display()
+        );
+        let prompt = "Fix Homebrew PATH?".to_string();
+        let (tx, rx) = oneshot::channel();
+        let tx = Arc::new(Mutex::new(Some(tx)));
+        if approval_tx.send((prompt, command, tx)).await.is_err() {
+            let _ = ui_tx
+                .send(UiUpdate::HomebrewPathFixApplied {
+                    result: Err("approval request could not be shown".to_string()),
+                })
+                .await;
+            return;
+        }
+
+        match rx.await {
+            Ok(true) => {
+                let result = crate::update::apply_homebrew_path_fix(&fix).map(|backup_path| {
+                    format!(
+                        "Homebrew PATH fixed. Previous binary moved to {}.",
+                        backup_path.display()
+                    )
+                });
+                let _ = ui_tx
+                    .send(UiUpdate::HomebrewPathFixApplied { result })
+                    .await;
+            }
+            Ok(false) => {
+                let _ = ui_tx
+                    .send(UiUpdate::HomebrewPathFixApplied {
+                        result: Ok("Homebrew PATH fix cancelled.".to_string()),
+                    })
+                    .await;
+            }
+            Err(_) => {
+                let _ = ui_tx
+                    .send(UiUpdate::HomebrewPathFixApplied {
+                        result: Err("approval was cancelled".to_string()),
+                    })
+                    .await;
+            }
+        }
+    });
+}
+
+fn clamp_execution_policy_selection(app: &mut TuiApp) {
+    let row_count = app.execution_policy_row_count();
+    if let AppState::ExecutionPolicy(selected) = &mut app.state {
+        *selected = (*selected).min(row_count.saturating_sub(1));
+    }
 }
 
 fn parse_update_command(input: &str) -> Option<UpdateCommand> {
@@ -545,6 +616,7 @@ pub async fn run_tui(
 
     // Spawn background worker in a separate thread to handle non-Send Connection
     let ui_tx_clone = ui_tx.clone();
+    let worker_approval_tx = approval_tx.clone();
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -560,7 +632,9 @@ pub async fn run_tui(
             };
 
             let mut api_cache = harper_core::core::cache::new_api_cache();
-            let approver = Arc::new(TuiApproval { approval_tx });
+            let approver = Arc::new(TuiApproval {
+                approval_tx: worker_approval_tx,
+            });
             let runtime_events = Arc::new(TuiRuntimeEvents {
                 ui_tx: ui_tx_clone.clone(),
             });
@@ -1332,6 +1406,17 @@ pub async fn run_tui(
                             app.set_activity_status(Some("checking updates".to_string()));
                             spawn_update_status_refresh(&ui_tx, true);
                         }
+                        EventResult::ConfirmHomebrewPathFix => {
+                            if let Some(fix) = crate::update::detect_homebrew_path_fix() {
+                                app.set_activity_status(Some(
+                                    "waiting Homebrew PATH approval".to_string(),
+                                ));
+                                spawn_homebrew_path_fix(&ui_tx, &approval_tx, fix);
+                            } else {
+                                app.homebrew_path_fix = None;
+                                app.set_info_message("No Homebrew PATH fix is needed.".to_string());
+                            }
+                        }
                         EventResult::SetPlanStepStatus {
                             session_id,
                             step_index,
@@ -1642,7 +1727,14 @@ pub async fn run_tui(
                                 chat_state.sidebar_sections = sections;
                             }
                         }
-                        UiUpdate::UpdateStatus { status, manual } => {
+                        UiUpdate::UpdateStatus {
+                            status,
+                            homebrew_path_fix,
+                            manual,
+                        } => {
+                            app.homebrew_path_fix =
+                                homebrew_path_fix.map(|fix| fix.shadow_path);
+                            clamp_execution_policy_selection(&mut app);
                             match status {
                                 Ok(status) => {
                                     app.update_status = status;
@@ -1673,6 +1765,22 @@ pub async fn run_tui(
                                         ));
                                     }
                                 }
+                            }
+                        }
+                        UiUpdate::HomebrewPathFixApplied { result } => {
+                            app.set_activity_status(None);
+                            match result {
+                                Ok(message) => {
+                                    app.homebrew_path_fix =
+                                        crate::update::detect_homebrew_path_fix()
+                                            .map(|fix| fix.shadow_path);
+                                    clamp_execution_policy_selection(&mut app);
+                                    app.set_info_message(message);
+                                }
+                                Err(err) => app.set_error_message(format!(
+                                    "Failed to fix Homebrew PATH: {}",
+                                    err
+                                )),
                             }
                         }
                         UiUpdate::Error(err) => {

--- a/lib/harper-ui/src/interfaces/ui/widgets.rs
+++ b/lib/harper-ui/src/interfaces/ui/widgets.rs
@@ -3384,7 +3384,7 @@ fn draw_execution_policy(
     } else {
         app.blocked_commands.join(", ")
     };
-    let rows = [
+    let mut rows = vec![
         format!(
             "Approval: {}",
             settings::approval_profile_name(app.approval_profile)
@@ -3405,8 +3405,14 @@ fn draw_execution_policy(
         format!("Allow: {allowed}"),
         format!("Block: {blocked}"),
         "Save".to_string(),
-        "Updates".to_string(),
+        format!(
+            "Updates: {}",
+            update_status_label(app.update_status.as_deref())
+        ),
     ];
+    if let Some(path) = &app.homebrew_path_fix {
+        rows.push(format!("Fix Homebrew PATH: {}", path.display()));
+    }
     let items: Vec<ListItem> = rows
         .iter()
         .enumerate()
@@ -3585,8 +3591,15 @@ fn execution_policy_context(selected: usize) -> &'static str {
         6 => "Edits comma-separated commands blocked by policy.",
         7 => "Writes the current policy settings to config/local.toml.",
         8 => "Checks for a newer release and refreshes the cached update status.",
+        9 => "Moves the shadowing local binary aside and points it to Homebrew's Harper.",
         _ => "",
     }
+}
+
+fn update_status_label(status: Option<&str>) -> &str {
+    status
+        .and_then(|status| status.strip_prefix("update: "))
+        .unwrap_or("not checked")
 }
 
 fn draw_profile(frame: &mut Frame, app: &TuiApp, selected: usize, theme: &Theme, area: Rect) {

--- a/lib/harper-ui/src/update.rs
+++ b/lib/harper-ui/src/update.rs
@@ -5,7 +5,10 @@ use harper_core::{
     verify_artifact_checksum, verify_artifact_signature, InstallSource,
 };
 use serde::Deserialize;
-use std::env;
+#[cfg(unix)]
+use std::fs;
+use std::path::PathBuf;
+use std::{env, path::Path};
 
 const UPDATE_MANIFEST_ENV: &str = "HARPER_UPDATE_MANIFEST_URL";
 const RELEASES_API_URL: &str = "https://api.github.com/repos/harpertoken/harper/releases";
@@ -22,6 +25,12 @@ struct GitHubRelease {
     draft: bool,
     prerelease: bool,
     assets: Vec<GitHubReleaseAsset>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HomebrewPathFix {
+    pub shadow_path: PathBuf,
+    pub homebrew_path: PathBuf,
 }
 
 pub async fn handle_update_command(args: &[String]) -> Option<i32> {
@@ -126,6 +135,8 @@ async fn handle_self_update(args: &[String]) -> i32 {
 
     let result = evaluate_update(crate::CLI_VERSION, &manifest, &target);
     println!("Latest version: {}", result.latest_version);
+    let homebrew_path_fix =
+        detect_homebrew_path_fix_for_install_source(&executable, install_source);
 
     if !result.artifact_available {
         println!(
@@ -155,6 +166,12 @@ async fn handle_self_update(args: &[String]) -> i32 {
     }
 
     if check_only {
+        if install_source == InstallSource::Homebrew || homebrew_path_fix.is_some() {
+            if result.update_available {
+                println!("Run: brew upgrade harpertoken/tap/harper-ai");
+            }
+            print_homebrew_shadow_guidance(&executable, install_source);
+        }
         return 0;
     }
 
@@ -163,8 +180,11 @@ async fn handle_self_update(args: &[String]) -> i32 {
     }
 
     match install_source {
+        _ if homebrew_path_fix.is_some() => {
+            print_install_source_guidance(InstallSource::Homebrew, &executable)
+        }
         InstallSource::Homebrew | InstallSource::Cargo | InstallSource::Npm => {
-            print_install_source_guidance(install_source)
+            print_install_source_guidance(install_source, &executable)
         }
         InstallSource::Direct => {
             let Some(artifact) = manifest.artifact_for_target(&target) else {
@@ -248,11 +268,12 @@ async fn handle_self_update(args: &[String]) -> i32 {
     }
 }
 
-fn print_install_source_guidance(install_source: InstallSource) -> i32 {
+fn print_install_source_guidance(install_source: InstallSource, executable: &Path) -> i32 {
     match install_source {
         InstallSource::Homebrew => {
             println!("This install is managed by Homebrew.");
             println!("Run: brew upgrade harpertoken/tap/harper-ai");
+            print_homebrew_shadow_guidance(executable, install_source);
             0
         }
         InstallSource::Cargo => {
@@ -271,6 +292,150 @@ fn print_install_source_guidance(install_source: InstallSource) -> i32 {
             2
         }
     }
+}
+
+fn print_homebrew_shadow_guidance(executable: &Path, install_source: InstallSource) {
+    let Some(fix) = detect_homebrew_path_fix_for_install_source(executable, install_source) else {
+        return;
+    };
+
+    let executable_text = fix.shadow_path.to_string_lossy();
+    let backup_path = next_backup_path(&fix.shadow_path);
+    let executable_arg = shell_quote(&executable_text);
+    let backup_arg = shell_quote(&backup_path.to_string_lossy());
+    let homebrew_arg = shell_quote(&fix.homebrew_path.to_string_lossy());
+    println!();
+    println!("Your shell is running another Harper binary:");
+    println!("  {}", fix.shadow_path.display());
+    println!();
+    println!("To make it use Homebrew's Harper:");
+    println!(
+        "  mv {executable_arg} {backup_arg}; ln -sfn {homebrew_arg} {executable_arg}; hash -r"
+    );
+}
+
+pub fn detect_homebrew_path_fix() -> Option<HomebrewPathFix> {
+    let executable = env::current_exe().ok()?;
+    let install_source = resolve_install_source(&executable).ok()?;
+    detect_homebrew_path_fix_for_install_source(&executable, install_source)
+}
+
+fn detect_homebrew_path_fix_for_install_source(
+    executable: &Path,
+    install_source: InstallSource,
+) -> Option<HomebrewPathFix> {
+    detect_homebrew_path_fix_for_executable_with_candidates(
+        executable,
+        install_source,
+        &[
+            PathBuf::from("/opt/homebrew/bin/harper"),
+            PathBuf::from("/usr/local/bin/harper"),
+        ],
+    )
+}
+
+fn detect_homebrew_path_fix_for_executable_with_candidates(
+    executable: &Path,
+    install_source: InstallSource,
+    homebrew_paths: &[PathBuf],
+) -> Option<HomebrewPathFix> {
+    let home = PathBuf::from(env::var_os("HOME")?);
+    detect_homebrew_path_fix_for_executable_with_home(
+        executable,
+        install_source,
+        &home,
+        homebrew_paths,
+    )
+}
+
+fn detect_homebrew_path_fix_for_executable_with_home(
+    executable: &Path,
+    install_source: InstallSource,
+    home: &Path,
+    homebrew_paths: &[PathBuf],
+) -> Option<HomebrewPathFix> {
+    if install_source != InstallSource::Homebrew {
+        return None;
+    }
+
+    if InstallSource::infer_from_executable(executable) == InstallSource::Homebrew {
+        return None;
+    }
+
+    let local_harper = home.join(".local").join("bin").join("harper");
+    if executable != local_harper {
+        return None;
+    }
+
+    let homebrew_path = homebrew_paths.iter().find(|path| path.exists())?.clone();
+
+    Some(HomebrewPathFix {
+        shadow_path: executable.to_path_buf(),
+        homebrew_path,
+    })
+}
+
+pub fn apply_homebrew_path_fix(fix: &HomebrewPathFix) -> Result<PathBuf, String> {
+    #[cfg(not(unix))]
+    {
+        let _ = fix;
+        Err("Homebrew PATH fix is only supported on Unix-like systems.".to_string())
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+
+        let backup_path = next_backup_path(&fix.shadow_path);
+        fs::rename(&fix.shadow_path, &backup_path).map_err(|err| {
+            format!(
+                "failed to move {} to {}: {}",
+                fix.shadow_path.display(),
+                backup_path.display(),
+                err
+            )
+        })?;
+        if let Err(err) = symlink(&fix.homebrew_path, &fix.shadow_path) {
+            let rollback = fs::rename(&backup_path, &fix.shadow_path)
+                .map(|_| String::new())
+                .unwrap_or_else(|rollback_err| {
+                    format!(
+                        " rollback failed: {} is still at {}: {}",
+                        fix.shadow_path.display(),
+                        backup_path.display(),
+                        rollback_err
+                    )
+                });
+            return Err(format!(
+                "failed to link {} to {}: {}{}",
+                fix.shadow_path.display(),
+                fix.homebrew_path.display(),
+                err,
+                rollback
+            ));
+        }
+        Ok(backup_path)
+    }
+}
+
+fn next_backup_path(path: &Path) -> PathBuf {
+    let first = PathBuf::from(format!("{}.old", path.display()));
+    if !first.exists() {
+        return first;
+    }
+
+    for index in 1..100 {
+        let candidate = PathBuf::from(format!("{}.old.{}", path.display(), index));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+
+    PathBuf::from(format!("{}.old.{}", path.display(), std::process::id()))
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn configured_manifest_url() -> Option<String> {
@@ -342,9 +507,13 @@ fn print_self_update_usage() {
 #[cfg(test)]
 mod tests {
     use super::{
-        configured_manifest_url, fetch_update_status, find_manifest_url, handle_update_command,
-        GitHubRelease, GitHubReleaseAsset,
+        configured_manifest_url, detect_homebrew_path_fix_for_executable_with_home,
+        fetch_update_status, find_manifest_url, handle_update_command, next_backup_path,
+        shell_quote, GitHubRelease, GitHubReleaseAsset, HomebrewPathFix,
     };
+    use harper_core::InstallSource;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[tokio::test]
     async fn version_command_is_handled() {
@@ -433,6 +602,138 @@ mod tests {
         assert_eq!(
             find_manifest_url(&releases).as_deref(),
             Some("https://example.com/release-manifest.json")
+        );
+    }
+
+    #[test]
+    fn shell_quote_handles_spaces_and_quotes() {
+        assert_eq!(
+            shell_quote("/Users/test/local harper's/bin/harper"),
+            "'/Users/test/local harper'\\''s/bin/harper'"
+        );
+    }
+
+    #[test]
+    fn next_backup_path_skips_existing_backups() {
+        let tempdir = tempdir().expect("tempdir");
+        let path = tempdir.path().join("harper");
+        fs::write(&path, "old").expect("write original");
+        fs::write(tempdir.path().join("harper.old"), "older").expect("write backup");
+
+        assert_eq!(next_backup_path(&path), tempdir.path().join("harper.old.1"));
+    }
+
+    #[test]
+    fn detects_shadowed_homebrew_with_homebrew_source() {
+        let tempdir = tempdir().expect("tempdir");
+        let home = tempdir.path().join("home");
+        let shadow_path = home.join(".local").join("bin").join("harper");
+        let homebrew_path = tempdir
+            .path()
+            .join("opt")
+            .join("homebrew")
+            .join("bin")
+            .join("harper");
+        fs::create_dir_all(shadow_path.parent().expect("shadow parent")).expect("shadow dir");
+        fs::create_dir_all(homebrew_path.parent().expect("homebrew parent")).expect("homebrew dir");
+        fs::write(&shadow_path, "shadow").expect("write shadow");
+        fs::write(&homebrew_path, "homebrew").expect("write homebrew");
+
+        assert_eq!(
+            detect_homebrew_path_fix_for_executable_with_home(
+                &shadow_path,
+                InstallSource::Homebrew,
+                &home,
+                std::slice::from_ref(&homebrew_path),
+            ),
+            Some(HomebrewPathFix {
+                shadow_path,
+                homebrew_path,
+            })
+        );
+    }
+
+    #[test]
+    fn does_not_treat_direct_local_install_as_homebrew_shadow() {
+        let tempdir = tempdir().expect("tempdir");
+        let home = tempdir.path().join("home");
+        let shadow_path = home.join(".local").join("bin").join("harper");
+        let homebrew_path = tempdir
+            .path()
+            .join("opt")
+            .join("homebrew")
+            .join("bin")
+            .join("harper");
+        fs::create_dir_all(shadow_path.parent().expect("shadow parent")).expect("shadow dir");
+        fs::create_dir_all(homebrew_path.parent().expect("homebrew parent")).expect("homebrew dir");
+        fs::write(&shadow_path, "direct").expect("write direct");
+        fs::write(&homebrew_path, "homebrew").expect("write homebrew");
+
+        assert_eq!(
+            detect_homebrew_path_fix_for_executable_with_home(
+                &shadow_path,
+                InstallSource::Direct,
+                &home,
+                std::slice::from_ref(&homebrew_path),
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn detects_intel_homebrew_prefix() {
+        let tempdir = tempdir().expect("tempdir");
+        let home = tempdir.path().join("home");
+        let shadow_path = home.join(".local").join("bin").join("harper");
+        let apple_silicon_path = tempdir
+            .path()
+            .join("opt")
+            .join("homebrew")
+            .join("bin")
+            .join("harper");
+        let intel_path = tempdir
+            .path()
+            .join("usr")
+            .join("local")
+            .join("bin")
+            .join("harper");
+        fs::create_dir_all(shadow_path.parent().expect("shadow parent")).expect("shadow dir");
+        fs::create_dir_all(intel_path.parent().expect("intel parent")).expect("intel dir");
+        fs::write(&shadow_path, "shadow").expect("write shadow");
+        fs::write(&intel_path, "homebrew").expect("write homebrew");
+
+        assert_eq!(
+            detect_homebrew_path_fix_for_executable_with_home(
+                &shadow_path,
+                InstallSource::Homebrew,
+                &home,
+                &[apple_silicon_path, intel_path.clone()],
+            )
+            .map(|fix| fix.homebrew_path),
+            Some(intel_path)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_homebrew_path_fix_moves_shadow_and_links_homebrew() {
+        let tempdir = tempdir().expect("tempdir");
+        let shadow_path = tempdir.path().join("harper");
+        let homebrew_path = tempdir.path().join("homebrew-harper");
+        fs::write(&shadow_path, "shadow").expect("write shadow");
+        fs::write(&homebrew_path, "homebrew").expect("write homebrew");
+
+        let backup = super::apply_homebrew_path_fix(&HomebrewPathFix {
+            shadow_path: shadow_path.clone(),
+            homebrew_path: homebrew_path.clone(),
+        })
+        .expect("apply fix");
+
+        assert_eq!(backup, tempdir.path().join("harper.old"));
+        assert_eq!(fs::read_to_string(&backup).expect("read backup"), "shadow");
+        assert_eq!(
+            fs::read_link(&shadow_path).expect("read symlink"),
+            homebrew_path
         );
     }
 }

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -6,44 +6,140 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
+DIM='\033[2m'
+BOLD='\033[1m'
 NC='\033[0m'
+
+ORANGE='\033[38;2;255;122;36m'
 
 TOTAL_STEPS=14
 PASSED_STEPS=0
 WARNED_STEPS=0
+CURRENT_STEP=""
 
 print_banner() {
+    echo
+
+    echo -e "${ORANGE}   ⣀⠴⠶⠛⢻⣄${NC}"
+    echo -e "${ORANGE}⠰⠛⠛⠙⢷⣦⡀ ⠹⣧⡀${NC}"
+    echo -e "${ORANGE}     ⠈⠻⣦⡀⢈⣷⣄⣀⡀${NC}"
+    echo -e "${ORANGE}      ⢀⣼⣿⣿⣿⣿⣿⣿⣦${NC}"
+    echo -e "${ORANGE}     ⢠⣿⣿⣅⣼⣿⣿⣿⣿⣿⢇⣴⣾⣿⣿⣷⣦⣄    ⢀⣀⣀⣀⣀${NC}"
+    echo -e "${ORANGE}     ⢸⣿⣿⣿⣿⣿⣿⣿⠿⠋⢸⣿⣿⣿⣿⣿⣿⣿⣷⡀⢠⣾⣿⣿⣿⣿⣿⣿⣦⡀${NC}"
+    echo -e "${ORANGE}     ⠈⠛⠻⠟⠛⠛⢉⣴⢶⣤⣈⠻⣿⣿⣿⣿⢟⡛⢿⡇⣿⡿⢟⠛⢿⣿⣿⣿⣿⣿⣦${NC}"
+    echo -e "${ORANGE}          ⣠⡿⠁⢀⣤⣭⣥⣬⣿⠟⠁⣾⣷ ⣠⣤⡶⣿⣿⣌⠻⣿⣿⣿⣿⣿⣧${NC}"
+    echo -e "${ORANGE}         ⣴⠟ ⢀⣿⠋⠉⠉⠉⠁   ⢹⣧⠉⠁ ⠈⠻⢿⣦⡙⣿⣿⣿⣿⡿${NC}"
+    echo -e "${ORANGE}       ⢠⡾⠃  ⣾⠃         ⢻⡆     ⠘⢷⣌⠉⠉⠁${NC}"
+    echo -e "${ORANGE}      ⣰⡟⠁  ⠸⠏          ⠈⢿⠄      ⠻⣦${NC}"
+
     echo
     echo -e "${BLUE}╭──────────────────────────────────────────────╮${NC}"
     echo -e "${BLUE}│          Harper Validation Suite             │${NC}"
     echo -e "${BLUE}│        Build. Lint. Test. Verify.            │${NC}"
     echo -e "${BLUE}╰──────────────────────────────────────────────╯${NC}"
+
     echo
 }
 
 print_status() {
     local status=$1
     local message=$2
+
     case $status in
-        PASS) echo -e "${GREEN}PASS${NC}: $message" ;;
-        FAIL) echo -e "${RED}FAIL${NC}: $message" ;;
-        WARN) echo -e "${YELLOW}WARN${NC}: $message" ;;
-        INFO) echo -e "${BLUE}INFO${NC}: $message" ;;
+        PASS)
+            echo -e "${GREEN}PASS${NC} $message"
+            ;;
+        FAIL)
+            echo -e "${RED}FAIL${NC} $message"
+            ;;
+        WARN)
+            echo -e "${YELLOW}WARN${NC} $message"
+            ;;
+        INFO)
+            echo -e "${BLUE}INFO${NC} $message"
+            ;;
     esac
+}
+
+draw_progress_bar() {
+    local current=$1
+    local total=$2
+    local width=28
+
+    local percent=$((current * 100 / total))
+    local filled=$((current * width / total))
+    local empty=$((width - filled))
+
+    printf "${BLUE}["
+
+    if [ "$filled" -gt 0 ]; then
+        printf "%0.s█" $(seq 1 "$filled")
+    fi
+
+    if [ "$empty" -gt 0 ]; then
+        printf "%0.s░" $(seq 1 "$empty")
+    fi
+
+    printf "]${NC}"
+
+    printf " ${BOLD}%3d%%${NC}" "$percent"
 }
 
 run_command_with_log() {
     local log_file
     log_file=$(mktemp)
 
-    if "$@" >"$log_file" 2>&1; then
+    local spinner='|/-\'
+    local delay=0.08
+    local pid
+    local start_time
+
+    start_time=$(date +%s)
+
+    "$@" >"$log_file" 2>&1 &
+    pid=$!
+
+    tput civis 2>/dev/null || true
+
+    while kill -0 "$pid" 2>/dev/null; do
+        for ((i = 0; i < ${#spinner}; i++)); do
+            kill -0 "$pid" 2>/dev/null || break
+
+            local elapsed
+            elapsed=$(( $(date +%s) - start_time ))
+
+            printf "\r\033[K"
+
+            draw_progress_bar "$PASSED_STEPS" "$TOTAL_STEPS"
+
+            printf " ${ORANGE}%s${NC} ${BOLD}%s${NC} ${DIM}(%ss)${NC}" \
+                "${spinner:i:1}" \
+                "$CURRENT_STEP" \
+                "$elapsed"
+
+            sleep "$delay"
+        done
+    done
+
+    local exit_code=0
+    wait "$pid" || exit_code=$?
+
+    printf "\r\033[K"
+
+    tput cnorm 2>/dev/null || true
+
+    if [ "$exit_code" -eq 0 ]; then
         rm -f "$log_file"
         return 0
     fi
 
-    echo "--- command output ---"
+    echo
+    echo -e "${RED}╭─ command output ─────────────────────────────${NC}"
     cat "$log_file"
+    echo -e "${RED}╰──────────────────────────────────────────────${NC}"
+
     rm -f "$log_file"
+
     return 1
 }
 
@@ -52,18 +148,24 @@ run_required_step() {
     local title=$2
     local fail_message=$3
     local tip_message=$4
+
     shift 4
+
+    CURRENT_STEP="$title"
 
     echo
     print_status "INFO" "[$step/$TOTAL_STEPS] $title"
+
     if run_command_with_log "$@"; then
-        print_status "PASS" "$title"
         PASSED_STEPS=$((PASSED_STEPS + 1))
+        print_status "PASS" "$title"
     else
         print_status "FAIL" "$fail_message"
+
         if [ -n "$tip_message" ]; then
-            echo "$tip_message"
+            echo -e "${DIM}$tip_message${NC}"
         fi
+
         exit 1
     fi
 }
@@ -71,16 +173,20 @@ run_required_step() {
 run_optional_step() {
     local step=$1
     local title=$2
+
     shift 2
+
+    CURRENT_STEP="$title"
 
     echo
     print_status "INFO" "[$step/$TOTAL_STEPS] $title"
-    if "$@"; then
-        print_status "PASS" "$title"
+
+    if run_command_with_log "$@"; then
         PASSED_STEPS=$((PASSED_STEPS + 1))
+        print_status "PASS" "$title"
     else
-        print_status "WARN" "$title"
         WARNED_STEPS=$((WARNED_STEPS + 1))
+        print_status "WARN" "$title"
     fi
 }
 
@@ -93,18 +199,28 @@ check_project_root() {
 
 check_large_files() {
     local large_files
-    large_files=$(find . -type f -size +10M -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
+
+    large_files=$(find . -type f -size +10M \
+        -not -path "./target/*" \
+        -not -path "./.git/*" 2>/dev/null || true)
+
     if [ -n "$large_files" ]; then
         print_status "FAIL" "Large files detected (>10MB)"
         echo "$large_files"
         return 1
     fi
+
     return 0
 }
 
 check_sensitive_files() {
     local sensitive_files
-    sensitive_files=$(find . \( -name "*.key" -o -name "*.pem" -o -name "*.env" \) -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
+
+    sensitive_files=$(find . \
+        \( -name "*.key" -o -name "*.pem" -o -name "*.env" \) \
+        -not -path "./target/*" \
+        -not -path "./.git/*" 2>/dev/null || true)
+
     if [ -n "$sensitive_files" ]; then
         print_status "WARN" "Potential sensitive files found"
         echo "$sensitive_files"
@@ -113,6 +229,7 @@ check_sensitive_files() {
         print_status "PASS" "No sensitive files found in repository"
         PASSED_STEPS=$((PASSED_STEPS + 1))
     fi
+
     return 0
 }
 
@@ -124,7 +241,12 @@ check_yaml() {
     fi
 
     local yaml_files
-    yaml_files=$(find . \( -name "*.yml" -o -name "*.yaml" \) -not -path "./target/*" -not -path "./.git/*" 2>/dev/null || true)
+
+    yaml_files=$(find . \
+        \( -name "*.yml" -o -name "*.yaml" \) \
+        -not -path "./target/*" \
+        -not -path "./.git/*" 2>/dev/null || true)
+
     if [ -z "$yaml_files" ]; then
         print_status "PASS" "No YAML files to validate"
         PASSED_STEPS=$((PASSED_STEPS + 1))
@@ -139,16 +261,19 @@ check_yaml() {
 
     print_status "FAIL" "YAML validation failed"
     echo "Run 'yamllint .github/workflows/*.yml docker/docker-compose.yml' for details"
+
     return 1
 }
 
 check_todos() {
     local todo_count
+
     todo_count=$(
         rg --glob '*.rs' --count-matches \
             '(//|///|/\*|\*|//!).*(TODO|FIXME|XXX)' \
             . 2>/dev/null || true
     )
+
     todo_count=$(
         printf '%s\n' "$todo_count" \
             | awk -F: '{sum += $NF} END {print sum + 0}'
@@ -162,20 +287,26 @@ check_todos() {
         echo "Consider resolving these or documenting why they're needed"
         WARNED_STEPS=$((WARNED_STEPS + 1))
     fi
+
     return 0
 }
 
 check_cargo_audit() {
-    if ! command -v cargo-audit >/dev/null 2>&1 && [ ! -x "$HOME/.cargo/bin/cargo-audit" ]; then
-        print_status "WARN" "cargo-audit not installed (run: cargo install cargo-audit)"
+    if ! command -v cargo-audit >/dev/null 2>&1 && \
+       [ ! -x "$HOME/.cargo/bin/cargo-audit" ]; then
+        print_status "WARN" \
+            "cargo-audit not installed (run: cargo install cargo-audit)"
         WARNED_STEPS=$((WARNED_STEPS + 1))
         return 0
     fi
 
     local audit_bin="cargo-audit"
+
     if ! command -v cargo-audit >/dev/null 2>&1; then
         audit_bin="$HOME/.cargo/bin/cargo-audit"
     fi
+
+    CURRENT_STEP="Security audit"
 
     if run_command_with_log "$audit_bin" audit --quiet; then
         print_status "PASS" "Security audit passed"
@@ -185,20 +316,26 @@ check_cargo_audit() {
 
     print_status "FAIL" "Security audit found vulnerabilities"
     echo "Run '$audit_bin audit' for details"
+
     return 1
 }
 
 check_cargo_deny() {
-    if ! command -v cargo-deny >/dev/null 2>&1 && [ ! -x "$HOME/.cargo/bin/cargo-deny" ]; then
-        print_status "WARN" "cargo-deny not installed (run: cargo install cargo-deny)"
+    if ! command -v cargo-deny >/dev/null 2>&1 && \
+       [ ! -x "$HOME/.cargo/bin/cargo-deny" ]; then
+        print_status "WARN" \
+            "cargo-deny not installed (run: cargo install cargo-deny)"
         WARNED_STEPS=$((WARNED_STEPS + 1))
         return 0
     fi
 
     local deny_bin="cargo-deny"
+
     if ! command -v cargo-deny >/dev/null 2>&1; then
         deny_bin="$HOME/.cargo/bin/cargo-deny"
     fi
+
+    CURRENT_STEP="cargo-deny policy check"
 
     if run_command_with_log "$deny_bin" check; then
         print_status "PASS" "cargo-deny policy checks passed"
@@ -208,21 +345,16 @@ check_cargo_deny() {
 
     print_status "FAIL" "cargo-deny reported dependency policy issues"
     echo "Run '$deny_bin check' for details"
+
     return 1
 }
 
 check_benchmarks() {
-    if cargo bench --workspace --quiet >/dev/null 2>&1; then
-        return 0
-    fi
-    return 1
+    cargo bench --workspace --quiet >/dev/null 2>&1
 }
 
 check_integration_tests() {
-    if cargo test --tests --workspace --quiet >/dev/null 2>&1; then
-        return 0
-    fi
-    return 1
+    cargo test --tests --workspace --quiet >/dev/null 2>&1
 }
 
 release_binary_size() {
@@ -232,24 +364,38 @@ release_binary_size() {
     fi
 
     local bin
-    bin=$(cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '.packages[0].targets[] | select(.kind[]=="bin") | .name' 2>/dev/null || echo "harper")
-    stat -f%z "target/release/$bin" 2>/dev/null || stat -c%s "target/release/$bin" 2>/dev/null || echo "unknown"
+
+    bin=$(
+        cargo metadata --no-deps --format-version 1 2>/dev/null \
+        | jq -r '.packages[0].targets[] | select(.kind[]=="bin") | .name' \
+        2>/dev/null || echo "harper"
+    )
+
+    stat -f%z "target/release/$bin" 2>/dev/null \
+        || stat -c%s "target/release/$bin" 2>/dev/null \
+        || echo "unknown"
 }
 
 print_summary() {
     echo
-    echo -e "${GREEN}✓ Harper validation completed${NC}"
+    echo -e "${GREEN}╭──────────────────────────────────────────────╮${NC}"
+    echo -e "${GREEN}│           Validation Complete ✓              │${NC}"
+    echo -e "${GREEN}╰──────────────────────────────────────────────╯${NC}"
+
     echo
-    echo "Summary:"
-    echo " • Passed steps: $PASSED_STEPS/$TOTAL_STEPS"
+    echo -e "${BOLD}Summary${NC}"
+    echo " • Passed steps : $PASSED_STEPS/$TOTAL_STEPS"
     echo " • Warning steps: $WARNED_STEPS"
     echo " • Required checks: all passed"
+
     echo
 }
 
 main() {
     check_project_root
+
     print_banner
+
     print_status "INFO" "Starting validation checks..."
 
     run_required_step 1 "Rust compilation check" \
@@ -260,7 +406,8 @@ main() {
     run_required_step 2 "Clippy linter" \
         "Clippy reported issues that need attention" \
         "Run 'cargo clippy --all-targets --all-features --workspace -- -A clippy::pedantic -D warnings' for details" \
-        cargo clippy --all-targets --all-features --workspace --quiet -- -A clippy::pedantic -D warnings
+        cargo clippy --all-targets --all-features --workspace \
+        --quiet -- -A clippy::pedantic -D warnings
 
     run_required_step 3 "Formatting check" \
         "Code formatting issues found" \
@@ -274,10 +421,14 @@ main() {
 
     echo
     print_status "INFO" "[5/$TOTAL_STEPS] Security audit"
-    check_cargo_audit
+
+    if ! check_cargo_audit; then
+        exit 1
+    fi
 
     echo
     print_status "INFO" "[6/$TOTAL_STEPS] Large file check"
+
     if check_large_files; then
         print_status "PASS" "No large files found"
         PASSED_STEPS=$((PASSED_STEPS + 1))
@@ -291,6 +442,7 @@ main() {
 
     echo
     print_status "INFO" "[8/$TOTAL_STEPS] YAML validation"
+
     if ! check_yaml; then
         exit 1
     fi
@@ -306,19 +458,26 @@ main() {
 
     echo
     print_status "INFO" "[11/$TOTAL_STEPS] cargo-deny policy check"
+
     if ! check_cargo_deny; then
         exit 1
     fi
 
-    run_optional_step 12 "Workspace benchmarks" check_benchmarks
-    run_optional_step 13 "Integration tests" check_integration_tests
+    run_optional_step 12 "Workspace benchmarks" \
+        check_benchmarks
+
+    run_optional_step 13 "Integration tests" \
+        check_integration_tests
 
     run_required_step 14 "Release build" \
         "Release build failed" \
         "Run 'cargo build --release --workspace' for details" \
         cargo build --release --workspace --quiet
 
-    print_status "PASS" "Release build successful (binary size: $(release_binary_size) bytes)"
+    print_status \
+        "PASS" \
+        "Release build successful (binary size: $(release_binary_size) bytes)"
+
     print_summary
 }
 

--- a/website/installation.html
+++ b/website/installation.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Installation</title>
-    <meta name="harper-update-version" content="2026-05-17-install-sandbox" />
+    <meta name="harper-update-version" content="2026-05-17-install-update-path" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -211,7 +211,7 @@ Tab</code></pre>
                     <pre><code>brew install harpertoken/tap/harper-ai</code></pre>
                     <button class="copy-btn"></button>
                 </div>
-                <p>Direct release artifacts are versioned and packaged for updater consumption. Homebrew users should keep using <code>brew upgrade harpertoken/tap/harper-ai</code>. Direct binary installs can use <code>harper self-update --check</code> to inspect the published manifest and <code>harper self-update</code> to replace the installed binary. By default Harper checks the latest GitHub release manifest, and <code>HARPER_UPDATE_MANIFEST_URL</code> can override that source. Before replacing the local binary, Harper verifies both the published SHA-256 checksum and the detached release signature.</p>
+                <p>Direct release artifacts are versioned and packaged for updater consumption. Homebrew users should keep using <code>brew upgrade harpertoken/tap/harper-ai</code>. If an older <code>harper</code> binary is earlier in <code>PATH</code>, Harper prints a safe one-line fix and shows <code>Fix Homebrew PATH</code> in <code>Settings -&gt; Execution Policy -&gt; Updates</code> when it can safely point that path at Homebrew's binary. Direct binary installs can use <code>harper self-update --check</code> to inspect the published manifest and <code>harper self-update</code> to replace the installed binary. By default Harper checks the latest GitHub release manifest, and <code>HARPER_UPDATE_MANIFEST_URL</code> can override that source. Before replacing the local binary, Harper verifies both the published SHA-256 checksum and the detached release signature.</p>
                 <div class="code-wrapper">
                     <pre><code>harper --version</code></pre>
                     <button class="copy-btn"></button>

--- a/website/nav-updates.json
+++ b/website/nav-updates.json
@@ -1,8 +1,8 @@
 {
   "index.html": "2026-05-17-home-sandbox",
   "docs.html": "2026-05-09-docs-shell",
-  "installation.html": "2026-05-17-install-sandbox",
-  "troubleshooting.html": "2026-05-01-troubleshooting-v2",
+  "installation.html": "2026-05-17-install-update-path",
+  "troubleshooting.html": "2026-05-17-troubleshooting-update-path",
   "blog.html": "2026-05-17-blog-sandbox",
   "changelog.html": "2026-04-28-changelog",
   "server.html": "2026-05-01-server-v8",

--- a/website/troubleshooting.html
+++ b/website/troubleshooting.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harper · Troubleshooting</title>
-    <meta name="harper-update-version" content="2026-05-01-troubleshooting-v2" />
+    <meta name="harper-update-version" content="2026-05-17-troubleshooting-update-path" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/203538727?s=200&v=4" />
 </head>
@@ -31,13 +31,25 @@
                 <p class="hero-lede">Common fixes for install, version, API, and runtime problems.</p>
 
                 <h2>Wrong version</h2>
-                <p>Check your installed version and location.</p>
+                <p>Check your installed version and location. If Homebrew upgraded Harper but the version still looks old, another binary is earlier in your PATH.</p>
                 <div class="code-wrapper">
                     <pre><code>which harper</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <div class="code-wrapper">
                     <pre><code>harper --version</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <div class="code-wrapper">
+                    <pre><code>$(brew --prefix)/bin/harper --version</code></pre>
+                    <button class="copy-btn"></button>
+                </div>
+                <p>If <code>which harper</code> points to <code>~/.local/bin/harper</code>, use <code>Settings -&gt; Execution Policy -&gt; Updates -&gt; Fix Homebrew PATH</code>, or run:</p>
+                <div class="code-wrapper">
+                    <pre><code>backup="$HOME/.local/bin/harper.old"; i=1; while [ -e "$backup" ]; do backup="$HOME/.local/bin/harper.old.$i"; i=$((i + 1)); done
+mv "$HOME/.local/bin/harper" "$backup"
+ln -sfn "$(brew --prefix)/bin/harper" "$HOME/.local/bin/harper"
+hash -r</code></pre>
                     <button class="copy-btn"></button>
                 </div>
                 <div class="code-wrapper">


### PR DESCRIPTION
## Changes

- Added a Homebrew PATH fix in settings when Harper detects a stale local binary shadowing Homebrew.
- Kept direct installs on the normal `harper self-update` path.
- Supported both Apple Silicon and Intel Homebrew prefixes.
- Updated install/troubleshooting docs and site pages.
- Refreshed `scripts/validate.sh` output and failure capture.

## Validation

- `cargo test -p harper-ui update`
- `cargo check -p harper-ui`
- `cargo run -p harper-ui --bin harper-batch -- --prompt "update check"`
- `cargo run -p harper-ui --bin harper-batch -- --prompt "update apply"`
- `bash scripts/validate.sh`
