### PR TITLE
[chore] use supported codex default model

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -16,7 +16,7 @@
 # Project-scoped Codex CLI settings for this repo.
 # See OpenAI Codex configuration docs for available fields and defaults.
 
-model = "gpt-5-codex"
+model = "gpt-5.5"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 


### PR DESCRIPTION
## Changes

- Updated the repo-scoped Codex CLI config:
  - Replaced `gpt-5-codex` with `gpt-5.5` in `.codex/config.toml`.
- Avoided Codex startup warnings caused by missing model metadata for the previous repo default.

## Validation

- `git diff --check -- .codex/config.toml`
- pre-push hooks:
  - `fmt`
  - `clippy`
  - `cargo check`